### PR TITLE
Feature/dont validate cached content headers

### DIFF
--- a/docs/features/ratelimiting.rst
+++ b/docs/features/ratelimiting.rst
@@ -19,7 +19,7 @@ OK so to get rate limiting working for a ReRoute you need to add the following j
 
 ClientWhitelist - This is an array that contains the whitelist of the client. It means that the client in this array will not be affected by the rate limiting.
 EnableRateLimiting - This value specifies enable endpoint rate limiting.
-Period - This value specifies the period, such as 1s, 5m, 1h,1d and so on.
+Period - This value specifies the period that the limit applies to, such as 1s, 5m, 1h,1d and so on. If you make more requests in the period than the limit allows then you need to wait for PeriodTimespan to elapse before you make another request.
 PeriodTimespan - This value specifies that we can retry after a certain number of seconds.
 Limit - This value specifies the maximum number of requests that a client can make in a defined period.
 

--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -88,7 +88,7 @@ namespace Ocelot.Cache.Middleware
 
             foreach (var header in cached.ContentHeaders)
             {
-                streamContent.Headers.Add(header.Key, header.Value);
+                streamContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
 
             return new DownstreamResponse(streamContent, cached.StatusCode, cached.Headers.ToList());

--- a/src/Ocelot/RateLimit/RateLimitCore.cs
+++ b/src/Ocelot/RateLimit/RateLimitCore.cs
@@ -34,7 +34,7 @@ namespace Ocelot.RateLimit
                 if (entry.HasValue)
                 {
                     // entry has not expired
-                    if (entry.Value.Timestamp + ConvertToTimeSpan(rule.Period) >= DateTime.UtcNow)
+                    if (entry.Value.Timestamp + TimeSpan.FromSeconds(rule.PeriodTimespan) >= DateTime.UtcNow)
                     {
                         // increment request count
                         var totalRequests = entry.Value.TotalRequests + 1;

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -183,6 +183,11 @@ namespace Ocelot.AcceptanceTests
             _ocelotClient = _ocelotServer.CreateClient();
         }
 
+        internal void GivenIWait(int wait)
+        {
+            Thread.Sleep(wait);
+        }
+
         public void GivenOcelotIsRunningWithMiddleareBeforePipeline<T>(Func<object, Task> callback)
         {
             _webHostBuilder = new WebHostBuilder();

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -392,6 +392,12 @@ namespace Ocelot.AcceptanceTests
             header.First().ShouldBe(value);
         }
 
+        public void ThenTheResponseBodyHeaderIs(string key, string value)
+        {
+            var header = _response.Content.Headers.GetValues(key);
+            header.First().ShouldBe(value);
+        }
+
         public void ThenTheTraceHeaderIsSet(string key)
         {
             var header = _response.Headers.GetValues(key);

--- a/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
@@ -64,9 +64,25 @@
         }
 
         [Fact]
+        public void should_returned_cached_item_when_it_is_in_cache_expires_header()
+        {
+            var contentHeaders = new Dictionary<string, IEnumerable<string>>
+            {
+                { "Expires", new List<string> { "-1" } }
+            };
+
+            var cachedResponse = new CachedResponse(HttpStatusCode.OK, new Dictionary<string, IEnumerable<string>>(), "", contentHeaders);
+            this.Given(x => x.GivenThereIsACachedResponse(cachedResponse))
+                .And(x => x.GivenTheDownstreamRouteIs())
+                .When(x => x.WhenICallTheMiddleware())
+                .Then(x => x.ThenTheCacheGetIsCalledCorrectly())
+                .BDDfy();
+        }
+
+        [Fact]
         public void should_continue_with_pipeline_and_cache_response()
         {
-            this.Given(x => x.GivenResponseIsNotCached())
+            this.Given(x => x.GivenResponseIsNotCached(new HttpResponseMessage()))
                 .And(x => x.GivenTheDownstreamRouteIs())
                 .When(x => x.WhenICallTheMiddleware())
                 .Then(x => x.ThenTheCacheAddIsCalledCorrectly())
@@ -87,9 +103,9 @@
               .Returns(_response);
         }
 
-        private void GivenResponseIsNotCached()
+        private void GivenResponseIsNotCached(HttpResponseMessage responseMessage)
         {
-            _downstreamContext.DownstreamResponse = new DownstreamResponse(new HttpResponseMessage());
+            _downstreamContext.DownstreamResponse = new DownstreamResponse(responseMessage);
         }
 
         private void GivenTheDownstreamRouteIs()


### PR DESCRIPTION
Fixes / New Feature #

fixes #400 

like a muppet ive done this branch from another branch so can't merge until that one is..sigh at me

## Proposed Changes

  - dont validate content headers when we hydrate htttpresponsemessage from the cache
  -
  -
