### PR TITLE
Default to NoLoadBalancer in LoadBalancerOptions previously this was not explicit.

### DIFF
--- a/src/Ocelot/Configuration/LoadBalancerOptions.cs
+++ b/src/Ocelot/Configuration/LoadBalancerOptions.cs
@@ -1,10 +1,12 @@
+using Ocelot.LoadBalancer.LoadBalancers;
+
 namespace Ocelot.Configuration
 {
     public class LoadBalancerOptions
     {
         public LoadBalancerOptions(string type, string key, int expiryInMs)
         {
-            Type = type;
+            Type = type ?? nameof(NoLoadBalancer);
             Key = key;
             ExpiryInMs = expiryInMs;
         }

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerOptionsTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerOptionsTests.cs
@@ -1,0 +1,17 @@
+using Ocelot.Configuration;
+using Ocelot.LoadBalancer.LoadBalancers;
+using Shouldly;
+using Xunit;
+
+namespace Ocelot.UnitTests.LoadBalancer
+{
+    public class LoadBalancerOptionsTests
+    {
+        [Fact]
+        public void should_default_to_no_load_balancer()
+        {
+            var options = new LoadBalancerOptionsBuilder().Build();
+            options.Type.ShouldBe(nameof(NoLoadBalancer));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #349 

## Proposed Changes

  - default to no load balancer so that in load balaner house we dont always rebuild the loadbalancer infrastructure because the load balancer options type is null