### PR TITLE
Hard-code coveralls.net version 

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #addin nuget:?package=Newtonsoft.Json&version=9.0.1
 #tool "nuget:?package=OpenCover"
 #tool "nuget:?package=ReportGenerator"
-#tool coveralls.net
+#tool "nuget:?package=coveralls.net&version=0.7.0"
 #addin Cake.Coveralls
 
 // compile


### PR DESCRIPTION
Coveralls.net 1.0.0 seems to only support .net core 2.1, so for now we need to hard-code the version as 0.7.0. We should probably revisit this once Ocelot is updated to 2.1.
