### PR TITLE
Feature/#458

### DIFF
--- a/src/Ocelot/Configuration/Builder/DynamicConfigurationBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/DynamicConfigurationBuilder.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.Builder
+{
+    public class DynamicConfigurationBuilder
+    {
+        private string _store;
+
+        private string _host;
+
+        private string _port;
+
+        public DynamicConfigurationBuilder WithStore(string store)
+        {
+            _store = store;
+            return this;
+        }
+
+        public DynamicConfigurationBuilder WithServer(string host, int port)
+        {
+            _host = host;
+            _port = port.ToString();
+            return this;
+        }
+
+        public DynamicReRouteConfiguration Build()
+        {
+            return new DynamicReRouteConfiguration(_store, _host, _port);
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Builder/RateLimitGlobalOptionsBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/RateLimitGlobalOptionsBuilder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.Builder
+{
+    public class RateLimitGlobalOptionsBuilder
+    {
+        private string _clientIdHeader;
+        private bool _disableRateLimitHeaders;
+        private string _quotaExceededMessage;
+        private string _rateLimitCounterPrefix;
+        private int _httpStatusCode;
+        
+        public RateLimitGlobalOptionsBuilder WithClientIdHeader(string clientIdheader)
+        {
+            _clientIdHeader = clientIdheader;
+            return this;
+        }
+
+        public RateLimitGlobalOptionsBuilder WithDisableRateLimitHeaders(bool disableRateLimitHeaders)
+        {
+            _disableRateLimitHeaders = disableRateLimitHeaders;
+            return this;
+        }
+
+        public RateLimitGlobalOptionsBuilder WithQuotaExceededMessage(string quotaExceededMessage)
+        {
+            _quotaExceededMessage = quotaExceededMessage;
+            return this;
+        }
+
+        public RateLimitGlobalOptionsBuilder WithRateLimitCounterPrefix(string rateLimitCounterPrefix)
+        {
+            _rateLimitCounterPrefix = rateLimitCounterPrefix;
+            return this;
+        }
+        
+        public RateLimitGlobalOptionsBuilder WithHttpStatusCode(int httpStatusCode)
+        {
+            _httpStatusCode = httpStatusCode;
+            return this;
+        }
+
+        public RateLimitGlobalOptions Build()
+        {
+            return new RateLimitGlobalOptions(_clientIdHeader,
+                _disableRateLimitHeaders, _quotaExceededMessage, _rateLimitCounterPrefix,
+                _httpStatusCode);
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Creator/DynamicConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/DynamicConfigurationCreator.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Ocelot.Configuration.Builder;
+using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration.Creator
+{
+    public class DynamicConfigurationCreator : IDynamicConfigurationCreator
+    {
+        public DynamicReRouteConfiguration Create(FileDynamicReRouteConfiguration dynamicReRouteConfiguration)
+        {
+            return new DynamicConfigurationBuilder()
+                .WithStore(dynamicReRouteConfiguration.Store)
+                .WithServer(dynamicReRouteConfiguration.Host, dynamicReRouteConfiguration.Port)
+                .Build();
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Creator/FileInternalConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/FileInternalConfigurationCreator.cs
@@ -35,6 +35,7 @@ namespace Ocelot.Configuration.Creator
         private readonly IAdministrationPath _adminPath;
         private readonly IHeaderFindAndReplaceCreator _headerFAndRCreator;
         private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
+        private readonly IDynamicConfigurationCreator _dynamicConfigurationCreator;
 
         public FileInternalConfigurationCreator(
             IConfigurationValidator configurationValidator,
@@ -51,7 +52,8 @@ namespace Ocelot.Configuration.Creator
             IHttpHandlerOptionsCreator httpHandlerOptionsCreator,
             IAdministrationPath adminPath,
             IHeaderFindAndReplaceCreator headerFAndRCreator,
-            IDownstreamAddressesCreator downstreamAddressesCreator
+            IDownstreamAddressesCreator downstreamAddressesCreator,
+            IDynamicConfigurationCreator dynamicConfigurationCreator
             )
         {
             _downstreamAddressesCreator = downstreamAddressesCreator;
@@ -69,6 +71,7 @@ namespace Ocelot.Configuration.Creator
             _qosOptionsCreator = qosOptionsCreator;
             _fileReRouteOptionsCreator = fileReRouteOptionsCreator;
             _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
+            _dynamicConfigurationCreator = dynamicConfigurationCreator;
         }
         
         public async Task<Response<IInternalConfiguration>> Create(FileConfiguration fileConfiguration)
@@ -109,15 +112,21 @@ namespace Ocelot.Configuration.Creator
 
             var qosOptions = _qosOptionsCreator.Create(fileConfiguration.GlobalConfiguration.QoSOptions);
 
+            var rateLimitOptions = _rateLimitOptionsCreator.Create(fileConfiguration.GlobalConfiguration.RateLimitOptions);
+
             var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileConfiguration.GlobalConfiguration.HttpHandlerOptions);
+
+            var dynamicReRouteConfiguration = _dynamicConfigurationCreator.Create(fileConfiguration.GlobalConfiguration.DynamicReRouteConfiguration);
 
             var config = new InternalConfiguration(reRoutes, 
                 _adminPath.Path, 
                 serviceProviderConfiguration, 
                 fileConfiguration.GlobalConfiguration.RequestIdKey, 
+                dynamicReRouteConfiguration,
                 lbOptions, 
                 fileConfiguration.GlobalConfiguration.DownstreamScheme,
                 qosOptions,
+                rateLimitOptions,
                 httpHandlerOptions
                 );
 

--- a/src/Ocelot/Configuration/Creator/IDynamicConfigurationCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IDynamicConfigurationCreator.cs
@@ -1,0 +1,12 @@
+﻿using Ocelot.Configuration.File;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.Creator
+{
+    public interface IDynamicConfigurationCreator
+    {
+        DynamicReRouteConfiguration Create(FileDynamicReRouteConfiguration dynamicReRouteConfiguration);
+    }
+}

--- a/src/Ocelot/Configuration/Creator/IRateLimitOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IRateLimitOptionsCreator.cs
@@ -5,5 +5,10 @@ namespace Ocelot.Configuration.Creator
     public interface IRateLimitOptionsCreator
     {
         RateLimitOptions Create(FileReRoute fileReRoute, FileGlobalConfiguration globalConfiguration, bool enableRateLimiting);
+
+        RateLimitOptions Create(FileReRoute fileReRoute, IInternalConfiguration configuration, bool enableRateLimiting);
+
+        RateLimitGlobalOptions Create(FileRateLimitOptions rateLimitOptions);
     }
+
 }

--- a/src/Ocelot/Configuration/Creator/RateLimitOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RateLimitOptionsCreator.cs
@@ -28,5 +28,39 @@ namespace Ocelot.Configuration.Creator
 
             return rateLimitOption;
         }
+
+        public RateLimitOptions Create(FileReRoute fileReRoute, IInternalConfiguration configuration, bool enableRateLimiting)
+        {
+            RateLimitOptions rateLimitOption = null;
+
+            if (enableRateLimiting)
+            {
+                rateLimitOption = new RateLimitOptionsBuilder()
+                    .WithClientIdHeader(configuration.RateLimitOptions.ClientIdHeader)
+                    .WithClientWhiteList(fileReRoute.RateLimitOptions.ClientWhitelist)
+                    .WithDisableRateLimitHeaders(configuration.RateLimitOptions.DisableRateLimitHeaders)
+                    .WithEnableRateLimiting(fileReRoute.RateLimitOptions.EnableRateLimiting)
+                    .WithHttpStatusCode(configuration.RateLimitOptions.HttpStatusCode)
+                    .WithQuotaExceededMessage(configuration.RateLimitOptions.QuotaExceededMessage)
+                    .WithRateLimitCounterPrefix(configuration.RateLimitOptions.RateLimitCounterPrefix)
+                    .WithRateLimitRule(new RateLimitRule(fileReRoute.RateLimitOptions.Period,
+                        fileReRoute.RateLimitOptions.PeriodTimespan,
+                        fileReRoute.RateLimitOptions.Limit))
+                    .Build();
+            }
+
+            return rateLimitOption;
+        }
+
+        public RateLimitGlobalOptions Create(FileRateLimitOptions rateLimitOptions)
+        {
+            return new RateLimitGlobalOptionsBuilder()
+                    .WithClientIdHeader(rateLimitOptions.ClientIdHeader)
+                    .WithDisableRateLimitHeaders(rateLimitOptions.DisableRateLimitHeaders)
+                    .WithHttpStatusCode(rateLimitOptions.HttpStatusCode)
+                    .WithQuotaExceededMessage(rateLimitOptions.QuotaExceededMessage)
+                    .WithRateLimitCounterPrefix(rateLimitOptions.RateLimitCounterPrefix)
+                    .Build();
+        }
     }
 }

--- a/src/Ocelot/Configuration/DynamicReRouteConfiguration.cs
+++ b/src/Ocelot/Configuration/DynamicReRouteConfiguration.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration
+{
+    /// <summary>
+    /// Describes options for retrieving reroute configuration 
+    /// when using service discovery for dynamic routing
+    /// </summary>
+    public class DynamicReRouteConfiguration
+    {
+        public DynamicReRouteConfiguration(string store, string host, string port)
+        {
+            Store = store;
+            Host = host;
+            Port = port;
+        }
+
+        /// <summary>
+        /// This property defines the provider to use to get the dynamic configuration.
+        /// This, in turn, means the store (persistance) to use.
+        /// </summary>
+        public string Store { get; }
+
+        /// <summary>
+        /// The host of the store.
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// The port on <see cref="Host"/> where the store is.
+        /// </summary>
+        public string Port { get; }
+    }
+}

--- a/src/Ocelot/Configuration/File/FileDynamicReRouteConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileDynamicReRouteConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.File
+{
+    public class FileDynamicReRouteConfiguration
+    {
+        public string Store { get; set; }
+
+        public string Host { get; set; }
+
+        public int Port { get; set; }
+    }
+}

--- a/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
@@ -9,6 +9,7 @@
             LoadBalancerOptions = new FileLoadBalancerOptions();
             QoSOptions = new FileQoSOptions();
             HttpHandlerOptions = new FileHttpHandlerOptions();
+            DynamicReRouteConfiguration = new FileDynamicReRouteConfiguration();
         }
 
         public string RequestIdKey { get; set; }
@@ -18,6 +19,8 @@
         public FileRateLimitOptions RateLimitOptions { get; set; }
 
         public FileQoSOptions QoSOptions { get; set; }
+
+        public FileDynamicReRouteConfiguration DynamicReRouteConfiguration { get; set; }
 
         public string BaseUrl { get ;set; }
 

--- a/src/Ocelot/Configuration/IInternalConfiguration.cs
+++ b/src/Ocelot/Configuration/IInternalConfiguration.cs
@@ -10,6 +10,8 @@ namespace Ocelot.Configuration
 
         ServiceProviderConfiguration ServiceProviderConfiguration {get;}
 
+        DynamicReRouteConfiguration DynamicReRouteConfiguration { get; }
+
         string RequestId {get;}
 
         LoadBalancerOptions LoadBalancerOptions { get; }
@@ -17,6 +19,8 @@ namespace Ocelot.Configuration
         string DownstreamScheme { get; }
 
         QoSOptions QoSOptions { get; }
+
+        RateLimitGlobalOptions RateLimitOptions { get; }
 
         HttpHandlerOptions HttpHandlerOptions { get; }
     }

--- a/src/Ocelot/Configuration/InternalConfiguration.cs
+++ b/src/Ocelot/Configuration/InternalConfiguration.cs
@@ -9,9 +9,11 @@ namespace Ocelot.Configuration
             string administrationPath, 
             ServiceProviderConfiguration serviceProviderConfiguration, 
             string requestId, 
+            DynamicReRouteConfiguration dynamicReRouteConfiguration,
             LoadBalancerOptions loadBalancerOptions, 
             string downstreamScheme, 
             QoSOptions qoSOptions, 
+            RateLimitGlobalOptions rateLimitOptions,
             HttpHandlerOptions httpHandlerOptions)
         {
             ReRoutes = reRoutes;
@@ -20,17 +22,23 @@ namespace Ocelot.Configuration
             RequestId = requestId;
             LoadBalancerOptions = loadBalancerOptions;
             DownstreamScheme = downstreamScheme;
+            DynamicReRouteConfiguration = dynamicReRouteConfiguration;
             QoSOptions = qoSOptions;
+            RateLimitOptions = rateLimitOptions;
             HttpHandlerOptions = httpHandlerOptions;
         }
 
         public List<ReRoute> ReRoutes { get; }
         public string AdministrationPath {get;}
         public ServiceProviderConfiguration ServiceProviderConfiguration {get;}
+
+        public DynamicReRouteConfiguration DynamicReRouteConfiguration { get; }
+
         public string RequestId {get;}
         public LoadBalancerOptions LoadBalancerOptions { get; }
         public string DownstreamScheme { get; }
         public QoSOptions QoSOptions { get; }
+        public RateLimitGlobalOptions RateLimitOptions { get; }
         public HttpHandlerOptions HttpHandlerOptions { get; }
     }
 }

--- a/src/Ocelot/Configuration/Parser/ConfigurationKeys.cs
+++ b/src/Ocelot/Configuration/Parser/ConfigurationKeys.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.Parser
+{
+    public static class ConfigurationKeys
+    {
+        public static class RateLimit
+        {
+            public const string CLIENT_WHITE_LIST = "rate_limit.client_white_list";
+            public const string ENABLE_RATE_LIMITING = "rate_limit.enable_rate_limiting";
+            public const string PERIOD = "rate_limit.period";
+            public const string PERIOD_TIME_SPAN = "rate_limit.period_time_span";
+            public const string LIMIT = "rate_limit.limit";
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Parser/IRedisDataConfigurationParser.cs
+++ b/src/Ocelot/Configuration/Parser/IRedisDataConfigurationParser.cs
@@ -1,0 +1,13 @@
+﻿using Ocelot.Configuration.File;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.Parser
+{
+    public interface IRedisDataConfigurationParser
+    {
+        FileReRoute Parse(List<HashEntry> hashEntries); 
+    }
+}

--- a/src/Ocelot/Configuration/Parser/RedisDataConfigurationParser.cs
+++ b/src/Ocelot/Configuration/Parser/RedisDataConfigurationParser.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ocelot.Configuration.File;
+using Ocelot.DynamicConfigurationProvider;
+using StackExchange.Redis;
+
+namespace Ocelot.Configuration.Parser
+{
+    public class RedisDataConfigurationParser : IRedisDataConfigurationParser
+    {
+        public FileReRoute Parse(List<HashEntry> hashEntries)
+        {
+            if (hashEntries == null || hashEntries.Count() == 0)
+            {
+                return new FileReRoute();
+            }
+
+            var hashesDict = hashEntries.ToDictionary(x => x.Name, x => x.Value);
+
+            var fileReRoute = new FileReRoute()
+            {
+                RateLimitOptions = new FileRateLimitRule
+                {
+                    ClientWhitelist = ParseString(GetRedisValue(hashesDict, ConfigurationKeys.RateLimit.CLIENT_WHITE_LIST))?.Split(',')?.Select(x => x.Trim())?.ToList(),
+                    EnableRateLimiting = ParseBoolean(GetRedisValue(hashesDict, ConfigurationKeys.RateLimit.ENABLE_RATE_LIMITING), false),
+                    Limit = ParseInt(GetRedisValue(hashesDict, ConfigurationKeys.RateLimit.LIMIT)),
+                    Period = ParseString(GetRedisValue(hashesDict, ConfigurationKeys.RateLimit.PERIOD)),
+                    PeriodTimespan = ParseDouble(GetRedisValue(hashesDict, ConfigurationKeys.RateLimit.PERIOD_TIME_SPAN))
+                }
+            };
+
+            return fileReRoute;
+        }
+
+        private string ParseString(RedisValue redisValue, string defaultValue = null)
+        {
+            if (!redisValue.IsNullOrEmpty)
+            {
+                return redisValue.ToString();
+            }
+
+            return defaultValue;
+        }
+
+        private int ParseInt(RedisValue redisValue, int defaultValue = 0)
+        {
+            int result = 0;
+            if (!redisValue.IsNullOrEmpty && int.TryParse(redisValue.ToString(), out result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        private double ParseDouble(RedisValue redisValue, double defaultValue = 0)
+        {
+            double result = 0;
+            if (!redisValue.IsNullOrEmpty && double.TryParse(redisValue.ToString(), out result))
+            {
+                return result;
+            }
+
+            return defaultValue;
+        }
+
+        private bool ParseBoolean(RedisValue redisValue, bool defaultValue = true)
+        {
+            var result = defaultValue;
+            if (!redisValue.IsNullOrEmpty)
+            {
+                if (redisValue.IsInteger)
+                {
+                    return redisValue.ToString().Equals("1");
+                }
+                else if(bool.TryParse(redisValue.ToString(), out result))
+                {
+                    return result;
+                }
+            }
+
+            return defaultValue;
+        }
+
+        private RedisValue GetRedisValue(Dictionary<RedisValue, RedisValue> hashDictonary, string key)
+        {
+            if (hashDictonary.ContainsKey(key))
+            {
+                return hashDictonary[key];
+            }
+
+            return RedisValue.Null;
+        }
+    }
+}

--- a/src/Ocelot/Configuration/RateLimitGlobalOptions.cs
+++ b/src/Ocelot/Configuration/RateLimitGlobalOptions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration
+{
+    public class RateLimitGlobalOptions
+    {
+        public RateLimitGlobalOptions(string clientIdHeader, bool disableRateLimitHeaders,
+            string quotaExceededMessage, string rateLimitCounterPrefix, int httpStatusCode)
+        {
+            ClientIdHeader = clientIdHeader;
+            DisableRateLimitHeaders = disableRateLimitHeaders;
+            QuotaExceededMessage = quotaExceededMessage;
+            RateLimitCounterPrefix = rateLimitCounterPrefix;
+            HttpStatusCode = httpStatusCode;
+        }
+
+        public string ClientIdHeader { get; private set; }
+        public string QuotaExceededMessage { get; private set; }
+        public string RateLimitCounterPrefix { get; private set; }
+        public bool DisableRateLimitHeaders { get; private set; }
+        public int HttpStatusCode { get; private set; }
+    }
+}

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -49,6 +49,8 @@ namespace Ocelot.DependencyInjection
     using Steeltoe.Common.Discovery;
     using Pivotal.Discovery.Client;
     using Ocelot.Request.Creator;
+    using Ocelot.DynamicConfigurationProvider;
+    using Ocelot.Infrastructure.Redis;
 
     public class OcelotBuilder : IOcelotBuilder
     {
@@ -86,6 +88,7 @@ namespace Ocelot.DependencyInjection
             _services.TryAddSingleton<IRequestIdKeyCreator, RequestIdKeyCreator>();
             _services.TryAddSingleton<IServiceProviderConfigurationCreator,ServiceProviderConfigurationCreator>();
             _services.TryAddSingleton<IQoSOptionsCreator, QoSOptionsCreator>();
+            _services.TryAddSingleton<IDynamicConfigurationCreator, DynamicConfigurationCreator>();
             _services.TryAddSingleton<IReRouteOptionsCreator, ReRouteOptionsCreator>();
             _services.TryAddSingleton<IRateLimitOptionsCreator, RateLimitOptionsCreator>();
             _services.TryAddSingleton<IBaseUrlFinder, BaseUrlFinder>();
@@ -95,6 +98,11 @@ namespace Ocelot.DependencyInjection
             _services.TryAddSingleton<IQosProviderHouse, QosProviderHouse>();
             _services.TryAddSingleton<IQoSProviderFactory, QoSProviderFactory>();
             _services.TryAddSingleton<IServiceDiscoveryProviderFactory, ServiceDiscoveryProviderFactory>();
+
+            _services.TryAddSingleton<IDynamicConfigurationProviderFactory, DynamicConfigurationProviderFactory>();
+            _services.TryAddSingleton<DynamicConfigurationProvider, RedisDynamicConfigurationProvider>();
+            _services.TryAddSingleton<IRedisClientFactory, RedisClientFactory>();
+
             _services.TryAddSingleton<ILoadBalancerFactory, LoadBalancerFactory>();
             _services.TryAddSingleton<ILoadBalancerHouse, LoadBalancerHouse>();
             _services.TryAddSingleton<IOcelotLoggerFactory, AspDotNetLoggerFactory>();
@@ -106,6 +114,7 @@ namespace Ocelot.DependencyInjection
             _services.TryAddSingleton<IAddHeadersToRequest, AddHeadersToRequest>();
             _services.TryAddSingleton<IAddQueriesToRequest, AddQueriesToRequest>();
             _services.TryAddSingleton<IClaimsParser, ClaimsParser>();
+            _services.TryAddSingleton<IRedisDataConfigurationParser, RedisDataConfigurationParser>();
             _services.TryAddSingleton<IUrlPathToUrlTemplateMatcher, RegExUrlMatcher>();
             _services.TryAddSingleton<IPlaceholderNameAndValueFinder, UrlPathPlaceholderNameAndValueFinder>();
             _services.TryAddSingleton<IDownstreamPathPlaceholderReplacer, DownstreamTemplatePathPlaceholderReplacer>();

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteCreator.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteCreator.cs
@@ -2,68 +2,124 @@
 {
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
     using Configuration;
     using Configuration.Builder;
     using Configuration.Creator;
     using Configuration.File;
     using LoadBalancer.LoadBalancers;
+    using Ocelot.Configuration.Repository;
+    using Ocelot.DynamicConfigurationProvider;
+    using Ocelot.Logging;
     using Responses;
     using UrlMatcher;
 
     public class DownstreamRouteCreator : IDownstreamRouteProvider
     {
         private readonly IQoSOptionsCreator _qoSOptionsCreator;
+        private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
+        private readonly IDynamicConfigurationProviderFactory _factory;
+        private readonly IOcelotLogger _logger;
         private readonly ConcurrentDictionary<string, OkResponse<DownstreamRoute>> _cache;
 
-        public DownstreamRouteCreator(IQoSOptionsCreator qoSOptionsCreator)
+        public DownstreamRouteCreator(IQoSOptionsCreator qoSOptionsCreator,
+            IRateLimitOptionsCreator rateLimitOptionsCreator,
+            IDynamicConfigurationProviderFactory factory,
+            IOcelotLoggerFactory loggerFactory)
         {
             _qoSOptionsCreator = qoSOptionsCreator;
+            _rateLimitOptionsCreator = rateLimitOptionsCreator;
+            _factory = factory;
+            _logger = loggerFactory.CreateLogger<DownstreamRouteCreator>();
             _cache = new ConcurrentDictionary<string, OkResponse<DownstreamRoute>>();
         }
 
-        public Response<DownstreamRoute> Get(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost)
+        public async Task<Response<DownstreamRoute>> GetAsync(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost)
         {            
             var serviceName = GetServiceName(upstreamUrlPath);
 
             var downstreamPath = GetDownstreamPath(upstreamUrlPath);
 
-            if(HasQueryString(downstreamPath))
+            if (HasQueryString(downstreamPath))
             {
                 downstreamPath = RemoveQueryString(downstreamPath);
             }
 
-            var downstreamPathForKeys = $"/{serviceName}{downstreamPath}";
+            var downstreamPathForKeys = CreateDownstreamPathForKeys(serviceName, downstreamPath);
 
             var loadBalancerKey = CreateLoadBalancerKey(downstreamPathForKeys, upstreamHttpMethod, configuration.LoadBalancerOptions);
 
-            if(_cache.TryGetValue(loadBalancerKey, out var downstreamRoute))
+            if (_cache.TryGetValue(loadBalancerKey + "", out var downstreamRoute))
             {
                 return downstreamRoute;
             }
-
-            var qosOptions = _qoSOptionsCreator.Create(configuration.QoSOptions, downstreamPathForKeys, new []{ upstreamHttpMethod });
-
-            var downstreamReRoute = new DownstreamReRouteBuilder()
-                .WithServiceName(serviceName)
-                .WithLoadBalancerKey(loadBalancerKey)
-                .WithDownstreamPathTemplate(downstreamPath)
-                .WithUseServiceDiscovery(true)
-                .WithHttpHandlerOptions(configuration.HttpHandlerOptions)
-                .WithQosOptions(qosOptions)
-                .WithDownstreamScheme(configuration.DownstreamScheme)
-                .WithLoadBalancerOptions(configuration.LoadBalancerOptions)
-                .Build();
+            
+            var downstreamReRoute = await SetUpDownstreamReRouteAsync(serviceName, loadBalancerKey, downstreamPath, upstreamHttpMethod, configuration);
 
             var reRoute = new ReRouteBuilder()
                 .WithDownstreamReRoute(downstreamReRoute)
-                .WithUpstreamHttpMethod(new List<string>(){ upstreamHttpMethod })
+                .WithUpstreamHttpMethod(new List<string>() { upstreamHttpMethod })
                 .Build();
 
             downstreamRoute = new OkResponse<DownstreamRoute>(new DownstreamRoute(new List<PlaceholderNameAndValue>(), reRoute));
 
             _cache.AddOrUpdate(loadBalancerKey, downstreamRoute, (x, y) => downstreamRoute);
-        
+
             return downstreamRoute;
+        }
+
+        private async Task<DownstreamReRoute> SetUpDownstreamReRouteAsync(string serviceName, string loadBalancerKey, 
+                                                            string downstreamPath, string upstreamHttpMethod,
+                                                            IInternalConfiguration configuration)
+        {
+            var downstreamPathForKeys = CreateDownstreamPathForKeys(serviceName, downstreamPath);
+
+            var qosOptions = _qoSOptionsCreator.Create(configuration.QoSOptions, downstreamPathForKeys, new[] { upstreamHttpMethod });
+
+            var reRoute = await GetDynamicRouteConfigurationAsync(serviceName, configuration);
+            
+            var enableRateLimiting = reRoute?.RateLimitOptions?.EnableRateLimiting == true;
+
+            var rateLimitOptions = _rateLimitOptionsCreator.Create(reRoute, configuration, enableRateLimiting);
+
+            //TODO: add other options as well
+
+            return new DownstreamReRouteBuilder()
+                .WithServiceName(serviceName)
+                .WithLoadBalancerKey(loadBalancerKey)
+                .WithDownstreamPathTemplate(downstreamPath)
+                .WithUseServiceDiscovery(true)
+                .WithEnableRateLimiting(enableRateLimiting)
+                .WithRateLimitOptions(rateLimitOptions)
+                .WithHttpHandlerOptions(configuration.HttpHandlerOptions)
+                .WithQosOptions(qosOptions)
+                .WithDownstreamScheme(configuration.DownstreamScheme)
+                .WithLoadBalancerOptions(configuration.LoadBalancerOptions)
+                .Build();
+        }
+
+        private async Task<FileReRoute> GetDynamicRouteConfigurationAsync(string serviceName, IInternalConfiguration configuration)
+        {
+            var configurationProvider = _factory.Get(configuration);
+            if (string.IsNullOrWhiteSpace(configuration?.DynamicReRouteConfiguration?.Host) ||
+                string.IsNullOrWhiteSpace(configuration?.DynamicReRouteConfiguration?.Port))
+            {
+                _logger.LogWarning($"Host/port defined for dynamic configuration store is empty. Cannot reach the store.");
+                return await Task.FromResult(new FileReRoute());
+            }
+
+            if (configurationProvider != null)
+            {
+                return await configurationProvider.BuildRouteConfigurationAsync(configuration.DynamicReRouteConfiguration.Host, configuration.DynamicReRouteConfiguration.Port, serviceName);
+            }
+
+            return await Task.FromResult(new FileReRoute());
+        }
+
+        private string CreateDownstreamPathForKeys(string serviceName, string downstreamPath)
+        {
+            return $"/{serviceName}{downstreamPath}";
         }
 
         private static string RemoveQueryString(string downstreamPath)

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Errors;
@@ -18,7 +19,7 @@ namespace Ocelot.DownstreamRouteFinder.Finder
             _placeholderNameAndValueFinder = urlPathPlaceholderNameAndValueFinder;
         }
 
-        public Response<DownstreamRoute> Get(string upstreamUrlPath, string upstreamQueryString, string httpMethod, IInternalConfiguration configuration, string upstreamHost)
+        public async Task<Response<DownstreamRoute>> GetAsync(string upstreamUrlPath, string upstreamQueryString, string httpMethod, IInternalConfiguration configuration, string upstreamHost)
         {
             var downstreamRoutes = new List<DownstreamRoute>();
 
@@ -41,10 +42,11 @@ namespace Ocelot.DownstreamRouteFinder.Finder
                 var notNullOption = downstreamRoutes.FirstOrDefault(x => !string.IsNullOrEmpty(x.ReRoute.UpstreamHost));
                 var nullOption = downstreamRoutes.FirstOrDefault(x => string.IsNullOrEmpty(x.ReRoute.UpstreamHost));
 
-                return notNullOption != null ? new OkResponse<DownstreamRoute>(notNullOption) : new OkResponse<DownstreamRoute>(nullOption);
+                var result = notNullOption != null ? new OkResponse<DownstreamRoute>(notNullOption) : new OkResponse<DownstreamRoute>(nullOption);
+                return await Task.FromResult(result);
             }
 
-            return new ErrorResponse<DownstreamRoute>(new UnableToFindDownstreamRouteError(upstreamUrlPath, httpMethod));
+            return await Task.FromResult(new ErrorResponse<DownstreamRoute>(new UnableToFindDownstreamRouteError(upstreamUrlPath, httpMethod)));
         }
 
         private bool RouteIsApplicableToThisRequest(ReRoute reRoute, string httpMethod, string upstreamHost)

--- a/src/Ocelot/DownstreamRouteFinder/Finder/IDownstreamRouteProvider.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/IDownstreamRouteProvider.cs
@@ -6,6 +6,6 @@ namespace Ocelot.DownstreamRouteFinder.Finder
 {
     public interface IDownstreamRouteProvider
     {
-        Response<DownstreamRoute> Get(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost);
+        Task<Response<DownstreamRoute>> GetAsync(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost);
     }
 }

--- a/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
@@ -41,7 +41,7 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
             var provider = _factory.Get(context.Configuration);
 
-            var downstreamRoute = provider.Get(upstreamUrlPath, upstreamQueryString, context.HttpContext.Request.Method, context.Configuration, upstreamHost);
+            var downstreamRoute = await provider.GetAsync(upstreamUrlPath, upstreamQueryString, context.HttpContext.Request.Method, context.Configuration, upstreamHost);
 
             if (downstreamRoute.IsError)
             {

--- a/src/Ocelot/DynamicConfigurationProvider/ConfigurationStoreAttribute.cs
+++ b/src/Ocelot/DynamicConfigurationProvider/ConfigurationStoreAttribute.cs
@@ -1,0 +1,23 @@
+﻿using Ocelot.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.DynamicConfigurationProvider
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class ConfigurationStoreAttribute : Attribute
+    {
+        public string Store { get; private set; }
+
+        public ConfigurationStoreAttribute(string store)
+        {
+            if (string.IsNullOrWhiteSpace(store))
+            {
+                throw new ArgumentNullException("invalid value for 'store'. It cannot be null, empty or whitespace.");
+            }
+
+            this.Store = store;
+        }
+    }
+}

--- a/src/Ocelot/DynamicConfigurationProvider/DynamicConfigurationProvider.cs
+++ b/src/Ocelot/DynamicConfigurationProvider/DynamicConfigurationProvider.cs
@@ -1,0 +1,40 @@
+﻿using Ocelot.Configuration;
+using Ocelot.Configuration.File;
+using Ocelot.Logging;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ocelot.DynamicConfigurationProvider
+{
+    public abstract class DynamicConfigurationProvider
+    {
+        protected readonly IOcelotLogger _logger;
+
+        public DynamicConfigurationProvider(IOcelotLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task<FileReRoute> BuildRouteConfigurationAsync(string host, string port, string key)
+        {
+            //using stopwatch to log time taken by implementation of GetRouteConfigurationAsync
+            //and this gives idea about the latency while fetching dynamic configuration
+            Stopwatch stopwatch = new Stopwatch();
+
+            _logger.LogDebug($"Getting route configuration from {host}:{port} for key:{key} using {this.GetType().Name}");
+
+            stopwatch.Start();
+            var reRoute = await GetRouteConfigurationAsync(host, port, key);
+            stopwatch.Stop();
+
+            _logger.LogDebug($"Completed route configuration fetch in {stopwatch.ElapsedMilliseconds}ms");
+
+            return reRoute;
+        }
+
+        protected abstract Task<FileReRoute> GetRouteConfigurationAsync(string host, string port, string key);
+    }
+}

--- a/src/Ocelot/DynamicConfigurationProvider/DynamicConfigurationProviderFactory.cs
+++ b/src/Ocelot/DynamicConfigurationProvider/DynamicConfigurationProviderFactory.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using Ocelot.Configuration;
+using Ocelot.Logging;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Ocelot.DynamicConfigurationProvider
+{
+    public class DynamicConfigurationProviderFactory : IDynamicConfigurationProviderFactory
+    {
+        private readonly Dictionary<string, DynamicConfigurationProvider> _providers;
+        private IOcelotLogger _logger;
+
+        public DynamicConfigurationProviderFactory(IServiceProvider provider, IOcelotLoggerFactory factory)
+        {
+            _logger = factory.CreateLogger<DynamicConfigurationProviderFactory>();
+
+            var providers = provider.GetServices<DynamicConfigurationProvider>();
+            try
+            {
+                _providers = providers.ToDictionary(x =>
+                {
+                    var storeAttribute = x.GetType().GetCustomAttribute<ConfigurationStoreAttribute>();
+
+                    if (storeAttribute == null)
+                    {
+                        throw new InvalidOperationException($"{x.GetType().FullName} is missing {nameof(ConfigurationStoreAttribute)} attribute. For a class to be dynamic configuration provider, it must be decorated with {nameof(ConfigurationStoreAttribute)} attribute");
+                    }
+
+                    return storeAttribute.Store.ToString();
+                });
+            }
+            catch (ArgumentException)
+            {
+                var duplicateStore = providers.GroupBy(x => x.GetType().GetCustomAttribute<ConfigurationStoreAttribute>().ToString()).FirstOrDefault(x => x.Count() > 1);
+                throw new InvalidOperationException($"error while trying to add store {duplicateStore}. reason: duplicate store, same store already exists");
+            }
+        }
+
+        public DynamicConfigurationProvider Get(IInternalConfiguration config)
+        {
+            if (config.DynamicReRouteConfiguration == null)
+            {
+                _logger.LogInformation($"Configuration section 'DynamicReRouteConfiguration' is not defined to ocelot");
+            }
+            else if (!_providers.ContainsKey(config.DynamicReRouteConfiguration.Store?.ToString()))
+            {
+                _logger.LogWarning($"Provider for store '{config.DynamicReRouteConfiguration.Store?.ToString()}' could not found or is not registered.");
+            }
+            else
+            {
+                _logger.LogInformation($"Using store '{config.DynamicReRouteConfiguration.Store.ToString()}' to get Dynamic configuration.");
+                return _providers[config.DynamicReRouteConfiguration.Store.ToString()];
+            }
+            
+            return null;
+        }
+    }
+}

--- a/src/Ocelot/DynamicConfigurationProvider/IDynamicConfigurationProviderFactory.cs
+++ b/src/Ocelot/DynamicConfigurationProvider/IDynamicConfigurationProviderFactory.cs
@@ -1,0 +1,12 @@
+﻿using Ocelot.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.DynamicConfigurationProvider
+{
+    public interface IDynamicConfigurationProviderFactory
+    {
+        DynamicConfigurationProvider Get(IInternalConfiguration config);
+    }
+}

--- a/src/Ocelot/DynamicConfigurationProvider/RedisDynamicConfigurationProvider.cs
+++ b/src/Ocelot/DynamicConfigurationProvider/RedisDynamicConfigurationProvider.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using Ocelot.Configuration;
+using Ocelot.Configuration.File;
+using Ocelot.Infrastructure.Redis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+using System.Threading.Tasks;
+using StackExchange.Redis;
+using Ocelot.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using Ocelot.Configuration.Parser;
+
+namespace Ocelot.DynamicConfigurationProvider
+{
+    [ConfigurationStore("Redis")]
+    public class RedisDynamicConfigurationProvider : DynamicConfigurationProvider
+    {
+        private readonly IRedisClientFactory _factory;
+        private readonly IRedisDataConfigurationParser _configurationParser;
+
+        public RedisDynamicConfigurationProvider(IServiceProvider provider,
+            IRedisDataConfigurationParser configurationParser, IOcelotLoggerFactory loggerFactory)
+            :base(loggerFactory.CreateLogger<RedisDynamicConfigurationProvider>())
+        {
+            _factory = provider.GetService(typeof(IRedisClientFactory)) as IRedisClientFactory;
+            _configurationParser = configurationParser;
+        }
+
+        protected override async Task<FileReRoute> GetRouteConfigurationAsync(string host, string port, string key)
+        {
+            _logger.LogInformation($"Getting route configuration from Redis store at {host}:{port} for {key}");
+
+            try
+            {
+                //TODO: there should be way to pass constructr parameters while resolving types using IServiceProvider, then host/port can be passed as constuctor paramter
+                var db = _factory.Get(host, port);
+                var hashEntries = await db.HashGetAllAsync(key);
+
+                _logger.LogInformation($"Found {hashEntries.Length} hash entries from Redis store, including keys.");
+                return _configurationParser.Parse(hashEntries.ToList());
+            }
+            catch (RedisConnectionException exception)
+            {
+                _logger.LogError($"Unable to connect to Redis server {host}:{port}.", exception);
+                throw exception;
+            }
+        }
+    }
+}

--- a/src/Ocelot/Infrastructure/Redis/IRedisClientFactory.cs
+++ b/src/Ocelot/Infrastructure/Redis/IRedisClientFactory.cs
@@ -1,0 +1,12 @@
+﻿using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Infrastructure.Redis
+{
+    internal interface IRedisClientFactory
+    {
+        IDatabase Get(string host, string port);
+    }
+}

--- a/src/Ocelot/Infrastructure/Redis/RedisClientFactory.cs
+++ b/src/Ocelot/Infrastructure/Redis/RedisClientFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Ocelot.Logging;
+using Ocelot.Responses;
+using StackExchange.Redis;
+
+namespace Ocelot.Infrastructure.Redis
+{
+    internal class RedisClientFactory : IRedisClientFactory
+    {
+        private ConnectionMultiplexer _redis = null;
+        private object _lockObject = new object();
+        
+        public IDatabase Get(string host, string port)
+        {
+            var multiplexerKey = $"{host}_{port}";
+
+            //check for first and subsequent calls
+            if (_redis == null)
+            {
+                lock (_lockObject)
+                {
+                    //When first call is initializing _redis and second once is waiting for lock release
+                    //and once first call completes initialization then releases lock,
+                    //this check will prevent second call from re-initilaizing _redis
+                    if (_redis == null)
+                    {
+                        _redis = ConnectionMultiplexer.Connect($"{host}:{port}");
+                    }
+                }
+            }
+
+            return _redis.GetDatabase();
+        }
+    }
+}

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
@@ -45,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Ocelot.UnitTests/Configuration/ConsulFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/ConsulFileConfigurationRepositoryTests.cs
@@ -55,7 +55,7 @@ namespace Ocelot.UnitTests.Configuration
 
             _internalRepo
                 .Setup(x => x.Get())
-                .Returns(new OkResponse<IInternalConfiguration>(new InternalConfiguration(new List<ReRoute>(), "", new ServiceProviderConfigurationBuilder().Build(), "", It.IsAny<LoadBalancerOptions>(), It.IsAny<string>(), It.IsAny<QoSOptions>(), It.IsAny<HttpHandlerOptions>())));
+                .Returns(new OkResponse<IInternalConfiguration>(new InternalConfiguration(new List<ReRoute>(), "", new ServiceProviderConfigurationBuilder().Build(), "", new DynamicConfigurationBuilder().Build(), It.IsAny<LoadBalancerOptions>(), It.IsAny<string>(), It.IsAny<QoSOptions>(), It.IsAny<RateLimitGlobalOptions>(), It.IsAny<HttpHandlerOptions>())));
             
             _repo = new ConsulFileConfigurationRepository(_cache.Object, _internalRepo.Object, _factory.Object, _loggerFactory.Object);
         }
@@ -142,7 +142,9 @@ namespace Ocelot.UnitTests.Configuration
                 .Setup(x => x.Get())
                 .Returns(new OkResponse<IInternalConfiguration>(new InternalConfiguration(new List<ReRoute>(), "",
                     new ServiceProviderConfigurationBuilder().WithConfigurationKey(key).Build(), "",
+                    new DynamicConfigurationBuilder().Build(),
                     new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(),
+                    new RateLimitGlobalOptionsBuilder().Build(),
                     new HttpHandlerOptionsBuilder().Build())));
             
             _repo = new ConsulFileConfigurationRepository(_cache.Object, _internalRepo.Object, _factory.Object, _loggerFactory.Object);

--- a/test/Ocelot.UnitTests/Configuration/FileConfigurationSetterTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/FileConfigurationSetterTests.cs
@@ -38,7 +38,7 @@ namespace Ocelot.UnitTests.Configuration
         {
             var fileConfig = new FileConfiguration();
             var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
-            var config = new InternalConfiguration(new List<ReRoute>(), string.Empty, serviceProviderConfig, "asdf", new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
+            var config = new InternalConfiguration(new List<ReRoute>(), string.Empty, serviceProviderConfig, "asdf", new DynamicConfigurationBuilder().Build(), new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new RateLimitGlobalOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
 
             this.Given(x => GivenTheFollowingConfiguration(fileConfig))
                 .And(x => GivenTheRepoReturns(new OkResponse()))

--- a/test/Ocelot.UnitTests/Configuration/InMemoryConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/InMemoryConfigurationRepositoryTests.cs
@@ -103,11 +103,12 @@ namespace Ocelot.UnitTests.Configuration
             public string AdministrationPath {get;}
 
             public ServiceProviderConfiguration ServiceProviderConfiguration => throw new NotImplementedException();
-
+            public DynamicReRouteConfiguration DynamicReRouteConfiguration => throw new NotImplementedException();
             public string RequestId {get;}
             public LoadBalancerOptions LoadBalancerOptions { get; }
             public string DownstreamScheme { get; }
             public QoSOptions QoSOptions { get; }
+            public RateLimitGlobalOptions RateLimitOptions { get; }
             public HttpHandlerOptions HttpHandlerOptions { get; }
         }
     }

--- a/test/Ocelot.UnitTests/Configuration/RateLimitOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RateLimitOptionsCreatorTests.cs
@@ -16,9 +16,12 @@ namespace Ocelot.UnitTests.Configuration
     {
         private FileReRoute _fileReRoute;
         private FileGlobalConfiguration _fileGlobalConfig;
+        private IInternalConfiguration _internalConfig;
+        private FileRateLimitOptions _fileRateLimitOptions;
         private bool _enabled;
         private RateLimitOptionsCreator _creator;
         private RateLimitOptions _result;
+        private RateLimitGlobalOptions _globalOptionsResult;
 
         public RateLimitOptionsCreatorTests()
         {
@@ -71,6 +74,76 @@ namespace Ocelot.UnitTests.Configuration
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_create_rate_limit_options_with_internal_config()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                RateLimitOptions = new FileRateLimitRule
+                {
+                    ClientWhitelist = new List<string>(),
+                    Period = "Period",
+                    Limit = 1,
+                    PeriodTimespan = 1,
+                    EnableRateLimiting = true
+                }
+            };
+
+            var rateLimitGlobalOptions = new RateLimitGlobalOptions("ClientIdHeader", true,
+                "QuotaExceededMessage", "RateLimitCounterPrefix", 200);
+
+            var internalConfiguration = new InternalConfiguration(null, null,
+                null, null, null, null, null, null, rateLimitGlobalOptions, null);
+
+            var expected = new RateLimitOptionsBuilder()
+                .WithClientIdHeader(rateLimitGlobalOptions.ClientIdHeader)
+                .WithClientWhiteList(fileReRoute.RateLimitOptions.ClientWhitelist)
+                .WithDisableRateLimitHeaders(rateLimitGlobalOptions.DisableRateLimitHeaders)
+                .WithEnableRateLimiting(true)
+                .WithHttpStatusCode(rateLimitGlobalOptions.HttpStatusCode)
+                .WithQuotaExceededMessage(rateLimitGlobalOptions.QuotaExceededMessage)
+                .WithRateLimitCounterPrefix(rateLimitGlobalOptions.RateLimitCounterPrefix)
+                .WithRateLimitRule(new RateLimitRule(fileReRoute.RateLimitOptions.Period,
+                       fileReRoute.RateLimitOptions.PeriodTimespan,
+                       fileReRoute.RateLimitOptions.Limit))
+                .Build();
+
+            this.Given(x => x.GivenTheFollowingFileReRoute(fileReRoute))
+                .And(x => x.GivenTheFollowingInternalConfig(internalConfiguration))
+                .And(x => x.GivenRateLimitingIsEnabled())
+                .When(x => x.WhenICreateWithInternalConfig())
+                .Then(x => x.ThenTheFollowingIsReturned(expected))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_rate_limit_options_with_only_global_options()
+        {
+            var fileReRoute = new FileReRoute();
+
+            var fileRateLimitOptions = new FileRateLimitOptions
+            {
+                ClientIdHeader = "ClientIdHeader",
+                DisableRateLimitHeaders = true,
+                HttpStatusCode = 200,
+                QuotaExceededMessage = "QuotaExceededMessage",
+                RateLimitCounterPrefix = "RateLimitCounterPrefix"
+            };
+
+            var expected = new RateLimitGlobalOptionsBuilder()
+                .WithClientIdHeader(fileRateLimitOptions.ClientIdHeader)
+                .WithDisableRateLimitHeaders(fileRateLimitOptions.DisableRateLimitHeaders)
+                .WithHttpStatusCode(fileRateLimitOptions.HttpStatusCode)
+                .WithQuotaExceededMessage(fileRateLimitOptions.QuotaExceededMessage)
+                .WithRateLimitCounterPrefix(fileRateLimitOptions.RateLimitCounterPrefix)
+                .Build();
+
+            this.Given(x => x.GivenTheFollowingGlobalOptions(fileRateLimitOptions))
+                .When(x => x.WhenICreateWithGlobalOptions())
+                .Then(x => x.ThenTheFollowingIsReturned(expected))
+                .BDDfy();
+        }
+
         private void GivenTheFollowingFileReRoute(FileReRoute fileReRoute)
         {
             _fileReRoute = fileReRoute;
@@ -81,6 +154,16 @@ namespace Ocelot.UnitTests.Configuration
             _fileGlobalConfig = fileGlobalConfig;
         }
 
+        private void GivenTheFollowingInternalConfig(IInternalConfiguration config)
+        {
+            _internalConfig = config;
+        }
+
+        private void GivenTheFollowingGlobalOptions(FileRateLimitOptions options)
+        {
+            _fileRateLimitOptions = options;
+        }
+
         private void GivenRateLimitingIsEnabled()
         {
             _enabled = true;
@@ -89,6 +172,16 @@ namespace Ocelot.UnitTests.Configuration
         private void WhenICreate()
         {
             _result = _creator.Create(_fileReRoute, _fileGlobalConfig, _enabled);
+        }
+
+        private void WhenICreateWithInternalConfig()
+        {
+            _result = _creator.Create(_fileReRoute, _internalConfig, _enabled);
+        }
+
+        private void WhenICreateWithGlobalOptions()
+        {
+            _globalOptionsResult = _creator.Create(_fileRateLimitOptions);
         }
 
         private void ThenTheFollowingIsReturned(RateLimitOptions expected)
@@ -103,6 +196,15 @@ namespace Ocelot.UnitTests.Configuration
             _result.RateLimitRule.Limit.ShouldBe(expected.RateLimitRule.Limit);
             _result.RateLimitRule.Period.ShouldBe(expected.RateLimitRule.Period);
             TimeSpan.FromSeconds(_result.RateLimitRule.PeriodTimespan).Ticks.ShouldBe(TimeSpan.FromSeconds(expected.RateLimitRule.PeriodTimespan).Ticks);
+        }
+
+        private void ThenTheFollowingIsReturned(RateLimitGlobalOptions expected)
+        {
+            _globalOptionsResult.ClientIdHeader.ShouldBe(expected.ClientIdHeader);
+            _globalOptionsResult.DisableRateLimitHeaders.ShouldBe(expected.DisableRateLimitHeaders);
+            _globalOptionsResult.HttpStatusCode.ShouldBe(expected.HttpStatusCode);
+            _globalOptionsResult.QuotaExceededMessage.ShouldBe(expected.QuotaExceededMessage);
+            _globalOptionsResult.RateLimitCounterPrefix.ShouldBe(expected.RateLimitCounterPrefix);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Configuration/RedisDataConfigurationParserTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RedisDataConfigurationParserTests.cs
@@ -1,0 +1,73 @@
+﻿using Ocelot.Configuration.File;
+using Ocelot.Configuration.Parser;
+using StackExchange.Redis;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace Ocelot.UnitTests.Configuration
+{
+    public class RedisDataConfigurationParserTests
+    {
+        private IRedisDataConfigurationParser _parser;
+        private List<HashEntry> _hashEntries;
+        private FileReRoute _result;
+
+        public RedisDataConfigurationParserTests()
+        {
+            _parser = new RedisDataConfigurationParser();
+        }
+        
+        [Fact]
+        public void should_parse_reroute_configuration()
+        {
+            var hashEntries = new List<HashEntry>()
+            {
+                new HashEntry(ConfigurationKeys.RateLimit.CLIENT_WHITE_LIST, "  client1, client2  "),
+                new HashEntry(ConfigurationKeys.RateLimit.ENABLE_RATE_LIMITING, true),
+                new HashEntry(ConfigurationKeys.RateLimit.LIMIT, "30"),
+                new HashEntry(ConfigurationKeys.RateLimit.PERIOD, "10s"),
+                new HashEntry(ConfigurationKeys.RateLimit.PERIOD_TIME_SPAN, "60.5")
+            };
+
+            var expected = new FileReRoute
+            {
+                RateLimitOptions = new FileRateLimitRule
+                {
+                    ClientWhitelist = new List<string>() { "client1", "client2" },
+                    EnableRateLimiting = true,
+                    Limit = 30,
+                    Period = "10s",
+                    PeriodTimespan = 60.5
+                }
+            };
+
+            this.Given(x => x.GivenHashEntries(hashEntries))
+                .When(x => x.WhenIParse())
+                .Then(x => x.ThenTheReRouteIs(expected))
+                .BDDfy();
+        }
+        
+        private void GivenHashEntries(List<HashEntry> entries)
+        {
+            _hashEntries = entries;
+        }
+
+        private void WhenIParse()
+        {
+            _result = _parser.Parse(_hashEntries);
+        }
+
+        private void ThenTheReRouteIs(FileReRoute expected)
+        {
+            _result.RateLimitOptions.ClientWhitelist.ShouldBe(expected.RateLimitOptions.ClientWhitelist);
+            _result.RateLimitOptions.EnableRateLimiting.ShouldBe(expected.RateLimitOptions.EnableRateLimiting);
+            _result.RateLimitOptions.Limit.ShouldBe(expected.RateLimitOptions.Limit);
+            _result.RateLimitOptions.Period.ShouldBe(expected.RateLimitOptions.Period);
+            _result.RateLimitOptions.PeriodTimespan.ShouldBe(expected.RateLimitOptions.PeriodTimespan);
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
@@ -51,7 +51,7 @@
         [Fact]
         public void should_call_scoped_data_repository_correctly()
         {
-            var config = new InternalConfiguration(null, null, new ServiceProviderConfigurationBuilder().Build(), "", new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
+            var config = new InternalConfiguration(null, null, new ServiceProviderConfigurationBuilder().Build(), "", new DynamicConfigurationBuilder().Build(), new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new RateLimitGlobalOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
 
             var downstreamReRoute = new DownstreamReRouteBuilder()
                 .WithDownstreamPathTemplate("any old string")
@@ -86,8 +86,8 @@
         {
             _downstreamRoute = new OkResponse<DownstreamRoute>(downstreamRoute);
             _finder
-                .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IInternalConfiguration>(), It.IsAny<string>()))
-                .Returns(_downstreamRoute);
+                .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IInternalConfiguration>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(_downstreamRoute));
         }
 
         private void ThenTheScopedDataRepositoryIsCalledCorrectly()

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -142,7 +142,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
             var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
 
             this.Given(x => x.GivenThereIsAnUpstreamUrlPath("matchInUrlMatcher/"))
-                .And(x =>x.GivenTheTemplateVariableAndNameFinderReturns(
+                .And(x => x.GivenTheTemplateVariableAndNameFinderReturns(
                         new OkResponse<List<PlaceholderNameAndValue>>(
                             new List<PlaceholderNameAndValue>())))
                 .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
@@ -186,7 +186,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
             var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
 
             this.Given(x => x.GivenThereIsAnUpstreamUrlPath("matchInUrlMatcher"))
-                .And(x =>x.GivenTheTemplateVariableAndNameFinderReturns(
+                .And(x => x.GivenTheTemplateVariableAndNameFinderReturns(
                         new OkResponse<List<PlaceholderNameAndValue>>(
                             new List<PlaceholderNameAndValue>())))
                 .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
@@ -323,7 +323,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
 
         [Fact]
         public void should_not_return_route()
-        {            
+        {
             var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
 
             this.Given(x => x.GivenThereIsAnUpstreamUrlPath("dontMatchPath/"))
@@ -339,7 +339,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                         .WithUpstreamPathTemplate("somePath")
                         .WithUpstreamHttpMethod(new List<string> { "Get" })
                         .WithUpstreamTemplatePattern(new UpstreamPathTemplate("somePath", 1, false))
-                        .Build(),   
+                        .Build(),
                      }, string.Empty, serviceProviderConfig
                  ))
                  .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(false))))
@@ -788,7 +788,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private void GivenTheConfigurationIs(List<ReRoute> reRoutesConfig, string adminPath, ServiceProviderConfiguration serviceProviderConfig)
         {
             _reRoutesConfig = reRoutesConfig;
-            _config = new InternalConfiguration(_reRoutesConfig, adminPath, serviceProviderConfig, "", new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
+            _config = new InternalConfiguration(_reRoutesConfig, adminPath, serviceProviderConfig, "", null, new LoadBalancerOptionsBuilder().Build(), "", new QoSOptionsBuilder().Build(), new RateLimitGlobalOptionsBuilder().Build(), new HttpHandlerOptionsBuilder().Build());
         }
 
         private void GivenThereIsAnUpstreamUrlPath(string upstreamUrlPath)
@@ -798,7 +798,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
 
         private void WhenICallTheFinder()
         {
-            _result = _downstreamRouteFinder.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _config, _upstreamHost);
+            _result = _downstreamRouteFinder.GetAsync(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _config, _upstreamHost).GetAwaiter().GetResult();
         }
 
         private void ThenTheFollowingIsReturned(DownstreamRoute expected)
@@ -811,7 +811,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 _result.Data.TemplatePlaceholderNameAndValues[i].Name.ShouldBe(expected.TemplatePlaceholderNameAndValues[i].Name);
                 _result.Data.TemplatePlaceholderNameAndValues[i].Value.ShouldBe(expected.TemplatePlaceholderNameAndValues[i].Value);
             }
-            
+
             _result.IsError.ShouldBeFalse();
         }
     }

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -324,7 +324,7 @@
 
         private void GivenTheServiceProviderConfigIs(ServiceProviderConfiguration config)
         {
-            var configuration = new InternalConfiguration(null, null, config, null, null, null, null, null);
+            var configuration = new InternalConfiguration(null, null, config, null, null, null, null, null, null, null);
             _downstreamContext.Configuration = configuration;
         }
 

--- a/test/Ocelot.UnitTests/DynamicConfigurationProvider/DynamicConfigurationProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/DynamicConfigurationProvider/DynamicConfigurationProviderFactoryTests.cs
@@ -1,0 +1,164 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Ocelot.Configuration;
+using Ocelot.Configuration.File;
+using Ocelot.DynamicConfigurationProvider;
+using Ocelot.Logging;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using TestStack.BDDfy;
+using Xunit;
+using Ocelot.Configuration.Builder;
+using Ocelot.Configuration.Parser;
+
+namespace Ocelot.UnitTests.DynamicConfigurationProvider
+{
+    public class DynamicConfigurationProviderFactoryTests
+    {
+        private readonly Mock<IOcelotLogger> _logger;
+        private readonly IDynamicConfigurationProviderFactory _factory;
+        private readonly Mock<IOcelotLoggerFactory> _loggerFactory;
+        private readonly Mock<IServiceProvider> _provider;
+        private readonly Mock<IRedisDataConfigurationParser> _redisDataConfigurationParser;
+        private IInternalConfiguration _config;
+        private Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider _result;
+
+        public DynamicConfigurationProviderFactoryTests()
+        {
+            _logger = new Mock<IOcelotLogger>();
+            _loggerFactory = new Mock<IOcelotLoggerFactory>();
+            _provider = new Mock<IServiceProvider>();
+            _redisDataConfigurationParser = new Mock<IRedisDataConfigurationParser>();
+            _loggerFactory.Setup(x => x.CreateLogger<RedisDynamicConfigurationProvider>()).Returns(_logger.Object);
+            _loggerFactory.Setup(x => x.CreateLogger<DynamicConfigurationProviderFactory>()).Returns(_logger.Object);
+
+            var services = new ServiceCollection();
+            services.AddSingleton(typeof(IServiceProvider), _provider.Object);
+            services.AddSingleton(typeof(IOcelotLogger), _logger.Object);
+            services.AddSingleton(typeof(IOcelotLoggerFactory), _loggerFactory.Object);
+            services.AddSingleton(typeof(IRedisDataConfigurationParser), _redisDataConfigurationParser.Object);
+            services.AddSingleton<Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider, FakeOneProvider>();
+            services.AddSingleton<Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider, FakeTwoProvider>();
+            services.AddSingleton<Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider, RedisDynamicConfigurationProvider>();
+            var provider = services.BuildServiceProvider();
+            
+            _factory = new DynamicConfigurationProviderFactory(provider, _loggerFactory.Object);
+        }
+
+        [Fact]
+        public void should_return_no_provider()
+        {
+            var internalConfiguration = new InternalConfiguration(null, null, null, null, null, null, null, null, null, null);
+
+            this.Given(_ => GivenTheConfiguration(internalConfiguration))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBeNull())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_no_provider_with_invalid_store()
+        {
+            var dynamicReRouteConfiguration = new DynamicConfigurationBuilder()
+                                                .WithStore("InvalidStore")
+                                                .Build();
+
+            var internalConfiguration = new InternalConfiguration(null, null, null, null, dynamicReRouteConfiguration, null, null, null, null, null);
+
+            this.Given(_ => GivenTheConfiguration(internalConfiguration))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBeNull())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_fake_one_provider()
+        {
+            var dynamicReRouteConfiguration = new DynamicConfigurationBuilder()
+                                                .WithStore("StoreOne")
+                                                .Build();
+
+            var internalConfiguration = new InternalConfiguration(null, null, null, null, dynamicReRouteConfiguration, null, null, null, null, null);
+
+            this.Given(_ => GivenTheConfiguration(internalConfiguration))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBe<FakeOneProvider>())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_fake_two_provider()
+        {
+            var dynamicReRouteConfiguration = new DynamicConfigurationBuilder()
+                                                .WithStore("StoreTwo")
+                                                .Build();
+
+            var internalConfiguration = new InternalConfiguration(null, null, null, null, dynamicReRouteConfiguration, null, null, null, null, null);
+
+            this.Given(_ => GivenTheConfiguration(internalConfiguration))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBe<FakeTwoProvider>())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_redis_provider()
+        {
+            var dynamicReRouteConfiguration = new DynamicConfigurationBuilder()
+                                                .WithStore("Redis")
+                                                .Build();
+
+            var internalConfiguration = new InternalConfiguration(null, null, null, null, dynamicReRouteConfiguration, null, null, null, null, null);
+
+            this.Given(_ => GivenTheConfiguration(internalConfiguration))
+                .When(_ => WhenIGet())
+                .Then(_ => ThenTheResultShouldBe<RedisDynamicConfigurationProvider>())
+                .BDDfy();
+        }
+
+        private void WhenIGet()
+        {
+            _result = _factory.Get(_config);
+        }
+
+        private void GivenTheConfiguration(IInternalConfiguration configuration)
+        {
+            _config = configuration;
+        }
+
+        private void ThenTheResultShouldBe<T>()
+        {
+            _result.ShouldBeOfType<T>();
+        }
+
+        private void ThenTheResultShouldBeNull()
+        {
+            _result.ShouldBeNull();
+        }
+
+        [ConfigurationStoreAttribute("StoreOne")]
+        class FakeOneProvider : Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider
+        {
+            public FakeOneProvider(IOcelotLogger logger) : base(logger) { }
+
+            protected override Task<FileReRoute> GetRouteConfigurationAsync(string host, string port, string key)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [ConfigurationStoreAttribute("StoreTwo")]
+        class FakeTwoProvider : Ocelot.DynamicConfigurationProvider.DynamicConfigurationProvider
+        {
+            public FakeTwoProvider(IOcelotLogger logger) : base(logger) { }
+
+            protected override Task<FileReRoute> GetRouteConfigurationAsync(string host, string port, string key)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/Errors/ExceptionHandlerMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Errors/ExceptionHandlerMiddlewareTests.cs
@@ -51,7 +51,7 @@ namespace Ocelot.UnitTests.Errors
         [Fact]
         public void NoDownstreamException()
         {
-            var config = new InternalConfiguration(null, null, null, null, null, null, null, null);
+            var config = new InternalConfiguration(null, null, null, null, null, null, null, null, null, null);
 
             this.Given(_ => GivenAnExceptionWillNotBeThrownDownstream())
                 .And(_ => GivenTheConfigurationIs(config))
@@ -64,7 +64,7 @@ namespace Ocelot.UnitTests.Errors
         [Fact]
         public void DownstreamException()
         {
-            var config = new InternalConfiguration(null, null, null, null, null, null, null, null);
+            var config = new InternalConfiguration(null, null, null, null, null, null, null, null, null, null);
 
             this.Given(_ => GivenAnExceptionWillBeThrownDownstream())
                 .And(_ => GivenTheConfigurationIs(config))
@@ -76,7 +76,7 @@ namespace Ocelot.UnitTests.Errors
         [Fact]
         public void ShouldSetRequestId()
         {
-            var config = new InternalConfiguration(null, null, null, "requestidkey", null, null, null, null);
+            var config = new InternalConfiguration(null, null, null, "requestidkey", null, null, null, null, null, null);
 
             this.Given(_ => GivenAnExceptionWillNotBeThrownDownstream())
                 .And(_ => GivenTheConfigurationIs(config))
@@ -89,7 +89,7 @@ namespace Ocelot.UnitTests.Errors
         [Fact]
         public void ShouldSetAspDotNetRequestId()
         {
-            var config = new InternalConfiguration(null, null, null, null, null, null, null, null);
+            var config = new InternalConfiguration(null, null, null, null, null, null, null, null, null, null);
 
             this.Given(_ => GivenAnExceptionWillNotBeThrownDownstream())
                 .And(_ => GivenTheConfigurationIs(config))

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
@@ -117,7 +117,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         private void GivenTheConfigurationIs(ServiceProviderConfiguration config)
         {
             _config = config;
-            var configuration = new InternalConfiguration(null, null, config, null, null, null, null, null);
+            var configuration = new InternalConfiguration(null, null, config, null, null, null, null, null, null, null);
             _downstreamContext.Configuration = configuration;
         }
 


### PR DESCRIPTION
New Feature: Support for rate limiting options when dynamic routing is enabled and using service discovery

Changes
- Add configuration for store of dynamic reroute configuration
- Provide Redis as the available store (with options to create custom store provider by inheriting provider base class)
- Read dynamic reroute configuration using set store while creating downstream reroute.
