### PR TITLE
Correct status code available for middleware

### DIFF
--- a/src/Ocelot/Responder/HttpContextResponder.cs
+++ b/src/Ocelot/Responder/HttpContextResponder.cs
@@ -43,14 +43,7 @@ namespace Ocelot.Responder
                 AddHeaderIfDoesntExist(context, new Header("Content-Length", new []{ response.Content.Headers.ContentLength.ToString() }) );
             }
 
-            context.Response.OnStarting(state =>
-            {
-                var httpContext = (HttpContext)state;
-
-                httpContext.Response.StatusCode = (int)response.StatusCode;
-
-                return Task.CompletedTask;
-            }, context);
+            context.Response.StatusCode = (int)response.StatusCode;
 
             using(content)
             {


### PR DESCRIPTION
Status code is set directly instead of in OnStarting so that wrapping middlewares see the correct status code and can act on it. Fixes: #607 