### PR TITLE
Override ToString() in DownstreamRequest

### DIFF
--- a/src/Ocelot/Request/Middleware/DownstreamRequest.cs
+++ b/src/Ocelot/Request/Middleware/DownstreamRequest.cs
@@ -65,5 +65,10 @@ namespace Ocelot.Request.Middleware
 
             return uriBuilder.Uri.AbsoluteUri;
         }
+
+        public override string ToString() 
+        {
+            return ToUri();
+        }
     }
 }


### PR DESCRIPTION
When executing the downstreamUrlCreatorMittleware the downstream request
url shoud be written to the log. But instead of the url the type name
gets written because the ToString() method wasn't overriden.

Now ToString() internally calls the ToUri() method in order to provide
the url instead of the type name.