### PR TITLE
Add ability to specify whether to UseProxy or not on ReRoutes (#390)

### DIFF
--- a/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
@@ -18,7 +18,7 @@ namespace Ocelot.Configuration.Creator
             var useTracing = _tracer.GetType() != typeof(FakeServiceTracer) && options.UseTracing;
 
             return new HttpHandlerOptions(options.AllowAutoRedirect,
-                options.UseCookieContainer, useTracing);
+                options.UseCookieContainer, useTracing, options.UseProxy);
         }
     }
 }

--- a/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
@@ -6,6 +6,7 @@
         {
             AllowAutoRedirect = false;
             UseCookieContainer = false;
+            UseProxy = true;
         }
 
         public bool AllowAutoRedirect { get; set; }
@@ -13,5 +14,7 @@
         public bool UseCookieContainer { get; set; }
 
         public bool UseTracing { get; set; }
+
+        public bool UseProxy { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/HttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptions.cs
@@ -6,11 +6,12 @@
     /// </summary>
     public class HttpHandlerOptions
     {
-        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing)
+        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing, bool useProxy = true)
         {
             AllowAutoRedirect = allowAutoRedirect;
             UseCookieContainer = useCookieContainer;
             UseTracing = useTracing;
+            UseProxy = useProxy;
         }
 
         /// <summary>
@@ -23,9 +24,14 @@
         /// </summary>
         public bool UseCookieContainer { get; private set; }
 
-        // <summary>
+        /// <summary>
         /// Specify is handler has to use a opentracing
         /// </summary>
         public bool UseTracing { get; private set; }
+
+        /// <summary>
+        /// Specify if handler has to use a proxy
+        /// </summary>
+        public bool UseProxy { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/HttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptions.cs
@@ -6,7 +6,7 @@
     /// </summary>
     public class HttpHandlerOptions
     {
-        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing, bool useProxy = true)
+        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing, bool useProxy)
         {
             AllowAutoRedirect = allowAutoRedirect;
             UseCookieContainer = useCookieContainer;

--- a/src/Ocelot/Configuration/HttpHandlerOptionsBuilder.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptionsBuilder.cs
@@ -5,6 +5,7 @@
         private bool _allowAutoRedirect;
         private bool _useCookieContainer;
         private bool _useTracing;
+        private bool _useProxy;
 
         public HttpHandlerOptionsBuilder WithAllowAutoRedirect(bool input)
         {
@@ -24,9 +25,15 @@
             return this;
         }
 
+        public HttpHandlerOptionsBuilder WithUseProxy(bool useProxy)
+        {
+            _useProxy = useProxy;
+            return this;
+        }
+
         public HttpHandlerOptions Build()
         {
-            return new HttpHandlerOptions(_allowAutoRedirect, _useCookieContainer, _useTracing);
+            return new HttpHandlerOptions(_allowAutoRedirect, _useCookieContainer, _useTracing, _useProxy);
         }
     }
 }

--- a/src/Ocelot/Requester/HttpClientBuilder.cs
+++ b/src/Ocelot/Requester/HttpClientBuilder.cs
@@ -89,6 +89,7 @@ namespace Ocelot.Requester
             {
                 AllowAutoRedirect = context.DownstreamReRoute.HttpHandlerOptions.AllowAutoRedirect,
                 UseCookies = context.DownstreamReRoute.HttpHandlerOptions.UseCookieContainer,
+                UseProxy = context.DownstreamReRoute.HttpHandlerOptions.UseProxy
             };
         }
 
@@ -98,6 +99,7 @@ namespace Ocelot.Requester
                 {
                     AllowAutoRedirect = context.DownstreamReRoute.HttpHandlerOptions.AllowAutoRedirect,
                     UseCookies = context.DownstreamReRoute.HttpHandlerOptions.UseCookieContainer,
+                    UseProxy = context.DownstreamReRoute.HttpHandlerOptions.UseProxy,
                     CookieContainer = new CookieContainer()
                 };
         }

--- a/test/Ocelot.UnitTests/Configuration/FileInternalConfigurationCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/FileInternalConfigurationCreatorTests.cs
@@ -688,7 +688,7 @@
         {
             var reRouteOptions = new ReRouteOptionsBuilder()
                 .Build();
-            var httpHandlerOptions = new HttpHandlerOptions(true, true,false);
+            var httpHandlerOptions = new HttpHandlerOptions(true, true,false, true);
 
             this.Given(x => x.GivenTheConfigIs(new FileConfiguration
             {

--- a/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
@@ -96,6 +96,41 @@ namespace Ocelot.UnitTests.Configuration
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_create_options_with_useproxy_true_as_default()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                HttpHandlerOptions = new FileHttpHandlerOptions()
+            };
+
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_options_with_specified_useproxy()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                HttpHandlerOptions = new FileHttpHandlerOptions
+                {
+                    UseProxy = false
+                }
+            };
+
+            var expectedOptions = new HttpHandlerOptions(false, false, false, false);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
         private void GivenTheFollowing(FileReRoute fileReRoute)
         {
             _fileReRoute = fileReRoute;
@@ -112,6 +147,7 @@ namespace Ocelot.UnitTests.Configuration
             _httpHandlerOptions.AllowAutoRedirect.ShouldBe(expected.AllowAutoRedirect);
             _httpHandlerOptions.UseCookieContainer.ShouldBe(expected.UseCookieContainer);
             _httpHandlerOptions.UseTracing.ShouldBe(expected.UseTracing);
+            _httpHandlerOptions.UseProxy.ShouldBe(expected.UseProxy);
         }
 
         private void GivenARealTracer()

--- a/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
@@ -35,7 +35,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -54,7 +54,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, true, true);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .And(x => GivenARealTracer())
@@ -67,7 +67,7 @@ namespace Ocelot.UnitTests.Configuration
         public void should_create_options_with_useCookie_false_and_allowAutoRedirect_true_as_default()
         {
             var fileReRoute = new FileReRoute();
-            var expectedOptions = new HttpHandlerOptions(false, false, false);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -88,7 +88,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())

--- a/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
@@ -46,7 +46,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -82,7 +82,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandlerTwo",
@@ -119,7 +119,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandlerTwo",
@@ -155,7 +155,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -189,7 +189,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
                 .WithLoadBalancerKey("")
                 .Build();
 
@@ -215,7 +215,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -244,7 +244,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosProviderHouseReturns(new OkResponse<IQoSProvider>(It.IsAny<PollyQoSProvider>())))
@@ -264,7 +264,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheServiceProviderReturnsNothing())
@@ -284,7 +284,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosProviderHouseReturns(new OkResponse<IQoSProvider>(It.IsAny<PollyQoSProvider>())))
@@ -306,7 +306,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosProviderHouseReturns(new ErrorResponse<IQoSProvider>(It.IsAny<Error>())))

--- a/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
@@ -49,7 +49,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();
@@ -69,7 +69,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .WithDangerousAcceptAnyServerCertificateValidator(true)
@@ -91,7 +91,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();
@@ -122,7 +122,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, true, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, true, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();
@@ -157,7 +157,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();

--- a/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/test/Ocelot.UnitTests/Requester/HttpClientHttpRequesterTest.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpClientHttpRequesterTest.cs
@@ -52,7 +52,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();
@@ -78,7 +78,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().Build())
                 .Build();
@@ -103,7 +103,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
                 .WithLoadBalancerKey("")
                 .WithQosOptions(new QoSOptionsBuilder().WithTimeoutValue(1).Build())
                 .Build();


### PR DESCRIPTION
New Feature #390

Adds the possibility to specify whether to UseProxy or not as mentioned on the issue #390 . I kept the value defaulted to true which is the current default for the HttpHandler and that way the change is less invasive. A follow up feature would be to specify the proxy but that would be separate from this. Hope this is usefull. Let me know your thoughts.

Thanks.
