### PR TITLE
修改查找ocelot配置文件正则表达式中的问题

### DIFF
--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Ocelot.DependencyInjection
 
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder)
         {
-            const string pattern = "(?i)ocelot.([a-zA-Z0-9]*).json";
+            const string pattern = "(?i)ocelot\\.([a-zA-Z0-9]*)(\\.json)$";
 
             var reg = new Regex(pattern);
 


### PR DESCRIPTION
正则表达式"(?i)ocelot.([a-zA-Z0-9]*).json"，“ocelot.”中的“.”能匹配除"\n"外的任意字符；".json"原因是匹配json文件，但实际能匹配任何"*.json*"文件

Fixes / New Feature #

## Proposed Changes

  -
  -
  -
