### PR TITLE
Added overload of the IConfigurationBuilder.AddOcelot extension-method that accepts a specific folder

### DIFF
--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -30,11 +30,16 @@ namespace Ocelot.DependencyInjection
 
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder)
         {
+            return builder.AddOcelot(".");
+        }
+
+        public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, string folder)
+        {
             const string pattern = "(?i)ocelot\\.([a-zA-Z0-9]*)(\\.json)$";
 
             var reg = new Regex(pattern);
 
-            var files = Directory.GetFiles(".")
+            var files = Directory.GetFiles(folder)
                 .Where(path => reg.IsMatch(path))
                 .ToList();
 
@@ -43,7 +48,7 @@ namespace Ocelot.DependencyInjection
             foreach (var file in files)
             {
                 // windows and unix sigh...
-                if(files.Count > 1 && (file == "./ocelot.json" || file == ".\\ocelot.json"))
+                if(files.Count > 1 && (Path.GetFileName(file) == "ocelot.json"))
                 {
                     continue;
                 }
@@ -53,7 +58,7 @@ namespace Ocelot.DependencyInjection
                 var config = JsonConvert.DeserializeObject<FileConfiguration>(lines);
 
                 // windows and unix sigh...
-                if (file == "./ocelot.global.json" || file == ".\\ocelot.global.json")
+                if (Path.GetFileName(file) == "ocelot.global.json")
                 {
                     fileConfiguration.GlobalConfiguration = config.GlobalConfiguration;
                 }

--- a/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
+++ b/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
@@ -32,14 +32,29 @@
         [Fact]
         public void should_merge_files()
         {
-            this.Given(_ => GivenMultipleConfigurationFiles())
+            this.Given(_ => GivenMultipleConfigurationFiles(""))
                 .When(_ => WhenIAddOcelotConfiguration())
                 .Then(_ => ThenTheConfigsAreMerged())
                 .BDDfy();
         }
 
-        private void GivenMultipleConfigurationFiles()
+        [Fact]
+        public void should_merge_files_in_specific_folder()
         {
+            string configFolder = "ConfigFiles";
+            this.Given(_ => GivenMultipleConfigurationFiles(configFolder))
+                .When(_ => WhenIAddOcelotConfigurationWithSpecificFolder(configFolder))
+                .Then(_ => ThenTheConfigsAreMerged())
+                .BDDfy();
+        }
+
+        private void GivenMultipleConfigurationFiles(string folder)
+        {
+            if (!string.IsNullOrEmpty(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
             _globalConfig = new FileConfiguration
             {
                 GlobalConfiguration = new FileGlobalConfiguration
@@ -159,16 +174,28 @@
                 }
             };
 
-            File.WriteAllText("ocelot.global.json", JsonConvert.SerializeObject(_globalConfig));
-            File.WriteAllText("ocelot.reRoutesA.json", JsonConvert.SerializeObject(_reRouteA));
-            File.WriteAllText("ocelot.reRoutesB.json", JsonConvert.SerializeObject(_reRouteB));
-            File.WriteAllText("ocelot.aggregates.json", JsonConvert.SerializeObject(_aggregate));
+            string globalFilename = Path.Combine(folder, "ocelot.global.json");
+            string reroutesAFilename = Path.Combine(folder, "ocelot.reRoutesA.json");
+            string reroutesBFilename = Path.Combine(folder, "ocelot.reRoutesB.json");
+            string aggregatesFilename = Path.Combine(folder, "ocelot.aggregates.json");
+
+            File.WriteAllText(globalFilename, JsonConvert.SerializeObject(_globalConfig));
+            File.WriteAllText(reroutesAFilename, JsonConvert.SerializeObject(_reRouteA));
+            File.WriteAllText(reroutesBFilename, JsonConvert.SerializeObject(_reRouteB));
+            File.WriteAllText(aggregatesFilename, JsonConvert.SerializeObject(_aggregate));
         }
 
         private void WhenIAddOcelotConfiguration()
         {
             IConfigurationBuilder builder = new ConfigurationBuilder();
             builder.AddOcelot();
+            _configRoot = builder.Build();
+        }
+
+        private void WhenIAddOcelotConfigurationWithSpecificFolder(string folder)
+        {
+            IConfigurationBuilder builder = new ConfigurationBuilder();
+            builder.AddOcelot(folder);
             _configRoot = builder.Build();
         }
 


### PR DESCRIPTION
Added overload of the IConfigurationBuilder.AddOcelot extension-method that accepts a specific folder

New Feature #475 

## Proposed Changes
- Overload of the IConfigurationBuilder.AddOcelot extension-method that accepts a specific folder.
- Make checks on existing files more robust and platform independent.
