### PR TITLE
Change port in Consul documentation

### DIFF
--- a/docs/features/servicediscovery.rst
+++ b/docs/features/servicediscovery.rst
@@ -51,7 +51,7 @@ A lot of people have asked me to implement a feature where Ocelot polls consul f
         "Host": "localhost",
         "Port": 8500,
         "Type": "PollConsul",
-        "PollingInteral": 100
+        "PollingInterval": 100
     }
 
 The polling interval is in milliseconds and tells Ocelot how often to call Consul for changes in service configuration.

--- a/docs/features/servicediscovery.rst
+++ b/docs/features/servicediscovery.rst
@@ -18,7 +18,7 @@ will be used.
 
     "ServiceDiscoveryProvider": {
         "Host": "localhost",
-        "Port": 9500
+        "Port": 8500
     }
 
 In the future we can add a feature that allows ReRoute specfic configuration. 
@@ -49,7 +49,7 @@ A lot of people have asked me to implement a feature where Ocelot polls consul f
 
     "ServiceDiscoveryProvider": {
         "Host": "localhost",
-        "Port": 9500,
+        "Port": 8500,
         "Type": "PollConsul",
         "PollingInteral": 100
     }
@@ -67,7 +67,7 @@ If you are using ACL with Consul Ocelot supports adding the X-Consul-Token heade
 
     "ServiceDiscoveryProvider": {
         "Host": "localhost",
-        "Port": 9500,
+        "Port": 8500,
         "Token": "footoken"
     }
 


### PR DESCRIPTION
the default port for the consul api is 8500 not 9500 - https://www.consul.io/docs/agent/options.html
