### PR TITLE
#309 allow users to ignore ssl warnings, not sure this is advisable

### DIFF
--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -64,7 +64,8 @@ Here is an example ReRoute configuration, You don't need to set all of these thi
                 "UseCookieContainer": true,
                 "UseTracing": true
             },
-            "UseServiceDiscovery": false
+            "UseServiceDiscovery": false,
+            "DangerousAcceptAnyServerCertificateValidator": false
         }
 
 More information on how to use these options is below..
@@ -160,3 +161,14 @@ noticed that the cookies were being shared. I tried to think of a nice way to ha
 that means each request gets a new client and therefore a new cookie container. If you clear the cookies from the cached client container you get race conditions due to inflight
 requests. This would also mean that subsequent requests dont use the cookies from the previous response! All in all not a great situation. I would avoid setting 
 UseCookieContainer to true unless you have a really really good reason. Just look at your response headers and forward the cookies back with your next request! 
+
+SSL Errors
+----------
+
+Id you want to ignore SSL warnings / errors set the following in your ReRoute config.
+
+.. code-block:: json
+
+    "DangerousAcceptAnyServerCertificateValidator": false
+
+I don't reccomend doing this, I suggest creating your own certificate and then getting it trusted by your local / remote machine if you can.

--- a/src/Ocelot/Configuration/Builder/DownstreamReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/DownstreamReRouteBuilder.cs
@@ -40,6 +40,7 @@ namespace Ocelot.Configuration.Builder
         private List<string> _delegatingHandlers;
         private List<AddHeader> _addHeadersToDownstream;
         private List<AddHeader> _addHeadersToUpstream;
+        private bool _dangerousAcceptAnyServerCertificateValidator;
 
         public DownstreamReRouteBuilder()
         {
@@ -241,6 +242,12 @@ namespace Ocelot.Configuration.Builder
             return this;
         }
 
+        public DownstreamReRouteBuilder WithDangerousAcceptAnyServerCertificateValidator(bool dangerousAcceptAnyServerCertificateValidator)
+        {
+            _dangerousAcceptAnyServerCertificateValidator = dangerousAcceptAnyServerCertificateValidator;
+            return this;
+        }
+
         public DownstreamReRoute Build()
         {
             return new DownstreamReRoute(
@@ -272,7 +279,8 @@ namespace Ocelot.Configuration.Builder
                 _reRouteKey,
                 _delegatingHandlers,
                 _addHeadersToDownstream,
-                _addHeadersToUpstream);
+                _addHeadersToUpstream,
+                _dangerousAcceptAnyServerCertificateValidator);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/FileInternalConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/FileInternalConfigurationCreator.cs
@@ -213,6 +213,7 @@ namespace Ocelot.Configuration.Creator
                 .WithDelegatingHandlers(fileReRoute.DelegatingHandlers)
                 .WithAddHeadersToDownstream(hAndRs.AddHeadersToDownstream)
                 .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
+                .WithDangerousAcceptAnyServerCertificateValidator(fileReRoute.DangerousAcceptAnyServerCertificateValidator)
                 .Build();
 
             return reRoute;

--- a/src/Ocelot/Configuration/DownstreamReRoute.cs
+++ b/src/Ocelot/Configuration/DownstreamReRoute.cs
@@ -35,8 +35,10 @@ namespace Ocelot.Configuration
             string reRouteKey,
             List<string> delegatingHandlers,
             List<AddHeader> addHeadersToDownstream,
-            List<AddHeader> addHeadersToUpstream)
+            List<AddHeader> addHeadersToUpstream,
+            bool dangerousAcceptAnyServerCertificateValidator)
         {
+            DangerousAcceptAnyServerCertificateValidator = dangerousAcceptAnyServerCertificateValidator;
             AddHeadersToDownstream = addHeadersToDownstream;
             DelegatingHandlers = delegatingHandlers;
             Key = key;
@@ -97,5 +99,6 @@ namespace Ocelot.Configuration
         public List<string> DelegatingHandlers {get;private set;}
         public List<AddHeader> AddHeadersToDownstream {get;private set;}
         public List<AddHeader> AddHeadersToUpstream { get; private set; }
+        public bool DangerousAcceptAnyServerCertificateValidator { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileReRoute.cs
@@ -49,5 +49,6 @@ namespace Ocelot.Configuration.File
         public List<string> DelegatingHandlers {get;set;}
         public int Priority { get;set; }
         public int Timeout { get; set; }
+        public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
     }
 }

--- a/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+++ b/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
@@ -21,6 +21,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="idsrv3test.pfx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ocelot\Ocelot.csproj" />

--- a/test/Ocelot.AcceptanceTests/SslTests.cs
+++ b/test/Ocelot.AcceptanceTests/SslTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace Ocelot.AcceptanceTests
+{
+    public class SslTests : IDisposable
+    {
+        private IWebHost _builder;
+        private readonly Steps _steps;
+        private string _downstreamPath;
+
+        public SslTests()
+        {
+            _steps = new Steps();
+        }
+
+        [Fact]
+        public void should_dangerous_accept_any_server_certificate_validator()
+        {
+            int port = 51129;
+
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamScheme = "https",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = port,
+                                }
+                            },
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                            DangerousAcceptAnyServerCertificateValidator = true
+                        }
+                    }
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"https://localhost:{port}", "/", 200, "Hello from Laura", port))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_not_dangerous_accept_any_server_certificate_validator()
+        {
+            int port = 52129;
+
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamScheme = "https",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = port,
+                                }
+                            },
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                            DangerousAcceptAnyServerCertificateValidator = false
+                        }
+                    }
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"https://localhost:{port}", "/", 200, "Hello from Laura", port))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
+                .BDDfy();
+        }
+
+        private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody, int port)
+        {
+            _builder = new WebHostBuilder()
+                .UseUrls(baseUrl)
+                .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Loopback, port, listenOptions =>
+                    {
+                        listenOptions.UseHttps("idsrv3test.pfx", "idsrv3test");
+                    });
+                })
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .Configure(app =>
+                {
+                    app.UsePathBase(basePath);
+                    app.Run(async context =>
+                    {   
+                        _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
+
+                        if(_downstreamPath != basePath)
+                        {
+                            context.Response.StatusCode = statusCode;
+                            await context.Response.WriteAsync("downstream path didnt match base path");
+                        }
+                        else
+                        {
+                            context.Response.StatusCode = statusCode;
+                            await context.Response.WriteAsync(responseBody);
+                        }
+                    });
+                })
+                .Build();
+
+            _builder.Start();
+        }
+
+        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
+        {
+            _downstreamPath.ShouldBe(expectedDownstreamPath);
+        }
+
+        public void Dispose()
+        {
+            _builder?.Dispose();
+            _steps.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Closes #309 
- #309 

## Proposed Changes

  - Allows users to set `DangerousAcceptAnyServerCertificateValidator` in ReRoute config and this will ignore SSL errors, false by default.
