### PR TITLE
Use final paths in the reroutes of configuration.json file.

### DIFF
--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -18,8 +18,8 @@ namespace Ocelot.DownstreamRouteFinder.UrlMatcher
                     if (IsPlaceholder(upstreamUrlPathTemplate[counterForTemplate]))
                     {
                         var variableName = GetPlaceholderVariableName(upstreamUrlPathTemplate, counterForTemplate);
-                        
-                        var variableValue = GetPlaceholderVariableValue(upstreamUrlPath, counterForUrl);
+
+                        var variableValue = GetPlaceholderVariableValue(upstreamUrlPathTemplate, variableName, upstreamUrlPath, counterForUrl);
 
                         var templateVariableNameAndValue = new UrlPathPlaceholderNameAndValue(variableName, variableValue);
 
@@ -40,15 +40,15 @@ namespace Ocelot.DownstreamRouteFinder.UrlMatcher
             return new OkResponse<List<UrlPathPlaceholderNameAndValue>>(templateKeysAndValues);
         }
 
-        private string GetPlaceholderVariableValue(string urlPath, int counterForUrl)
+        private string GetPlaceholderVariableValue(string urlPathTemplate, string variableName, string urlPath, int counterForUrl)
         {
             var positionOfNextSlash = urlPath.IndexOf('/', counterForUrl);
 
-            if(positionOfNextSlash == -1)
+            if (positionOfNextSlash == -1 || urlPathTemplate.Trim('/').EndsWith(variableName))
             {
                 positionOfNextSlash = urlPath.Length;
             }
-            
+
             var variableValue = urlPath.Substring(counterForUrl, positionOfNextSlash - counterForUrl);
 
             return variableValue;

--- a/test/Ocelot.AcceptanceTests/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingTests.cs
@@ -46,7 +46,6 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPort = 51879,
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = "Get",
- 
                         }
                     }
             };
@@ -289,6 +288,34 @@ namespace Ocelot.AcceptanceTests
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/newThing?DeviceType=IphoneApp&Browser=moonpigIphone&BrowserString=-&CountryCode=123&DeviceName=iPhone 5 (GSM+CDMA)&OperatingSystem=iPhone OS 7.1.2&BrowserVersion=3708AdHoc&ipAddress=-"))
                 .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
                 .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_response_200_with_placeholder_for_final_url_path()
+        {
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/api/{urlPath}",
+                            DownstreamScheme = "http",
+                            DownstreamHost = "localhost",
+                            DownstreamPort = 51879,
+                            UpstreamPathTemplate = "/myApp1Name/api/{urlPath}",
+                            UpstreamHttpMethod = "Get",
+                        }
+                    }
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51879/myApp1Name/api/products/1", 200, "Some Product"))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/myApp1Name/api/products/1"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("Some Product"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/TemplateVariableNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/TemplateVariableNameAndValueFinderTests.cs
@@ -140,6 +140,21 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
                  .BDDfy();
         }
 
+        [Fact]
+        public void can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path()
+        {
+            var expectedTemplates = new List<UrlPathPlaceholderNameAndValue>
+            {
+                new UrlPathPlaceholderNameAndValue("{finalUrlPath}", "product/products/categories/"),
+            };
+
+            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/categories/"))
+                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/"))
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                 .BDDfy();
+        }
+
         private void ThenTheTemplatesVariablesAre(List<UrlPathPlaceholderNameAndValue> expectedResults)
         {
             foreach (var expectedResult in expectedResults)


### PR DESCRIPTION
The idea is the user not have to map all request when use Ocelot like a simple request redirector.

Imagine the following scenario:

1. An intranet with three web apis.
2. An internal gateway like unique enter point to internal requests.
3. An external gateway like unique enter point to external requests.
4. The web apis (of point 1) can interact via internal gateway.
5. Our clients and mobiles apps use the api via external gateway.
6. The external gateway only offers a couple of methods that are mapped in the configuration file. If we need add or quit methods, we edit it´s configuration file.
7. The apis of intranet can changes frecuently. Every day our developers can implement two o three new controllers per api. We dont want have to edit the internal gateway configuration continously.

The configuration.json for internal gateway could be something like this:

```
{
      "UpstreamPathTemplate": "/api/api1/{urlPath}",
      "UpstreamHttpMethod": "Get",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5001,
      "QoSOptions": {
        "ExceptionsAllowedBeforeBreaking": 3,
        "DurationOfBreak": 10,
        "TimeoutValue": 10000
      }
    },
    ...
    {
      "UpstreamPathTemplate": "/api/api2/{urlPath}",
      "UpstreamHttpMethod": "Get",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5002,
      "QoSOptions": {
        "ExceptionsAllowedBeforeBreaking": 3,
        "DurationOfBreak": 10,
        "TimeoutValue": 10000
      }
    },
    ...
    {
      "UpstreamPathTemplate": "/api/api3/{urlPath}",
      "UpstreamHttpMethod": "Get",
      "DownstreamPathTemplate": "/api/{urlPath}",
      "DownstreamScheme": "http",
      "DownstreamHost": "localhost",
      "DownstreamPort": 5003,
      "QoSOptions": {
        "ExceptionsAllowedBeforeBreaking": 3,
        "DurationOfBreak": 10,
        "TimeoutValue": 10000
      }
    },
    ...
```

If we add new controllers to our web apis, we don´t need edit the internal gateway configuration, because the traffic will be redirected without problems.

Thanks.