### PR TITLE
#262 - Integrated Steeltoe Service Discovery with Ocelot for review.

### DIFF
--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -45,6 +45,7 @@ namespace Ocelot.DependencyInjection
     using Ocelot.Infrastructure.Consul;
     using Butterfly.Client.Tracing;
     using Ocelot.Middleware.Multiplexer;
+    using Pivotal.Discovery.Client;
 
     public class OcelotBuilder : IOcelotBuilder
     {
@@ -111,6 +112,20 @@ namespace Ocelot.DependencyInjection
             _services.TryAddSingleton<IHttpHandlerOptionsCreator, HttpHandlerOptionsCreator>();
             _services.TryAddSingleton<IDownstreamAddressesCreator, DownstreamAddressesCreator>();
             _services.TryAddSingleton<IDelegatingHandlerHandlerFactory, DelegatingHandlerHandlerFactory>();
+
+            // Steeltoe Service Discovery Implementation
+            if (configurationRoot.GetSection("GlobalConfiguration:ServiceDiscoveryProvider").Key != null &&
+                configurationRoot.GetValue<string>("GlobalConfiguration:ServiceDiscoveryProvider:Type") != null &&
+                configurationRoot.GetValue<string>("GlobalConfiguration:ServiceDiscoveryProvider:Type") == "Steeltoe" &&
+                configurationRoot.GetSection("eureka").Key != null)
+            {
+                _services.AddDiscoveryClient(configurationRoot);
+                _services.TryAddSingleton<IHttpRequester, DiscoveryClientHttpRequester>();
+            }
+            else
+            {
+                _services.TryAddSingleton<IHttpRequester, HttpClientHttpRequester>();
+            }
 
             // see this for why we register this as singleton http://stackoverflow.com/questions/37371264/invalidoperationexception-unable-to-resolve-service-for-type-microsoft-aspnetc
             // could maybe use a scoped data repository

--- a/src/Ocelot/Middleware/OcelotMiddlewareExtensions.cs
+++ b/src/Ocelot/Middleware/OcelotMiddlewareExtensions.cs
@@ -17,6 +17,7 @@
     using Rafty.Concensus;
     using Rafty.Infrastructure;
     using Ocelot.Middleware.Pipeline;
+    using Pivotal.Discovery.Client;
 
     public static class OcelotMiddlewareExtensions
     {
@@ -37,6 +38,9 @@
             {
                 SetUpRafty(builder);
             }
+
+            //Invoke Steeltow Service Discoverys
+            UserSteeltoeServiceDiscovery(builder, configuration);
 
             ConfigureDiagnosticListener(builder);
 
@@ -61,6 +65,16 @@
             });
 
             return builder;
+        }
+
+        // Inject Service Discovery Client into app
+        private static void UserSteeltoeServiceDiscovery(IApplicationBuilder builder, IInternalConfiguration configuration)
+        {
+            if (configuration != null && configuration.ServiceProviderConfiguration != null &&
+                configuration.ServiceProviderConfiguration.Type == "Steeltoe")
+            {
+                builder.UseDiscoveryClient();
+            }
         }
 
         private static bool UsingRafty(IApplicationBuilder builder)

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
+    <PackageReference Include="Pivotal.Discovery.Client" Version="1.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Ocelot/Requester/DiscoveryClientHttpRequester.cs
+++ b/src/Ocelot/Requester/DiscoveryClientHttpRequester.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Ocelot.Logging;
+using Ocelot.Middleware;
+using Ocelot.Responses;
+using Pivotal.Discovery.Client;
+using Polly.CircuitBreaker;
+using Polly.Timeout;
+
+namespace Ocelot.Requester
+{
+    public class DiscoveryClientHttpRequester : IHttpRequester
+    {
+        private readonly IHttpClientCache _cacheHandlers;
+        private readonly IOcelotLogger _logger;
+        private readonly IDelegatingHandlerHandlerFactory _factory;
+        private readonly IDiscoveryClient _discoveryClient;
+        private DiscoveryHttpClientHandler _handler;
+
+        public DiscoveryClientHttpRequester(IOcelotLoggerFactory loggerFactory,
+            IHttpClientCache cacheHandlers,
+            IDelegatingHandlerHandlerFactory house, IDiscoveryClient discoveryClient)
+        {
+            _logger = loggerFactory.CreateLogger<HttpClientHttpRequester>();
+            _cacheHandlers = cacheHandlers;
+            _factory = house;
+            _discoveryClient = discoveryClient;
+        }
+
+        public async Task<Response<HttpResponseMessage>> GetResponse(DownstreamContext request)
+        {
+            var builder = new HttpClientBuilder(_factory, _cacheHandlers, _logger);
+
+            _handler = new DiscoveryHttpClientHandler(_discoveryClient);
+            var discoveryClientBuilder = new DiscoveryHttpClientBuilder().Create(_handler, request.DownstreamReRoute);
+            var httpDiscoveryClient = discoveryClientBuilder.Client;
+
+            try
+            {
+                var response = await httpDiscoveryClient.SendAsync(request.DownstreamRequest.ToHttpRequestMessage());
+                return new OkResponse<HttpResponseMessage>(response);
+            }
+            catch (TimeoutRejectedException exception)
+            {
+                return
+                    new ErrorResponse<HttpResponseMessage>(new RequestTimedOutError(exception));
+            }
+            catch (BrokenCircuitException exception)
+            {
+                return
+                    new ErrorResponse<HttpResponseMessage>(new RequestTimedOutError(exception));
+            }
+            catch (Exception exception)
+            {
+                return new ErrorResponse<HttpResponseMessage>(new UnableToCompleteRequestError(exception));
+            }
+            finally
+            {
+                builder.Save();
+            }
+        }
+    }
+}

--- a/src/Ocelot/Requester/DiscoveryHttpClientBuilder.cs
+++ b/src/Ocelot/Requester/DiscoveryHttpClientBuilder.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Ocelot.Configuration;
+using Pivotal.Discovery.Client;
+
+namespace Ocelot.Requester
+{
+    public class DiscoveryHttpClientBuilder : IDiscoveryHttpClientBuilder
+    {
+        public IHttpClient Create(DiscoveryHttpClientHandler handler, DownstreamReRoute request)
+        {
+            var client = new HttpClient(handler);
+            return new HttpClientWrapper(client);
+        }
+    }
+}

--- a/src/Ocelot/Requester/IDiscoveryHttpClientBuilder.cs
+++ b/src/Ocelot/Requester/IDiscoveryHttpClientBuilder.cs
@@ -1,0 +1,19 @@
+﻿using Ocelot.Configuration;
+using Pivotal.Discovery.Client;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Requester
+{
+    public interface IDiscoveryHttpClientBuilder
+    {
+        /// <summary>
+        /// Creates the <see cref="HttpClient"/>
+        /// </summary>
+        /// <param name="handler">Discovery handler</param>
+        /// <param name="request">Downstream Route request</param>
+        /// <returns>IHttpClient</returns>
+        IHttpClient Create(DiscoveryHttpClientHandler handler, DownstreamReRoute request);
+    }
+}


### PR DESCRIPTION
Fixes / New Feature #

## Proposed Changes

Including the Steeltoe Discovery Client in Ocelot based upon the Configuration attribute value ServiceDiscoveryProvider:Type as "Steeltoe" and override the HttpClientHttpRequester with DiscoveryClientHttpRequester which will make a call through DiscoveryClientHandler. 

I followed another approach shared by @TomPallister by not changing anything on Ocelot and add a EurekaHandler logic in our application itself. But the problem is that HttpClientHttpRequester is being injected in OcelotBuilder and getting executed at first instead of EurekaHandler. We need to somehow override the HttpClientHttpRequester  invocation.

Please guide me the approach to achieve this.

Thanks,
Siva