### PR TITLE
Update middlewareinjection.rst

### DIFF
--- a/docs/features/middlewareinjection.rst
+++ b/docs/features/middlewareinjection.rst
@@ -9,7 +9,7 @@ and override middleware. This is done as follos.
 
 .. code-block:: csharp
 
-    var configuration = new OcelotMiddlewareConfiguration
+    var configuration = new OcelotPipelineConfiguration
     {
         PreErrorResponderMiddleware = async (ctx, next) =>
         {


### PR DESCRIPTION
Class name "OcelotMiddlewareConfiguration" does not exist and "UseOcelot" extension method expects a "OcelotPipelineConfiguration" so i think this documentaiton is outdated.

Fixes#
Documentation update.
## Proposed Changes

  - Example / Snipped referencing the wrong class name.
