### PR TITLE
#289 preserve query string

### DIFF
--- a/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
@@ -19,6 +19,7 @@ namespace Ocelot.AcceptanceTests
 {
     using IdentityServer4;
     using IdentityServer4.Test;
+    using Shouldly;
 
     public class ClaimsToQueryStringForwardingTests : IDisposable
     {
@@ -27,6 +28,7 @@ namespace Ocelot.AcceptanceTests
         private readonly Steps _steps;
         private Action<IdentityServerAuthenticationOptions> _options;
         private string _identityServerRootUrl = "http://localhost:57888";
+        private string _downstreamQueryString;
 
         public ClaimsToQueryStringForwardingTests()
         {
@@ -105,6 +107,71 @@ namespace Ocelot.AcceptanceTests
                .BDDfy();
         }
 
+        [Fact]
+        public void should_return_response_200_and_foward_claim_as_query_string_and_preserve_original_string()
+        {
+           var user = new TestUser()
+           {
+               Username = "test",
+               Password = "test",
+               SubjectId = "registered|1231231",
+               Claims = new List<Claim>
+               {
+                   new Claim("CustomerId", "123"),
+                   new Claim("LocationId", "1")
+               }
+           };
+
+           var configuration = new FileConfiguration
+           {
+               ReRoutes = new List<FileReRoute>
+                   {
+                       new FileReRoute
+                       {
+                           DownstreamPathTemplate = "/",
+                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           {
+                               new FileHostAndPort
+                               {
+                                   Host = "localhost",
+                                   Port = 57876,
+                               }
+                           },
+                           DownstreamScheme = "http",
+                           UpstreamPathTemplate = "/",
+                           UpstreamHttpMethod = new List<string> { "Get" },
+                           AuthenticationOptions = new FileAuthenticationOptions
+                           {
+                               AuthenticationProviderKey = "Test",
+                               AllowedScopes = new List<string>
+                               {
+                                   "openid", "offline_access", "api"
+                               },
+                           },
+                           AddQueriesToRequest =
+                           {
+                               {"CustomerId", "Claims[CustomerId] > value"},
+                               {"LocationId", "Claims[LocationId] > value"},
+                               {"UserType", "Claims[sub] > value[0] > |"},
+                               {"UserId", "Claims[sub] > value[1] > |"}
+                           }
+                       }
+                   }
+           };
+
+           this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:57888", "api", AccessTokenType.Jwt, user))
+               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:57876", 200))
+               .And(x => _steps.GivenIHaveAToken("http://localhost:57888"))
+               .And(x => _steps.GivenThereIsAConfiguration(configuration))
+               .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
+               .And(x => _steps.GivenIHaveAddedATokenToMyRequest())
+               .When(x => _steps.WhenIGetUrlOnTheApiGateway("/?test=1&test=2"))
+               .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+               .And(x => _steps.ThenTheResponseBodyShouldBe("CustomerId: 123 LocationId: 1 UserType: registered UserId: 1231231"))
+               .And(_ => _downstreamQueryString.ShouldBe("?test=1&test=2&CustomerId=123&LocationId=1&UserId=1231231&UserType=registered"))
+               .BDDfy();
+        }
+
         private void GivenThereIsAServiceRunningOn(string url, int statusCode)
         {
             _servicebuilder = new WebHostBuilder()
@@ -117,6 +184,8 @@ namespace Ocelot.AcceptanceTests
                 {
                     app.Run(async context =>
                     {
+                        _downstreamQueryString = context.Request.QueryString.Value;
+
                         StringValues customerId;
                         context.Request.Query.TryGetValue("CustomerId", out customerId);
 


### PR DESCRIPTION
Fixes / New Feature #

fixes #289 

## Proposed Changes

  - fix for issue where I was not preserving original query string when more than one query with same name
  - dirty loops to build query string, bit crappy but checked the ms libs and they do the same thing when building a string out of dictionary<string,string> for some reason they dont take dictionary<string, stringvalues> which is what all the parse methods return!
