### PR TITLE
Map content specific headers properly

### DIFF
--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -47,9 +47,26 @@
 
             var content = new ByteArrayContent(await ToByteArray(request.Body));
 
-            content.Headers.TryAddWithoutValidation("Content-Type", new[] {request.ContentType});
+            content.Headers
+                .TryAddWithoutValidation("Content-Type", new[] {request.ContentType});
 
+            AddHeaderIfExistsOnRequest("Content-Language", content, request);
+            AddHeaderIfExistsOnRequest("Content-Location", content, request);
+            AddHeaderIfExistsOnRequest("Content-Range", content, request);
+            AddHeaderIfExistsOnRequest("Content-MD5", content, request);
+            AddHeaderIfExistsOnRequest("Content-Disposition", content, request);
+            AddHeaderIfExistsOnRequest("Content-Encoding", content, request);
+            
             return content;
+        }
+
+        private void AddHeaderIfExistsOnRequest(string key, HttpContent content, HttpRequest request)
+        {
+            if(request.Headers.ContainsKey(key))
+            {
+                content.Headers
+                    .TryAddWithoutValidation(key, request.Headers[key].ToList());  
+            }            
         }
 
         private HttpMethod MapMethod(HttpRequest request)

--- a/test/Ocelot.AcceptanceTests/GzipTests.cs
+++ b/test/Ocelot.AcceptanceTests/GzipTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace Ocelot.AcceptanceTests
+{
+    public class GzipTests : IDisposable
+    {
+        private IWebHost _builder;
+        private readonly Steps _steps;
+
+        public GzipTests()
+        {
+            _steps = new Steps();
+        }
+
+        [Fact]
+        public void should_return_response_200_with_simple_url()
+        {
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamScheme = "http",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = 51879,
+                                }
+                            },
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = new List<string> { "Post" },
+                        }
+                    }
+            };
+
+            var input = "people";
+            
+            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51879", "/", 200, "Hello from Laura", "\"people\""))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .And(x => _steps.GivenThePostHasGzipContent(input))
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
+                .BDDfy();
+        }
+
+        private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody, string expected)
+        {
+            _builder = new WebHostBuilder()
+                .UseUrls(baseUrl)
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .Configure(app =>
+                {
+                    app.UsePathBase(basePath);
+                    app.Run(async context =>
+                    {   
+                        if(context.Request.Headers.TryGetValue("Content-Encoding", out var contentEncoding))
+                        {
+                            contentEncoding.First().ShouldBe("gzip");
+                            
+                            string text = null;
+                            using (var decompress = new GZipStream(context.Request.Body, CompressionMode.Decompress))
+                            {
+                                using (var sr = new StreamReader(decompress)) {
+                                    text = sr.ReadToEnd();
+                                }
+                            }
+
+                            if(text != expected)
+                            {
+                                throw new Exception("not gzipped");
+                            }
+                            
+                            context.Response.StatusCode = statusCode;
+                            await context.Response.WriteAsync(responseBody);
+                        }
+                        else
+                        {
+                            context.Response.StatusCode = statusCode;
+                            await context.Response.WriteAsync("downstream path didnt match base path");
+                        }
+                    });
+                })
+                .Build();
+
+            _builder.Start();
+        }
+        public void Dispose()
+        {
+            _builder?.Dispose();
+            _steps.Dispose();
+        }
+    }
+}

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -22,6 +22,8 @@ using Ocelot.Middleware;
 using Shouldly;
 using ConfigurationBuilder = Microsoft.Extensions.Configuration.ConfigurationBuilder;
 using Ocelot.AcceptanceTests.Caching;
+using System.IO.Compression;
+using System.Text;
 
 namespace Ocelot.AcceptanceTests
 {
@@ -580,6 +582,22 @@ namespace Ocelot.AcceptanceTests
         public void GivenThePostHasContent(string postcontent)
         {
             _postContent = new StringContent(postcontent);
+        }
+
+        public void GivenThePostHasGzipContent(object input)
+        {
+            string json = JsonConvert.SerializeObject(input);
+            byte[] jsonBytes = Encoding.UTF8.GetBytes(json);
+            MemoryStream ms = new MemoryStream();
+            using (GZipStream gzip = new GZipStream(ms, CompressionMode.Compress, true))
+            {
+                gzip.Write(jsonBytes, 0, jsonBytes.Length);
+            }
+            ms.Position = 0;
+            StreamContent content = new StreamContent(ms);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            content.Headers.ContentEncoding.Add("gzip");
+            _postContent = content;
         }
 
         public void ThenTheResponseBodyShouldBe(string expectedBody)


### PR DESCRIPTION
## Fixes #263 
- #263 

## Proposed Changes
  - map all content specific headers to downstream request content property, make sure we dont map them to request specific headers, added a gzip encoding acceptance test
