### PR TITLE
Make Acceptance Test less rubbish

### DIFF
--- a/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
@@ -1,37 +1,36 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Security.Claims;
-using IdentityServer4.AccessTokenValidation;
-using IdentityServer4.Models;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Ocelot.Configuration.File;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
     using IdentityServer4.Test;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Security.Claims;
+    using IdentityServer4.AccessTokenValidation;
+    using IdentityServer4.Models;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.DependencyInjection;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
 
     public class AuthenticationTests : IDisposable
     {
-        private IWebHost _servicebuilder;
         private readonly Steps _steps;
         private IWebHost _identityServerBuilder;
         private string _identityServerRootUrl = "http://localhost:51888";
         private string _downstreamServicePath = "/";
         private string _downstreamServiceHost = "localhost";
-        private int _downstreamServicePort = 51876;
         private string _downstreamServiceScheme = "http";
-        private string _downstreamServiceUrl = "http://localhost:51876";
+        private string _downstreamServiceUrl = "http://localhost:";
         private readonly Action<IdentityServerAuthenticationOptions> _options;
+        private readonly ServiceHandler _serviceHandler;
 
         public AuthenticationTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
             _options = o =>
             {
@@ -46,6 +45,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_401_using_identity_server_access_token()
         {
+            int port = 54329;
+
            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
@@ -58,7 +59,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host =_downstreamServiceHost,
-                                   Port = _downstreamServicePort,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = _downstreamServiceScheme,
@@ -73,7 +74,7 @@ namespace Ocelot.AcceptanceTests
            };
 
             this.Given(x => x.GivenThereIsAnIdentityServerOn(_identityServerRootUrl, "api", "api2", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn(_downstreamServiceUrl, 201, string.Empty))
+               .And(x => x.GivenThereIsAServiceRunningOn($"{_downstreamServiceUrl}{port}", 201, string.Empty))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
                .And(x => _steps.GivenThePostHasContent("postContent"))
@@ -85,7 +86,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_using_identity_server()
         {
-           var configuration = new FileConfiguration
+            int port = 54099;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -97,7 +100,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host =_downstreamServiceHost,
-                                   Port = _downstreamServicePort,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = _downstreamServiceScheme,
@@ -112,7 +115,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn(_identityServerRootUrl, "api", "api2", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn(_downstreamServiceUrl, 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"{_downstreamServiceUrl}{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveAToken(_identityServerRootUrl))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -126,7 +129,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_401_using_identity_server_with_token_requested_for_other_api()
         {
-           var configuration = new FileConfiguration
+            int port = 54196;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -138,7 +143,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host =_downstreamServiceHost,
-                                   Port = _downstreamServicePort,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = _downstreamServiceScheme,
@@ -153,7 +158,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn(_identityServerRootUrl, "api", "api2", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn(_downstreamServiceUrl, 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"{_downstreamServiceUrl}{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveATokenForApi2(_identityServerRootUrl))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -166,7 +171,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_201_using_identity_server_access_token()
         {
-           var configuration = new FileConfiguration
+            int port = 52226;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -178,7 +185,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host =_downstreamServiceHost,
-                                   Port = _downstreamServicePort,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = _downstreamServiceScheme,
@@ -193,7 +200,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn(_identityServerRootUrl, "api", "api2", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn(_downstreamServiceUrl, 201, string.Empty))
+               .And(x => x.GivenThereIsAServiceRunningOn($"{_downstreamServiceUrl}{port}", 201, string.Empty))
                .And(x => _steps.GivenIHaveAToken(_identityServerRootUrl))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -207,7 +214,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_201_using_identity_server_reference_token()
         {
-           var configuration = new FileConfiguration
+            int port = 52222;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -219,7 +228,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host =_downstreamServiceHost,
-                                   Port = _downstreamServicePort,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = _downstreamServiceScheme,
@@ -234,7 +243,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn(_identityServerRootUrl, "api", "api2", AccessTokenType.Reference))
-               .And(x => x.GivenThereIsAServiceRunningOn(_downstreamServiceUrl, 201, string.Empty))
+               .And(x => x.GivenThereIsAServiceRunningOn($"{_downstreamServiceUrl}{port}", 201, string.Empty))
                .And(x => _steps.GivenIHaveAToken(_identityServerRootUrl))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -247,23 +256,11 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string url, int statusCode, string responseBody)
         {
-            _servicebuilder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
-                {
-                    app.Run(async context =>
-                    {
-                        context.Response.StatusCode = statusCode;
-                        await context.Response.WriteAsync(responseBody);
-                    });
-                })
-                .Build();
-
-            _servicebuilder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+            {
+                context.Response.StatusCode = statusCode;
+                await context.Response.WriteAsync(responseBody);
+            });
         }
 
         private void GivenThereIsAnIdentityServerOn(string url, string apiName, string api2Name, AccessTokenType tokenType)
@@ -371,7 +368,7 @@ namespace Ocelot.AcceptanceTests
 
         public void Dispose()
         {
-            _servicebuilder?.Dispose();
+            _serviceHandler.Dispose();
             _steps.Dispose();
             _identityServerBuilder?.Dispose();
         }

--- a/test/Ocelot.AcceptanceTests/AuthorisationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthorisationTests.cs
@@ -1,33 +1,32 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Security.Claims;
-using IdentityServer4.AccessTokenValidation;
-using IdentityServer4.Models;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Ocelot.Configuration.File;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
-    using IdentityServer4;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Security.Claims;
+    using IdentityServer4.AccessTokenValidation;
+    using IdentityServer4.Models;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.DependencyInjection;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
     using IdentityServer4.Test;
 
     public class AuthorisationTests : IDisposable
     {
-        private IWebHost _servicebuilder;
         private IWebHost _identityServerBuilder;
         private readonly Steps _steps;
-        private Action<IdentityServerAuthenticationOptions> _options;
+        private readonly Action<IdentityServerAuthenticationOptions> _options;
         private string _identityServerRootUrl = "http://localhost:51888";
+        private readonly ServiceHandler _serviceHandler;
 
         public AuthorisationTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
             _options = o =>
             {
@@ -42,8 +41,10 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_authorising_route()
         {
-           var configuration = new FileConfiguration
-           {
+            int port = 52875;
+
+            var configuration = new FileConfiguration
+            {
                ReRoutes = new List<FileReRoute>
                    {
                        new FileReRoute
@@ -54,7 +55,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host = "localhost",
-                                   Port = 51876,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = "http",
@@ -83,10 +84,10 @@ namespace Ocelot.AcceptanceTests
                            }
                        }
                    }
-           };
+            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:51888", "api", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveAToken("http://localhost:51888"))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -100,7 +101,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_403_authorising_route()
         {
-           var configuration = new FileConfiguration
+            int port = 59471;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -112,7 +115,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host = "localhost",
-                                   Port = 51876,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = "http",
@@ -143,7 +146,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:51888", "api", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveAToken("http://localhost:51888"))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -156,7 +159,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_using_identity_server_with_allowed_scope()
         {
-           var configuration = new FileConfiguration
+            int port = 63471;
+
+            var configuration = new FileConfiguration
            {   
                ReRoutes = new List<FileReRoute>
                    {
@@ -168,7 +173,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host = "localhost",
-                                   Port = 51876,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = "http",
@@ -184,7 +189,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:51888", "api", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveATokenForApiReadOnlyScope("http://localhost:51888"))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -197,7 +202,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_403_using_identity_server_with_scope_not_allowed()
         {
-           var configuration = new FileConfiguration
+            int port = 60571;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -209,7 +216,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host = "localhost",
-                                   Port = 51876,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = "http",
@@ -225,7 +232,7 @@ namespace Ocelot.AcceptanceTests
            };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:51888", "api", AccessTokenType.Jwt))
-               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveATokenForApiReadOnlyScope("http://localhost:51888"))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -238,7 +245,9 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_fix_issue_240()
         {
-           var configuration = new FileConfiguration
+            int port = 61071;
+
+            var configuration = new FileConfiguration
            {
                ReRoutes = new List<FileReRoute>
                    {
@@ -250,7 +259,7 @@ namespace Ocelot.AcceptanceTests
                                new FileHostAndPort
                                {
                                    Host = "localhost",
-                                   Port = 51876,
+                                   Port = port,
                                }
                            },
                            DownstreamScheme = "http",
@@ -284,7 +293,7 @@ namespace Ocelot.AcceptanceTests
             };
 
            this.Given(x => x.GivenThereIsAnIdentityServerOn("http://localhost:51888", "api", AccessTokenType.Jwt, users))
-               .And(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", 200, "Hello from Laura"))
+               .And(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "Hello from Laura"))
                .And(x => _steps.GivenIHaveAToken("http://localhost:51888"))
                .And(x => _steps.GivenThereIsAConfiguration(configuration))
                .And(x => _steps.GivenOcelotIsRunning(_options, "Test"))
@@ -297,23 +306,11 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string url, int statusCode, string responseBody)
         {
-            _servicebuilder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
-                {
-                    app.Run(async context =>
-                    {
-                        context.Response.StatusCode = statusCode;
-                        await context.Response.WriteAsync(responseBody);
-                    });
-                })
-                .Build();
-
-            _servicebuilder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+            {
+                context.Response.StatusCode = statusCode;
+                await context.Response.WriteAsync(responseBody);
+            });
         }
 
         private void GivenThereIsAnIdentityServerOn(string url, string apiName, AccessTokenType tokenType)
@@ -465,7 +462,7 @@ namespace Ocelot.AcceptanceTests
 
         public void Dispose()
         {
-            _servicebuilder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
             _identityServerBuilder?.Dispose();
         }

--- a/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
@@ -1,23 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class CaseSensitiveRoutingTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
+        private readonly ServiceHandler _serviceHandler;
 
         public CaseSensitiveRoutingTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
@@ -226,29 +224,16 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(baseUrl)
-                .Configure(app =>
-                {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {
-                        context.Response.StatusCode = statusCode;
-                        await context.Response.WriteAsync(responseBody);
-                    });
-                })
-                .Build();
-
-            _builder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                context.Response.StatusCode = statusCode;
+                await context.Response.WriteAsync(responseBody);
+            });
         }
 
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
@@ -1,34 +1,23 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Shouldly;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
-using TestStack.BDDfy;
-using Xunit;
-
-namespace Ocelot.AcceptanceTests
+﻿namespace Ocelot.AcceptanceTests
 {
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class ClientRateLimitTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
-         private int _counterOne;
+        private int _counterOne;
+        private readonly ServiceHandler _serviceHandler;
 
         public ClientRateLimitTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
-        }
-
-        public void Dispose()
-        {
-            _builder?.Dispose();
-            _steps.Dispose();
         }
 
         [Fact]
@@ -158,6 +147,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_call_middleware_withWhitelistClient()
         {
+            int port = 61876;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -170,7 +161,7 @@ namespace Ocelot.AcceptanceTests
                                 new FileHostAndPort
                                 {
                                     Host = "localhost",
-                                    Port = 51876,
+                                    Port = port,
                                 }
                             },
                             DownstreamScheme = "http",
@@ -201,7 +192,7 @@ namespace Ocelot.AcceptanceTests
                 }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51876", "/api/ClientRateLimit"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/ClientRateLimit"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGatewayMultipleTimesForRateLimit("/api/ClientRateLimit", 4))
@@ -211,26 +202,18 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(baseUrl)
-                .Configure(app =>
-                {
-                    app.UsePathBase(basePath);
-                    app.Run(context =>
-                    {
-                        _counterOne++;
-                        context.Response.StatusCode = 200;
-                        context.Response.WriteAsync(_counterOne.ToString());
-                        return Task.CompletedTask;
-                    });
-                })
-                .Build();
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, context =>
+            {
+                _counterOne++;
+                context.Response.StatusCode = 200;
+                context.Response.WriteAsync(_counterOne.ToString());
+                return Task.CompletedTask;
+            });
+        }
 
-            _builder.Start();
+        public void Dispose()
+        {
+            _steps.Dispose();
         }
     }
 }

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -1,29 +1,27 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Net;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Ocelot.Middleware;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
-namespace Ocelot.AcceptanceTests
+﻿namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Net;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using Ocelot.Middleware;
+    using Shouldly;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class CustomMiddlewareTests : IDisposable
     {
         private readonly string _configurationPath;
-        private IWebHost _builder;
         private readonly Steps _steps;
         private int _counter;
+        private readonly ServiceHandler _serviceHandler;
 
         public CustomMiddlewareTests()
         {
+            _serviceHandler = new ServiceHandler();
             _counter = 0;
             _steps = new Steps();
             _configurationPath = "ocelot.json";
@@ -340,37 +338,24 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string url, int statusCode, string basePath)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, context =>
+            {
+                if (string.IsNullOrEmpty(basePath))
                 {
-                    app.UsePathBase(basePath);
-                    app.Run(context =>
-                    {
-                        if(string.IsNullOrEmpty(basePath))
-                        {
-                            context.Response.StatusCode = statusCode;
-                        }
-                        else if(context.Request.Path.Value != basePath)
-                        {
-                            context.Response.StatusCode = 404;
-                        }
+                    context.Response.StatusCode = statusCode;
+                }
+                else if (context.Request.Path.Value != basePath)
+                {
+                    context.Response.StatusCode = 404;
+                }
 
-                        return Task.CompletedTask;
-                    });
-                })
-                .Build();
-
-            _builder.Start();
+                return Task.CompletedTask;
+            });
         }
 
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
 

--- a/test/Ocelot.AcceptanceTests/RequestIdTests.cs
+++ b/test/Ocelot.AcceptanceTests/RequestIdTests.cs
@@ -1,26 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Primitives;
-using Ocelot.Configuration.File;
-using TestStack.BDDfy;
-using Xunit;
-
-namespace Ocelot.AcceptanceTests
+﻿namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class RequestIdTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
+        private readonly ServiceHandler _serviceHandler;
 
         public RequestIdTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
@@ -171,30 +166,17 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string url)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
-                {
-                    app.Run(context =>
-                    {
-                        StringValues requestId;
-                        context.Request.Headers.TryGetValue(_steps.RequestIdKey, out requestId);
-                        context.Response.Headers.Add(_steps.RequestIdKey, requestId.First());
-                        return Task.CompletedTask;
-                    });
-                })
-                .Build();
-
-            _builder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, context =>
+            {
+                context.Request.Headers.TryGetValue(_steps.RequestIdKey, out var requestId);
+                context.Response.Headers.Add(_steps.RequestIdKey, requestId.First());
+                return Task.CompletedTask;
+            });
         }
 
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/ResponseCodeTests.cs
+++ b/test/Ocelot.AcceptanceTests/ResponseCodeTests.cs
@@ -1,25 +1,20 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class ResponseCodeTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
-        private string _downstreamPath;
+        private readonly ServiceHandler _serviceHandler;
 
         public ResponseCodeTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
@@ -58,26 +53,15 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .Configure(app =>
-                {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {   
-                            context.Response.StatusCode = statusCode;
-                    });
-                })
-                .Build();
-
-            _builder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                context.Response.StatusCode = statusCode;
+            });
         }
+
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -1,22 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Ocelot.Configuration.File;
-using TestStack.BDDfy;
-using Xunit;
-
-namespace Ocelot.AcceptanceTests
+﻿namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class ReturnsErrorTests : IDisposable
     {
-        private IWebHost _servicebuilder;
         private readonly Steps _steps;
+        private readonly ServiceHandler _serviceHandler;
 
         public ReturnsErrorTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
@@ -55,27 +53,12 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string url)
         {
-            _servicebuilder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
-                {
-                    app.Run(context =>
-                    {
-                        throw new Exception("BLAMMMM");
-                    });
-                })
-                .Build();
-
-            _servicebuilder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, context => throw new Exception("BLAMMMM"));
         }
 
         public void Dispose()
         {
-            _servicebuilder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
@@ -1,25 +1,21 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class RoutingWithQueryStringTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
-        private string _downstreamPath;
+        private readonly ServiceHandler _serviceHandler;
 
         public RoutingWithQueryStringTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
@@ -208,41 +204,24 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, string queryString, int statusCode, string responseBody)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                if (context.Request.PathBase.Value != basePath || context.Request.QueryString.Value != queryString)
                 {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {   
-                        if(context.Request.PathBase.Value != basePath || context.Request.QueryString.Value != queryString)
-                        {
-                            context.Response.StatusCode = 500;
-                            await context.Response.WriteAsync("downstream path didnt match base path");
-                        }
-                        else
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync(responseBody);
-                        }
-                    });
-                })
-                .Build();
-
-            _builder.Start();
-        }
-
-        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
-        {
-            _downstreamPath.ShouldBe(expectedDownstreamPath);
+                    context.Response.StatusCode = 500;
+                    await context.Response.WriteAsync("downstream path didnt match base path");
+                }
+                else
+                {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(responseBody);
+                }
+            });
         }
 
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/ServiceHandler.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceHandler.cs
@@ -1,0 +1,108 @@
+﻿namespace Ocelot.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Net.WebSockets;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    public class ServiceHandler : IDisposable
+    {
+        private IWebHost _builder;
+
+        public void GivenThereIsAServiceRunningOn(string baseUrl, RequestDelegate del)
+        {
+            _builder = new WebHostBuilder()
+                .UseUrls(baseUrl)
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .Configure(app =>
+                {
+                    app.Run(del);
+                })
+                .Build();
+
+            _builder.Start();
+        }
+
+        public void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, RequestDelegate del)
+        {
+            _builder = new WebHostBuilder()
+                .UseUrls(baseUrl)
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .Configure(app =>
+                {
+                    app.UsePathBase(basePath);
+                    app.Run(del);
+                })
+                .Build();
+
+            _builder.Start();
+        }
+
+        public void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, string fileName, string password, int port, RequestDelegate del)
+        {
+            _builder = new WebHostBuilder()
+                .UseUrls(baseUrl)
+                .UseKestrel(options =>
+                {
+                    options.Listen(IPAddress.Loopback, port, listenOptions =>
+                    {
+                        listenOptions.UseHttps(fileName, password);
+                    });
+                })
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .Configure(app =>
+                {
+                    app.UsePathBase(basePath);
+                    app.Run(del);
+                })
+                .Build();
+
+            _builder.Start();
+        }
+
+        public async Task StartFakeDownstreamService(string url, string path, Func<HttpContext, Func<Task>, Task> middleware)
+        {
+            _builder = new WebHostBuilder()
+                .ConfigureServices(s => { }).UseKestrel()
+                .UseUrls(url)
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
+                    var env = hostingContext.HostingEnvironment;
+                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
+                    config.AddEnvironmentVariables();
+                })
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                    logging.AddConsole();
+                })
+                .Configure(app =>
+                {
+                    app.UseWebSockets();
+                    app.Use(middleware);
+                })
+                .UseIISIntegration()
+                .Build();
+
+            await _builder.StartAsync();
+        }
+
+        public void Dispose()
+        {
+            _builder?.Dispose();
+        }
+    }
+}

--- a/test/Ocelot.AcceptanceTests/TwoDownstreamServicesTests.cs
+++ b/test/Ocelot.AcceptanceTests/TwoDownstreamServicesTests.cs
@@ -1,30 +1,25 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Consul;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Consul;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class TwoDownstreamServicesTests : IDisposable
     {
-        private IWebHost _builderOne;
-        private IWebHost _builderTwo;
-        private IWebHost _fakeConsulBuilder;
         private readonly Steps _steps;
         private readonly List<ServiceEntry> _serviceEntries;
         private string _downstreamPathOne;
         private string _downstreamPathTwo;
+        private readonly ServiceHandler _serviceHandler;
 
         public TwoDownstreamServicesTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
             _serviceEntries = new List<ServiceEntry>();
         }
@@ -98,93 +93,58 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAFakeConsulServiceDiscoveryProvider(string url)
         {
-            _fakeConsulBuilder = new WebHostBuilder()
-                            .UseUrls(url)
-                            .UseKestrel()
-                            .UseContentRoot(Directory.GetCurrentDirectory())
-                            .UseIISIntegration()
-                            .UseUrls(url)
-                            .Configure(app =>
-                            {
-                                app.Run(async context =>
-                                {
-                                    if(context.Request.Path.Value == "/v1/health/service/product")
-                                    {
-                                        await context.Response.WriteJsonAsync(_serviceEntries);
-                                    }
-                                });
-                            })
-                            .Build();
-
-            _fakeConsulBuilder.Start();
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+            {
+                if (context.Request.Path.Value == "/v1/health/service/product")
+                {
+                    await context.Response.WriteJsonAsync(_serviceEntries);
+                }
+            });
         }
 
         private void GivenProductServiceOneIsRunning(string baseUrl, string basePath, int statusCode, string responseBody)
         {
-            _builderOne = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                _downstreamPathOne = !string.IsNullOrEmpty(context.Request.PathBase.Value)
+                    ? context.Request.PathBase.Value
+                    : context.Request.Path.Value;
+
+                if (_downstreamPathOne != basePath)
                 {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {   
-                        _downstreamPathOne = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
-
-                        if(_downstreamPathOne != basePath)
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync("downstream path didnt match base path");
-                        }
-                        else
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync(responseBody);
-                        }
-                    });
-                })
-                .Build();
-
-            _builderOne.Start();
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync("downstream path didnt match base path");
+                }
+                else
+                {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(responseBody);
+                }
+            });
         }
 
         private void GivenProductServiceTwoIsRunning(string baseUrl, string basePath, int statusCode, string responseBody)
         {
-            _builderTwo = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                _downstreamPathTwo = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
+
+                if (_downstreamPathTwo != basePath)
                 {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {   
-                        _downstreamPathTwo = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
-
-                        if(_downstreamPathTwo != basePath)
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync("downstream path didnt match base path");
-                        }
-                        else
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync(responseBody);
-                        }
-                    });
-                })
-                .Build();
-
-            _builderTwo.Start();
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync("downstream path didnt match base path");
+                }
+                else
+                {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(responseBody);
+                }
+            });
         }
 
         public void Dispose()
         {
-            _builderOne?.Dispose();
-            _builderTwo?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/UpstreamHostTests.cs
+++ b/test/Ocelot.AcceptanceTests/UpstreamHostTests.cs
@@ -1,31 +1,30 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration.File;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class UpstreamHostTests : IDisposable
     {
-        private IWebHost _builder;
         private readonly Steps _steps;
         private string _downstreamPath;
+        private readonly ServiceHandler _serviceHandler;
 
         public UpstreamHostTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
         }
 
         [Fact]
         public void should_return_response_200_with_simple_url_and_hosts_match()
         {
+            int port = 64905;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -39,7 +38,7 @@ namespace Ocelot.AcceptanceTests
                                 new FileHostAndPort
                                 {
                                     Host = "localhost",
-                                    Port = 51875,
+                                    Port = port,
                                 }
                             },
                             UpstreamPathTemplate = "/",
@@ -49,7 +48,7 @@ namespace Ocelot.AcceptanceTests
                     }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51875", "/", 200, "Hello from Laura"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200, "Hello from Laura"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
@@ -61,6 +60,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_with_simple_url_and_hosts_match_multiple_re_routes()
         {
+            int port = 64904;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -74,7 +75,7 @@ namespace Ocelot.AcceptanceTests
                             new FileHostAndPort
                             {
                                 Host = "localhost",
-                                Port = 51875,
+                                Port = port,
                             }
                         },
                         UpstreamPathTemplate = "/",
@@ -100,7 +101,7 @@ namespace Ocelot.AcceptanceTests
                 }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51875", "/", 200, "Hello from Laura"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200, "Hello from Laura"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
@@ -112,6 +113,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_with_simple_url_and_hosts_match_multiple_re_routes_reversed()
         {
+            int port = 64903;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -141,7 +144,7 @@ namespace Ocelot.AcceptanceTests
                             new FileHostAndPort
                             {
                                 Host = "localhost",
-                                Port = 51875,
+                                Port = port,
                             }
                         },
                         UpstreamPathTemplate = "/",
@@ -151,7 +154,7 @@ namespace Ocelot.AcceptanceTests
                 }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51875", "/", 200, "Hello from Laura"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200, "Hello from Laura"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
@@ -163,6 +166,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_200_with_simple_url_and_hosts_match_multiple_re_routes_reversed_with_no_host_first()
         {
+            int port = 64902;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -191,7 +196,7 @@ namespace Ocelot.AcceptanceTests
                             new FileHostAndPort
                             {
                                 Host = "localhost",
-                                Port = 51875,
+                                Port = port,
                             }
                         },
                         UpstreamPathTemplate = "/",
@@ -201,7 +206,7 @@ namespace Ocelot.AcceptanceTests
                 }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51875", "/", 200, "Hello from Laura"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200, "Hello from Laura"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
@@ -213,6 +218,8 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_return_response_404_with_simple_url_and_hosts_dont_match()
         {
+            int port = 64901;
+
             var configuration = new FileConfiguration
             {
                 ReRoutes = new List<FileReRoute>
@@ -226,7 +233,7 @@ namespace Ocelot.AcceptanceTests
                             new FileHostAndPort
                             {
                                 Host = "localhost",
-                                Port = 51875,
+                                Port = port,
                             }
                         },
                         UpstreamPathTemplate = "/",
@@ -236,7 +243,7 @@ namespace Ocelot.AcceptanceTests
                 }
             };
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn("http://localhost:51875", "/", 200, "Hello from Laura"))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200, "Hello from Laura"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
@@ -246,43 +253,26 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody)
         {
-            _builder = new WebHostBuilder()
-                .UseUrls(baseUrl)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
+
+                if (_downstreamPath != basePath)
                 {
-                    app.UsePathBase(basePath);
-                    app.Run(async context =>
-                    {   
-                        _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
-
-                        if(_downstreamPath != basePath)
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync("downstream path didnt match base path");
-                        }
-                        else
-                        {
-                            context.Response.StatusCode = statusCode;
-                            await context.Response.WriteAsync(responseBody);
-                        }
-                    });
-                })
-                .Build();
-
-            _builder.Start();
-        }
-
-        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
-        {
-            _downstreamPath.ShouldBe(expectedDownstreamPath);
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync("downstream path didnt match base path");
+                }
+                else
+                {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(responseBody);
+                }
+            });
         }
 
         public void Dispose()
         {
-            _builder?.Dispose();
+            _serviceHandler?.Dispose();
             _steps.Dispose();
         }
     }

--- a/test/Ocelot.AcceptanceTests/WebSocketTests.cs
+++ b/test/Ocelot.AcceptanceTests/WebSocketTests.cs
@@ -1,35 +1,29 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net.WebSockets;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Consul;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Ocelot.Configuration.File;
-using Shouldly;
-using TestStack.BDDfy;
-using Xunit;
-
 namespace Ocelot.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net.WebSockets;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Consul;
+    using Microsoft.AspNetCore.Http;
+    using Ocelot.Configuration.File;
+    using Shouldly;
+    using TestStack.BDDfy;
+    using Xunit;
+
     public class WebSocketTests : IDisposable
     {
-        private IWebHost _firstDownstreamHost;
-        private IWebHost _secondDownstreamHost;
         private readonly List<string> _secondRecieved;
         private readonly List<string> _firstRecieved;
         private readonly List<ServiceEntry> _serviceEntries;
         private readonly Steps _steps;
-        private IWebHost _fakeConsulBuilder;
+        private readonly ServiceHandler _serviceHandler;
 
         public WebSocketTests()
         {
+            _serviceHandler = new ServiceHandler();
             _steps = new Steps();
             _firstRecieved = new List<string>();
             _secondRecieved = new List<string>();
@@ -211,25 +205,13 @@ namespace Ocelot.AcceptanceTests
 
         private void GivenThereIsAFakeConsulServiceDiscoveryProvider(string url, string serviceName)
         {
-            _fakeConsulBuilder = new WebHostBuilder()
-                .UseUrls(url)
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseUrls(url)
-                .Configure(app =>
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+            {
+                if (context.Request.Path.Value == $"/v1/health/service/{serviceName}")
                 {
-                    app.Run(async context =>
-                    {
-                        if (context.Request.Path.Value == $"/v1/health/service/{serviceName}")
-                        {
-                            await context.Response.WriteJsonAsync(_serviceEntries);
-                        }
-                    });
-                })
-                .Build();
-
-            _fakeConsulBuilder.Start();
+                    await context.Response.WriteJsonAsync(_serviceEntries);
+                }
+            });
         }
 
         private async Task WhenIStartTheClients()
@@ -333,94 +315,48 @@ namespace Ocelot.AcceptanceTests
 
         private async Task StartFakeDownstreamService(string url, string path)
         {
-            _firstDownstreamHost = new WebHostBuilder()
-                .ConfigureServices(s => { }).UseKestrel()
-                .UseUrls(url)
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .ConfigureAppConfiguration((hostingContext, config) =>
+            await _serviceHandler.StartFakeDownstreamService(url, path, async(context, next) =>
+            {
+                if (context.Request.Path == path)
                 {
-                    config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
-                    var env = hostingContext.HostingEnvironment;
-                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
-                    config.AddEnvironmentVariables();
-                })
-                .ConfigureLogging((hostingContext, logging) =>
-                {
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                    logging.AddConsole();
-                })
-                .Configure(app =>
-                {
-                    app.UseWebSockets();
-                    app.Use(async (context, next) =>
+                    if (context.WebSockets.IsWebSocketRequest)
                     {
-                        if (context.Request.Path == path)
-                        {
-                            if (context.WebSockets.IsWebSocketRequest)
-                            {
-                                WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
-                                await Echo(webSocket);
-                            }
-                            else
-                            {
-                                context.Response.StatusCode = 400;
-                            }
-                        }
-                        else
-                        {
-                            await next();
-                        }
-                    });
-                })
-                .UseIISIntegration().Build();
-            await _firstDownstreamHost.StartAsync();
+                        var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                        await Echo(webSocket);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                    }
+                }
+                else
+                {
+                    await next();
+                }
+            });
         }
 
         private async Task StartSecondFakeDownstreamService(string url, string path)
         {
-            _secondDownstreamHost = new WebHostBuilder()
-                .ConfigureServices(s => { }).UseKestrel()
-                .UseUrls(url)
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .ConfigureAppConfiguration((hostingContext, config) =>
+            await _serviceHandler.StartFakeDownstreamService(url, path, async (context, next) =>
+            {
+                if (context.Request.Path == path)
                 {
-                    config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
-                    var env = hostingContext.HostingEnvironment;
-                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: false);
-                    config.AddEnvironmentVariables();
-                })
-                .ConfigureLogging((hostingContext, logging) =>
-                {
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                    logging.AddConsole();
-                })
-                .Configure(app =>
-                {
-                    app.UseWebSockets();
-                    app.Use(async (context, next) =>
+                    if (context.WebSockets.IsWebSocketRequest)
                     {
-                        if (context.Request.Path == path)
-                        {
-                            if (context.WebSockets.IsWebSocketRequest)
-                            {
-                                WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
-                                await Message(webSocket);
-                            }
-                            else
-                            {
-                                context.Response.StatusCode = 400;
-                            }
-                        }
-                        else
-                        {
-                            await next();
-                        }
-                    });
-                })
-                .UseIISIntegration().Build();
-            await _secondDownstreamHost.StartAsync();
+                        WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
+                        await Message(webSocket);
+                    }
+                    else
+                    {
+                        context.Response.StatusCode = 400;
+                    }
+                }
+                else
+                {
+                    await next();
+                }
+            });
         }
 
         private async Task Echo(WebSocket webSocket)
@@ -473,10 +409,8 @@ namespace Ocelot.AcceptanceTests
 
         public void Dispose()
         {
+            _serviceHandler?.Dispose();
             _steps.Dispose();
-            _firstDownstreamHost?.Dispose();
-            _secondDownstreamHost?.Dispose();
-            _fakeConsulBuilder?.Dispose();
         }
     }
 }


### PR DESCRIPTION
Ive made the acceptance tests share the same builder in an effort to duplicate the linux port in use issue I have when running acceptance tests...seems to have been some use...now to test in CI

