### PR TITLE
Feature/reduce build warnings

### DIFF
--- a/codeanalysis.ruleset
+++ b/codeanalysis.ruleset
@@ -1,74 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for StyleCop.Analyzers.csproj." ToolsVersion="14.0">
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for StyleCop.Analyzers.csproj." ToolsVersion="15.0">
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
     <Rule Id="AvoidAsyncSuffix" Action="None" />
-    <Rule Id="AvoidAsyncVoid" Action="None" />
+    <Rule Id="AvoidAsyncVoid" Action="Error" />
     <Rule Id="UseAsyncSuffix" Action="None" />
-    <Rule Id="UseConfigureAwait" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1001" Action="None" />
-    <Rule Id="CA1009" Action="None" />
-    <Rule Id="CA1016" Action="None" />
-    <Rule Id="CA1033" Action="None" />
-    <Rule Id="CA1049" Action="None" />
-    <Rule Id="CA1060" Action="None" />
-    <Rule Id="CA1061" Action="None" />
-    <Rule Id="CA1063" Action="None" />
-    <Rule Id="CA1065" Action="None" />
-    <Rule Id="CA1301" Action="None" />
-    <Rule Id="CA1400" Action="None" />
-    <Rule Id="CA1401" Action="None" />
-    <Rule Id="CA1403" Action="None" />
-    <Rule Id="CA1404" Action="None" />
-    <Rule Id="CA1405" Action="None" />
-    <Rule Id="CA1410" Action="None" />
-    <Rule Id="CA1415" Action="None" />
-    <Rule Id="CA1821" Action="None" />
-    <Rule Id="CA1900" Action="None" />
-    <Rule Id="CA1901" Action="None" />
-    <Rule Id="CA2002" Action="None" />
-    <Rule Id="CA2100" Action="None" />
-    <Rule Id="CA2101" Action="None" />
-    <Rule Id="CA2108" Action="None" />
-    <Rule Id="CA2111" Action="None" />
-    <Rule Id="CA2112" Action="None" />
-    <Rule Id="CA2114" Action="None" />
-    <Rule Id="CA2116" Action="None" />
-    <Rule Id="CA2117" Action="None" />
-    <Rule Id="CA2122" Action="None" />
-    <Rule Id="CA2123" Action="None" />
-    <Rule Id="CA2124" Action="None" />
-    <Rule Id="CA2126" Action="None" />
-    <Rule Id="CA2131" Action="None" />
-    <Rule Id="CA2132" Action="None" />
-    <Rule Id="CA2133" Action="None" />
-    <Rule Id="CA2134" Action="None" />
-    <Rule Id="CA2137" Action="None" />
-    <Rule Id="CA2138" Action="None" />
-    <Rule Id="CA2140" Action="None" />
-    <Rule Id="CA2141" Action="None" />
-    <Rule Id="CA2146" Action="None" />
-    <Rule Id="CA2147" Action="None" />
-    <Rule Id="CA2149" Action="None" />
-    <Rule Id="CA2200" Action="None" />
-    <Rule Id="CA2202" Action="None" />
-    <Rule Id="CA2207" Action="None" />
-    <Rule Id="CA2212" Action="None" />
-    <Rule Id="CA2213" Action="None" />
-    <Rule Id="CA2214" Action="None" />
-    <Rule Id="CA2216" Action="None" />
-    <Rule Id="CA2220" Action="None" />
-    <Rule Id="CA2229" Action="None" />
-    <Rule Id="CA2231" Action="None" />
-    <Rule Id="CA2232" Action="None" />
-    <Rule Id="CA2235" Action="None" />
-    <Rule Id="CA2236" Action="None" />
-    <Rule Id="CA2237" Action="None" />
-    <Rule Id="CA2238" Action="None" />
-    <Rule Id="CA2240" Action="None" />
-    <Rule Id="CA2241" Action="None" />
-    <Rule Id="CA2242" Action="None" />
+    <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
@@ -77,76 +13,76 @@
     <Rule Id="SA0000" Action="Hidden" />
     <Rule Id="SA1000" Action="None" />
     <Rule Id="SA1001" Action="None" />
-    <Rule Id="SA1002" Action="None" />	
+    <Rule Id="SA1002" Action="None" />
     <Rule Id="SA1003" Action="None" />
-	<Rule Id="SA1005" Action="None" />
-    <Rule Id="SA1008" Action="None" />	
+    <Rule Id="SA1005" Action="None" />
+    <Rule Id="SA1008" Action="None" />
     <Rule Id="SA1009" Action="None" />
     <Rule Id="SA1011" Action="None" />
     <Rule Id="SA1012" Action="None" />
     <Rule Id="SA1013" Action="None" />
-    <Rule Id="SA1015" Action="None" />	
+    <Rule Id="SA1015" Action="None" />
     <Rule Id="SA1016" Action="None" />
-    <Rule Id="SA1021" Action="None" />
-    <Rule Id="SA1022" Action="None" />
-    <Rule Id="SA1024" Action="None" />	
-    <Rule Id="SA1026" Action="None" />	
-    <Rule Id="SA1028" Action="None" />	
-    <Rule Id="SA1100" Action="None" />
+    <Rule Id="SA1021" Action="Error" />
+    <Rule Id="SA1022" Action="Error" />
+    <Rule Id="SA1024" Action="None" />
+    <Rule Id="SA1026" Action="None" />
+    <Rule Id="SA1028" Action="None" />
+    <Rule Id="SA1100" Action="Error" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1106" Action="None" />
     <Rule Id="SA1111" Action="None" />
     <Rule Id="SA1112" Action="None" />
-    <Rule Id="SA1116" Action="None" />	
-    <Rule Id="SA1117" Action="None" />	
+    <Rule Id="SA1116" Action="None" />
+    <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1118" Action="None" />
-    <Rule Id="SA1119" Action="None" />
-    <Rule Id="SA1121" Action="None" />
+    <Rule Id="SA1119" Action="Error" />
+    <Rule Id="SA1121" Action="Error" />
     <Rule Id="SA1122" Action="None" />
-    <Rule Id="SA1128" Action="None" />	
-    <Rule Id="SA1133" Action="None" />
+    <Rule Id="SA1128" Action="None" />
+    <Rule Id="SA1133" Action="Error" />
     <Rule Id="SA1200" Action="None" />
-    <Rule Id="SA1201" Action="None" />	
-    <Rule Id="SA1202" Action="None" />	
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
     <Rule Id="SA1203" Action="None" />
-    <Rule Id="SA1204" Action="None" />	
-    <Rule Id="SA1208" Action="None" />	
-    <Rule Id="SA1209" Action="None" />	
-    <Rule Id="SA1210" Action="None" />	
-    <Rule Id="SA1214" Action="None" />	
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1208" Action="None" />
+    <Rule Id="SA1209" Action="None" />
+    <Rule Id="SA1210" Action="None" />
+    <Rule Id="SA1214" Action="None" />
     <Rule Id="SA1216" Action="None" />	
     <Rule Id="SA1300" Action="None" />
-    <Rule Id="SA1302" Action="None" />
+    <Rule Id="SA1302" Action="Error" />
     <Rule Id="SA1303" Action="None" />
-    <Rule Id="SA1304" Action="None" />
+    <Rule Id="SA1304" Action="Error" />
     <Rule Id="SA1305" Action="None" />
     <Rule Id="SA1309" Action="None" />
     <Rule Id="SA1310" Action="None" />
-    <Rule Id="SA1311" Action="None" />
+    <Rule Id="SA1311" Action="Error" />
     <Rule Id="SA1400" Action="None" />
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1402" Action="None" />
-    <Rule Id="SA1403" Action="None" />
-    <Rule Id="SA1404" Action="None" />
-    <Rule Id="SA1405" Action="None" />
-    <Rule Id="SA1406" Action="None" />
-    <Rule Id="SA1407" Action="None" />
+    <Rule Id="SA1403" Action="Error" />
+    <Rule Id="SA1404" Action="Error" />
+    <Rule Id="SA1405" Action="Error" />
+    <Rule Id="SA1406" Action="Error" />
+    <Rule Id="SA1407" Action="Error" />
     <Rule Id="SA1408" Action="None" />
-    <Rule Id="SA1410" Action="None" />
-    <Rule Id="SA1411" Action="None" />
+    <Rule Id="SA1410" Action="Error" />
+    <Rule Id="SA1411" Action="Error" />
     <Rule Id="SA1412" Action="None" />
-    <Rule Id="SA1500" Action="None" />	
-    <Rule Id="SA1502" Action="None" />		
-    <Rule Id="SA1516" Action="None" />	
+    <Rule Id="SA1500" Action="None" />
+    <Rule Id="SA1502" Action="None" />
+    <Rule Id="SA1516" Action="None" />
     <Rule Id="SA1600" Action="None" />
-    <Rule Id="SA1603" Action="None" />
-    <Rule Id="SA1609" Action="None" />
-    <Rule Id="SA1623" Action="None" />	
+    <Rule Id="SA1603" Action="Error" />
+    <Rule Id="SA1609" Action="Error" />
+    <Rule Id="SA1611" Action="None" />	
+    <Rule Id="SA1623" Action="None" />
     <Rule Id="SA1633" Action="None" />
-    <Rule Id="SA1636" Action="None" />
-    <Rule Id="SA1642" Action="None" />
-    <Rule Id="SA1643" Action="None" />
+    <Rule Id="SA1636" Action="Error" />
+    <Rule Id="SA1642" Action="Error" />
+    <Rule Id="SA1643" Action="Error" />
     <Rule Id="SA1652" Action="None" />
-
   </Rules>
 </RuleSet>

--- a/src/Ocelot/Configuration/Repository/FileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationRepository.cs
@@ -18,7 +18,7 @@ namespace Ocelot.Configuration.Repository
             _configFilePath = $"{AppContext.BaseDirectory}/configuration{(string.IsNullOrEmpty(hostingEnvironment.EnvironmentName) ? string.Empty : ".")}{hostingEnvironment.EnvironmentName}.json";
         }
 
-        public async Task<Response<FileConfiguration>> Get()
+        public Task<Response<FileConfiguration>> Get()
         {
             string jsonConfiguration;
 
@@ -29,10 +29,10 @@ namespace Ocelot.Configuration.Repository
 
             var fileConfiguration = JsonConvert.DeserializeObject<FileConfiguration>(jsonConfiguration);
 
-            return new OkResponse<FileConfiguration>(fileConfiguration);
+            return Task.FromResult<Response<FileConfiguration>>(new OkResponse<FileConfiguration>(fileConfiguration));
         }
 
-        public async Task<Response> Set(FileConfiguration fileConfiguration)
+        public Task<Response> Set(FileConfiguration fileConfiguration)
         {
             string jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration);
 
@@ -45,8 +45,8 @@ namespace Ocelot.Configuration.Repository
 
                 System.IO.File.WriteAllText(_configFilePath, jsonConfiguration);
             }
-            
-            return new OkResponse();
+
+            return Task.FromResult<Response>(new OkResponse());
         }
     }
 }

--- a/src/Ocelot/Configuration/Repository/InMemoryOcelotConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/InMemoryOcelotConfigurationRepository.cs
@@ -12,19 +12,19 @@ namespace Ocelot.Configuration.Repository
 
         private IOcelotConfiguration _ocelotConfiguration;
 
-        public async Task<Response<IOcelotConfiguration>> Get()
+        public Task<Response<IOcelotConfiguration>> Get()
         {
-            return new OkResponse<IOcelotConfiguration>(_ocelotConfiguration);
+            return Task.FromResult<Response<IOcelotConfiguration>>(new OkResponse<IOcelotConfiguration>(_ocelotConfiguration));
         }
 
-        public async Task<Response> AddOrReplace(IOcelotConfiguration ocelotConfiguration)
+        public Task<Response> AddOrReplace(IOcelotConfiguration ocelotConfiguration)
         {
             lock (LockObject)
             {
                 _ocelotConfiguration = ocelotConfiguration;
             }
 
-            return new OkResponse();
+            return Task.FromResult<Response>(new OkResponse());
         }
     }
 }

--- a/src/Ocelot/ServiceDiscovery/ServiceFabricServiceDiscoveryProvider.cs
+++ b/src/Ocelot/ServiceDiscovery/ServiceFabricServiceDiscoveryProvider.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ocelot.Values;
 
@@ -14,16 +13,16 @@ namespace Ocelot.ServiceDiscovery
             _configuration = configuration;
         }
 
-        public async Task<List<Service>> Get()
+        public Task<List<Service>> Get()
         {
-            return new List<Service>
+            return Task.FromResult(new List<Service>
             {
                 new Service(_configuration.ServiceName, 
                     new ServiceHostAndPort(_configuration.HostName, _configuration.Port), 
                     "doesnt matter with service fabric", 
                     "doesnt matter with service fabric", 
                     new List<string>())
-            };
+            });
         }
     }
 }

--- a/test/Ocelot.AcceptanceTests/HeaderTests.cs
+++ b/test/Ocelot.AcceptanceTests/HeaderTests.cs
@@ -221,13 +221,15 @@ namespace Ocelot.AcceptanceTests
                 .Configure(app =>
                 {
                     app.UsePathBase(basePath);
-                    app.Run(async context =>
+                    app.Run(context => 
                     {   
                         context.Response.OnStarting(() => {
                             context.Response.Headers.Add(headerKey, headerValue);
                             context.Response.StatusCode = statusCode;
                             return Task.CompletedTask;
                         });
+
+                        return Task.CompletedTask;
                     });
                 })
                 .Build();

--- a/test/Ocelot.AcceptanceTests/HeaderTests.cs
+++ b/test/Ocelot.AcceptanceTests/HeaderTests.cs
@@ -18,7 +18,6 @@ namespace Ocelot.AcceptanceTests
     {
         private IWebHost _builder;
         private readonly Steps _steps;
-        private string _downstreamPath;
 
         public HeaderTests()
         {
@@ -235,11 +234,6 @@ namespace Ocelot.AcceptanceTests
                 .Build();
 
             _builder.Start();
-        }
-
-        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
-        {
-            _downstreamPath.ShouldBe(expectedDownstreamPath);
         }
 
         public void Dispose()

--- a/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
@@ -6,6 +6,7 @@ namespace Ocelot.UnitTests.Authentication
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Moq;
     using Ocelot.Authentication.Middleware;
@@ -44,10 +45,11 @@ namespace Ocelot.UnitTests.Authentication
 
         private void WhenICallTheMiddleware()
         {
-            _next = async (context) => {
+            _next = (context) => {
                 byte[] byteArray = Encoding.ASCII.GetBytes("The user is authenticated");
-                MemoryStream stream = new MemoryStream(byteArray);
+                var stream = new MemoryStream(byteArray);
                 context.HttpContext.Response.Body = stream;
+                return Task.CompletedTask;
             };
             _middleware = new AuthenticationMiddleware(_next, _factory.Object);
             _middleware.Invoke(_downstreamContext).GetAwaiter().GetResult();
@@ -55,10 +57,11 @@ namespace Ocelot.UnitTests.Authentication
 
         private void GivenTheTestServerPipelineIsConfigured()
         {
-            _next = async (context) => {
+            _next = (context) => {
                 byte[] byteArray = Encoding.ASCII.GetBytes("The user is authenticated");
-                MemoryStream stream = new MemoryStream(byteArray);
+                var stream = new MemoryStream(byteArray);
                 context.HttpContext.Response.Body = stream;
+                return Task.CompletedTask;
             };
         }
 

--- a/test/Ocelot.UnitTests/Authorization/AuthorisationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authorization/AuthorisationMiddlewareTests.cs
@@ -4,18 +4,17 @@ namespace Ocelot.UnitTests.Authorization
 {
     using System.Collections.Generic;
     using System.Security.Claims;
+    using System.Threading.Tasks;
     using Moq;
     using Ocelot.Authorisation;
     using Ocelot.Authorisation.Middleware;
     using Ocelot.Configuration.Builder;
-    using Ocelot.DownstreamRouteFinder;
     using Ocelot.DownstreamRouteFinder.UrlMatcher;
     using Ocelot.Logging;
     using Ocelot.Responses;
     using TestStack.BDDfy;
     using Xunit;
     using Microsoft.AspNetCore.Http;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Ocelot.Configuration;
 
     public class AuthorisationMiddlewareTests
@@ -36,9 +35,7 @@ namespace Ocelot.UnitTests.Authorization
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<AuthorisationMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new AuthorisationMiddleware(_next, _authService.Object, _authScopesService.Object, _loggerFactory.Object);
         }
 

--- a/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareRealCacheTests.cs
+++ b/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareRealCacheTests.cs
@@ -10,6 +10,7 @@ namespace Ocelot.UnitTests.Cache
     using Shouldly;
     using System.Collections.Generic;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using Moq;
     using Ocelot.Cache;
     using Ocelot.Cache.Middleware;
@@ -43,9 +44,7 @@ namespace Ocelot.UnitTests.Cache
             _cacheManager = new OcelotCacheManagerCache<CachedResponse>(cacheManagerOutputCache);
             _downstreamContext = new DownstreamContext(new DefaultHttpContext());
             _downstreamContext.DownstreamRequest = new HttpRequestMessage(HttpMethod.Get, "https://some.url/blah?abcd=123");
-            _next = async context => {
-                //do nothing..
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new OutputCacheMiddleware(_next, _loggerFactory.Object, _cacheManager, _regionCreator);
         }
 

--- a/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
@@ -7,19 +7,16 @@ namespace Ocelot.UnitTests.Cache
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
-    using Microsoft.AspNetCore.Builder;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using Ocelot.Cache;
     using Ocelot.Cache.Middleware;
     using Ocelot.Configuration;
     using Ocelot.Configuration.Builder;
     using Ocelot.DownstreamRouteFinder;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Ocelot.DownstreamRouteFinder.UrlMatcher;
     using Ocelot.Logging;
-    using Ocelot.Responses;
     using TestStack.BDDfy;
     using Xunit;
 
@@ -42,10 +39,7 @@ namespace Ocelot.UnitTests.Cache
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<OutputCacheMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
-
+            _next = context => Task.CompletedTask;
             _downstreamContext.DownstreamRequest = new HttpRequestMessage(HttpMethod.Get, "https://some.url/blah?abcd=123");
         }
 

--- a/test/Ocelot.UnitTests/Claims/ClaimsBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Claims/ClaimsBuilderMiddlewareTests.cs
@@ -3,6 +3,7 @@
 namespace Ocelot.UnitTests.Claims
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Moq;
     using Ocelot.Claims;
@@ -32,9 +33,7 @@ namespace Ocelot.UnitTests.Claims
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<ClaimsBuilderMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new ClaimsBuilderMiddleware(_next, _loggerFactory.Object, _addHeaders.Object);
         }
 

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
@@ -4,9 +4,8 @@ using Ocelot.Middleware.Multiplexer;
 namespace Ocelot.UnitTests.DownstreamRouteFinder
 {
     using System.Collections.Generic;
-    using Microsoft.AspNetCore.Builder;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using Ocelot.Configuration;
     using Ocelot.Configuration.Builder;
@@ -42,9 +41,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<DownstreamRouteFinderMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _multiplexer = new Mock<IMultiplexer>();
             _middleware = new DownstreamRouteFinderMiddleware(_next, _loggerFactory.Object, _finder.Object, _provider.Object, _multiplexer.Object);
         }

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -6,23 +6,19 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator
     using System;
     using System.Collections.Generic;
     using System.Net.Http;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.Extensions.DependencyInjection;
+    using System.Threading.Tasks;
     using Moq;
     using Ocelot.Configuration.Builder;
     using Ocelot.DownstreamRouteFinder;
     using Ocelot.DownstreamRouteFinder.UrlMatcher;
-    using Ocelot.DownstreamUrlCreator;
     using Ocelot.DownstreamUrlCreator.Middleware;
     using Ocelot.DownstreamUrlCreator.UrlTemplateReplacer;
-    using Ocelot.Infrastructure.RequestData;
     using Ocelot.Logging;
     using Ocelot.Responses;
     using Ocelot.Values;
     using TestStack.BDDfy;
     using Xunit;
     using Shouldly;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Microsoft.AspNetCore.Http;
 
     public class DownstreamUrlCreatorMiddlewareTests
@@ -43,9 +39,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator
             _loggerFactory.Setup(x => x.CreateLogger<DownstreamUrlCreatorMiddleware>()).Returns(_logger.Object);
             _downstreamUrlTemplateVariableReplacer = new Mock<IDownstreamPathPlaceholderReplacer>();
             _downstreamContext.DownstreamRequest = new HttpRequestMessage(HttpMethod.Get, "https://my.url/abc/?q=123");
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
         }
 
         [Fact]

--- a/test/Ocelot.UnitTests/Headers/HttpHeadersTransformationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Headers/HttpHeadersTransformationMiddlewareTests.cs
@@ -11,11 +11,12 @@ using Ocelot.Configuration.Builder;
 using Ocelot.Headers;
 using System.Net.Http;
 using Ocelot.Authorisation.Middleware;
-using Ocelot.DownstreamRouteFinder.Middleware;
 using Ocelot.Middleware;
 
 namespace Ocelot.UnitTests.Headers
 {
+    using System.Threading.Tasks;
+
     public class HttpHeadersTransformationMiddlewareTests
     {
         private Mock<IHttpContextRequestHeaderReplacer> _preReplacer;
@@ -34,9 +35,7 @@ namespace Ocelot.UnitTests.Headers
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<AuthorisationMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new HttpHeadersTransformationMiddleware(_next, _loggerFactory.Object, _preReplacer.Object, _postReplacer.Object);
         }
 

--- a/test/Ocelot.UnitTests/Headers/HttpRequestHeadersBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Headers/HttpRequestHeadersBuilderMiddlewareTests.cs
@@ -4,14 +4,12 @@ namespace Ocelot.UnitTests.Headers
 {
     using System.Collections.Generic;
     using System.Net.Http;
-    using Microsoft.AspNetCore.Builder;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using Ocelot.Configuration;
     using Ocelot.Configuration.Builder;
     using Ocelot.DownstreamRouteFinder;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Ocelot.DownstreamRouteFinder.UrlMatcher;
     using Ocelot.Headers;
     using Ocelot.Headers.Middleware;
@@ -37,9 +35,7 @@ namespace Ocelot.UnitTests.Headers
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<HttpRequestHeadersBuilderMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new HttpRequestHeadersBuilderMiddleware(_next, _loggerFactory.Object, _addHeaders.Object);
             _downstreamContext.DownstreamRequest = new HttpRequestMessage();
         }

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerHouseTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerHouseTests.cs
@@ -19,12 +19,13 @@ namespace Ocelot.UnitTests.LoadBalancer
         private readonly LoadBalancerHouse _loadBalancerHouse;
         private Response<ILoadBalancer> _getResult;
         private readonly Mock<ILoadBalancerFactory> _factory;
-        private ServiceProviderConfiguration _serviceProviderConfig;
+        private readonly ServiceProviderConfiguration _serviceProviderConfig;
 
         public LoadBalancerHouseTests()
         {
             _factory = new Mock<ILoadBalancerFactory>();
             _loadBalancerHouse = new LoadBalancerHouse(_factory.Object);
+            _serviceProviderConfig = new ServiceProviderConfiguration("myType","myHost",123);
         }
 
         [Fact]

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
@@ -4,6 +4,7 @@ namespace Ocelot.UnitTests.LoadBalancer
 {
     using System.Collections.Generic;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using Microsoft.AspNetCore.Http;
     using Moq;
     using Ocelot.Configuration;
@@ -43,9 +44,7 @@ namespace Ocelot.UnitTests.LoadBalancer
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<LoadBalancingMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _downstreamContext.DownstreamRequest = _downstreamRequest;
         }
 

--- a/test/Ocelot.UnitTests/Middleware/MultiplexerTests.cs
+++ b/test/Ocelot.UnitTests/Middleware/MultiplexerTests.cs
@@ -24,7 +24,7 @@ namespace Ocelot.UnitTests.Middleware
         {
             _aggregator = new Mock<IResponseAggregator>();
             _context = new DownstreamContext(new DefaultHttpContext());
-            _pipeline = async context => { _count++; }; 
+            _pipeline = context => Task.FromResult(_count++); 
             _multiplexer = new Multiplexer(_aggregator.Object);
         }
 

--- a/test/Ocelot.UnitTests/QueryStrings/QueryStringBuilderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/QueryStrings/QueryStringBuilderMiddlewareTests.cs
@@ -4,7 +4,6 @@ namespace Ocelot.UnitTests.QueryStrings
 {
     using System.Collections.Generic;
     using System.Net.Http;
-    using Microsoft.Extensions.DependencyInjection;
     using Moq;
     using Ocelot.Configuration;
     using Ocelot.Configuration.Builder;
@@ -17,9 +16,8 @@ namespace Ocelot.UnitTests.QueryStrings
     using TestStack.BDDfy;
     using Xunit;
     using System.Security.Claims;
-    using Microsoft.AspNetCore.Builder;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Microsoft.AspNetCore.Http;
+    using System.Threading.Tasks;
 
     public class QueryStringBuilderMiddlewareTests
     {
@@ -36,9 +34,7 @@ namespace Ocelot.UnitTests.QueryStrings
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<QueryStringBuilderMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _addQueries = new Mock<IAddQueriesToRequest>();
             _downstreamContext.DownstreamRequest = new HttpRequestMessage();
             _middleware = new QueryStringBuilderMiddleware(_next, _loggerFactory.Object, _addQueries.Object);

--- a/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
@@ -15,9 +15,9 @@ namespace Ocelot.UnitTests.RateLimit
     using Shouldly;
     using TestStack.BDDfy;
     using Xunit;
-    using Ocelot.DownstreamRouteFinder.Middleware;
     using Microsoft.Extensions.Caching.Memory;
     using System.IO;
+    using System.Threading.Tasks;
 
     public class ClientRateLimitMiddlewareTests
     {
@@ -42,8 +42,7 @@ namespace Ocelot.UnitTests.RateLimit
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<ClientRateLimitMiddleware>()).Returns(_logger.Object);
-             _next = async (context) => {
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new ClientRateLimitMiddleware(_next, _loggerFactory.Object, _rateLimitCounterHandler);
         }
 

--- a/test/Ocelot.UnitTests/RequestId/ReRouteRequestIdMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/RequestId/ReRouteRequestIdMiddlewareTests.cs
@@ -9,6 +9,7 @@ namespace Ocelot.UnitTests.RequestId
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using Moq;
     using Ocelot.Configuration.Builder;
     using Ocelot.DownstreamRouteFinder;
@@ -40,8 +41,10 @@ namespace Ocelot.UnitTests.RequestId
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<ReRouteRequestIdMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
+            _next = context =>
+            {
                 context.HttpContext.Response.Headers.Add("LSRequestId", context.HttpContext.TraceIdentifier);
+                return Task.CompletedTask;
             };
             _middleware = new ReRouteRequestIdMiddleware(_next, _loggerFactory.Object, _repo.Object);
             _downstreamContext.DownstreamRequest = _downstreamRequest;

--- a/test/Ocelot.UnitTests/Requester/FakeDelegatingHandler.cs
+++ b/test/Ocelot.UnitTests/Requester/FakeDelegatingHandler.cs
@@ -17,12 +17,13 @@ namespace Ocelot.UnitTests.Requester
         }
 
         public int Order {get;private set;}
+
         public DateTime TimeCalled {get;private set;}
 
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             TimeCalled = DateTime.Now;
-            return new HttpResponseMessage();
+            return Task.FromResult(new HttpResponseMessage());
         }
     }
 }

--- a/test/Ocelot.UnitTests/Requester/HttpRequesterMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpRequesterMiddlewareTests.cs
@@ -13,6 +13,7 @@ namespace Ocelot.UnitTests.Requester
     using TestStack.BDDfy;
     using Xunit;
     using Shouldly;
+    using System.Threading.Tasks;
 
     public class HttpRequesterMiddlewareTests
     {
@@ -30,9 +31,7 @@ namespace Ocelot.UnitTests.Requester
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<HttpRequesterMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new HttpRequesterMiddleware(_next, _loggerFactory.Object, _requester.Object);
         }
 

--- a/test/Ocelot.UnitTests/Responder/ResponderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ResponderMiddlewareTests.cs
@@ -5,6 +5,7 @@ namespace Ocelot.UnitTests.Responder
 {
     using Microsoft.AspNetCore.Http;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using Moq;
     using Ocelot.DownstreamRouteFinder.Finder;
     using Ocelot.Errors;
@@ -32,9 +33,7 @@ namespace Ocelot.UnitTests.Responder
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
             _logger = new Mock<IOcelotLogger>();
             _loggerFactory.Setup(x => x.CreateLogger<ResponderMiddleware>()).Returns(_logger.Object);
-            _next = async context => {
-                //do nothing
-            };
+            _next = context => Task.CompletedTask;
             _middleware = new ResponderMiddleware(_next, _responder.Object, _loggerFactory.Object, _codeMapper.Object);
         }
 


### PR DESCRIPTION
Fixes / New Feature #

#260

## Proposed Changes

Fixes all build warnings except for...

1. The warnings relating to package analysis. These are because of limitations in the current dotnet core package production infrastructure - see https://github.com/NuGet/Home/issues/4587. Not sure what the status is for the fix of this. We could disable package analysis, but that might hide other problems, so suggest we leave it as is for now.

2. CS0618 (using obsolete code) 

I've also enabled errors for some of the rules, which I forgot to do as part of #253. The rules I've chosen are a subset of the rules I use on my own projects. When I turned on errors for these rules it did not result in any errors in the code, so I'm taking that as proof that these rules are pretty unobtrusive and won't cause much hassle for devs unless they are really following bad practices.