### PR TITLE
dont use dynamic routing unless service discovery provider explictly set and log that we are going to use dynamic info

### DIFF
--- a/docs/features/servicediscovery.rst
+++ b/docs/features/servicediscovery.rst
@@ -18,7 +18,8 @@ will be used.
 
     "ServiceDiscoveryProvider": {
         "Host": "localhost",
-        "Port": 8500
+        "Port": 8500,
+        "Type": "Consul"
     }
 
 In the future we can add a feature that allows ReRoute specfic configuration. 
@@ -137,7 +138,7 @@ The config might look something like
             "ServiceDiscoveryProvider": {
                 "Host": "localhost",
                 "Port": 8510,
-                "Type": null,
+                "Type": "Consul",
                 "Token": null,
                 "ConfigurationKey": null
             },

--- a/docs/features/servicediscovery.rst
+++ b/docs/features/servicediscovery.rst
@@ -137,7 +137,7 @@ The config might look something like
             "RequestIdKey": null,
             "ServiceDiscoveryProvider": {
                 "Host": "localhost",
-                "Port": 8510,
+                "Port": 8500,
                 "Type": "Consul",
                 "Token": null,
                 "ConfigurationKey": null

--- a/src/Ocelot/Configuration/Creator/ServiceProviderConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ServiceProviderConfigurationCreator.cs
@@ -8,7 +8,7 @@ namespace Ocelot.Configuration.Creator
         public ServiceProviderConfiguration Create(FileGlobalConfiguration globalConfiguration)
         {
             var port = globalConfiguration?.ServiceDiscoveryProvider?.Port ?? 0;
-            var host = globalConfiguration?.ServiceDiscoveryProvider?.Host ?? "consul";
+            var host = globalConfiguration?.ServiceDiscoveryProvider?.Host ?? "localhost";
             var pollingInterval = globalConfiguration?.ServiceDiscoveryProvider?.PollingInterval ?? 0;
 
             return new ServiceProviderConfigurationBuilder()

--- a/src/Ocelot/Configuration/Creator/ServiceProviderConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ServiceProviderConfigurationCreator.cs
@@ -9,12 +9,15 @@ namespace Ocelot.Configuration.Creator
         {
             var port = globalConfiguration?.ServiceDiscoveryProvider?.Port ?? 0;
             var host = globalConfiguration?.ServiceDiscoveryProvider?.Host ?? "localhost";
+            var type = !string.IsNullOrEmpty(globalConfiguration?.ServiceDiscoveryProvider?.Type) 
+                ? globalConfiguration?.ServiceDiscoveryProvider?.Type 
+                : "consul";
             var pollingInterval = globalConfiguration?.ServiceDiscoveryProvider?.PollingInterval ?? 0;
 
             return new ServiceProviderConfigurationBuilder()
                 .WithHost(host)
                 .WithPort(port)
-                .WithType(globalConfiguration?.ServiceDiscoveryProvider?.Type)
+                .WithType(type)
                 .WithToken(globalConfiguration?.ServiceDiscoveryProvider?.Token)
                 .WithConfigurationKey(globalConfiguration?.ServiceDiscoveryProvider?.ConfigurationKey)
                 .WithPollingInterval(pollingInterval)

--- a/test/Ocelot.ManualTest/Program.cs
+++ b/test/Ocelot.ManualTest/Program.cs
@@ -7,6 +7,8 @@
     using Microsoft.Extensions.DependencyInjection;
     using Ocelot.DependencyInjection;
     using Ocelot.Middleware;
+    using System;
+    using IdentityServer4.AccessTokenValidation;
 
     public class Program
     {

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteProviderFactoryTests.cs
@@ -1,26 +1,28 @@
-using System.Collections.Generic;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
-using Ocelot.Configuration;
-using Ocelot.Configuration.Builder;
-using Ocelot.DownstreamRouteFinder;
-using Ocelot.DownstreamRouteFinder.Finder;
-using Ocelot.DownstreamRouteFinder.UrlMatcher;
-using Ocelot.Responses;
-using Ocelot.Values;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.UnitTests.DownstreamRouteFinder
 {
+    using System.Collections.Generic;
+    using Microsoft.Extensions.DependencyInjection;
+    using Moq;
+    using Ocelot.Configuration;
+    using Ocelot.Configuration.Builder;
+    using Ocelot.DownstreamRouteFinder;
+    using Ocelot.DownstreamRouteFinder.Finder;
+    using Ocelot.DownstreamRouteFinder.UrlMatcher;
+    using Ocelot.Responses;
+    using Ocelot.Values;
+    using Shouldly;
+    using TestStack.BDDfy;
+    using Xunit;
     using Ocelot.Configuration.Creator;
+    using Ocelot.Logging;
 
     public class DownstreamRouteProviderFactoryTests
     {
         private readonly DownstreamRouteProviderFactory _factory;
         private IInternalConfiguration _config;
         private IDownstreamRouteProvider _result;
+        private Mock<IOcelotLogger> _logger;
+        private Mock<IOcelotLoggerFactory> _loggerFactory;
 
         public DownstreamRouteProviderFactoryTests()
         {
@@ -31,7 +33,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
             services.AddSingleton<IDownstreamRouteProvider, Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteFinder>();
             services.AddSingleton<IDownstreamRouteProvider, Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteCreator>();
             var provider = services.BuildServiceProvider();
-            _factory = new DownstreamRouteProviderFactory(provider);
+            _logger = new Mock<IOcelotLogger>();
+            _loggerFactory = new Mock<IOcelotLoggerFactory>();
+            _loggerFactory.Setup(x => x.CreateLogger<DownstreamRouteProviderFactory>()).Returns(_logger.Object);
+            _factory = new DownstreamRouteProviderFactory(provider, _loggerFactory.Object);
         }
 
         [Fact]
@@ -49,12 +54,34 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         }
 
         [Fact]
-        public void should_return_downstream_route_finder_as_no_service_discovery()
+        public void should_return_downstream_route_finder_as_no_service_discovery_given_no_host()
         {
-            var spConfig = new ServiceProviderConfigurationBuilder().Build();
-            var reRoutes = new List<ReRoute>
-            {
-            };
+            var spConfig = new ServiceProviderConfigurationBuilder().WithHost("").WithPort(50).Build();
+            var reRoutes = new List<ReRoute>();
+
+            this.Given(_ => GivenTheReRoutes(reRoutes, spConfig))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBe<Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteFinder>())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_downstream_route_finder_given_no_service_discovery_port()
+        {
+            var spConfig = new ServiceProviderConfigurationBuilder().WithHost("localhost").WithPort(0).Build();
+            var reRoutes = new List<ReRoute>();
+
+            this.Given(_ => GivenTheReRoutes(reRoutes, spConfig))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBe<Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteFinder>())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_downstream_route_finder_given_no_service_discovery_type()
+        {
+            var spConfig = new ServiceProviderConfigurationBuilder().WithHost("localhost").WithPort(50).WithType("").Build();
+            var reRoutes = new List<ReRoute>();
 
             this.Given(_ => GivenTheReRoutes(reRoutes, spConfig))
                 .When(_ => WhenIGet())
@@ -65,10 +92,9 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         [Fact]
         public void should_return_downstream_route_creator()
         {
-            var spConfig = new ServiceProviderConfigurationBuilder().WithHost("test").WithPort(50).Build();
-            var reRoutes = new List<ReRoute>
-            {
-            };
+            var spConfig = new ServiceProviderConfigurationBuilder().WithHost("test").WithPort(50).WithType("test").Build();
+            var reRoutes = new List<ReRoute>();
+
             this.Given(_ => GivenTheReRoutes(reRoutes, spConfig))
                 .When(_ => WhenIGet())
                 .Then(_ => ThenTheResultShouldBe<Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteCreator>())


### PR DESCRIPTION
Fixes #428 

## Proposed Changes

  - dont use dynamic routing unless sd provider explicit
  - log if we are using dynamic routing for request
 
