### PR TITLE
Develop

### DIFF
--- a/src/Ocelot/Requester/HttpClientBuilder.cs
+++ b/src/Ocelot/Requester/HttpClientBuilder.cs
@@ -97,7 +97,11 @@ namespace Ocelot.Requester
 
         private string GetCacheKey(DownstreamContext request)
         {
-            return request.DownstreamRequest.OriginalString;
+            var cacheKey = $"{request.DownstreamRequest.Method}:{request.DownstreamRequest.OriginalString}";
+
+            this._logger.LogDebug($"Cache key for request is {cacheKey}");
+
+            return cacheKey;
         }
     }
 }


### PR DESCRIPTION
Fixes # 330

#330 Fix issue with httpclient being cached based on url but not including the http verb. This caused issues because handers were being called on incorrect routes because the httpclient was being shared by multipe routes. Added the http verb to the cache key and added unit test
