### PR TITLE
Fixes #571. Added IDownstreamRequestBaseHostProvider to resolve actua…

### DIFF
--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -49,6 +49,7 @@ namespace Ocelot.DependencyInjection
     using Steeltoe.Common.Discovery;
     using Pivotal.Discovery.Client;
     using Ocelot.Request.Creator;
+    using Ocelot.LoadBalancer.Providers;
 
     public class OcelotBuilder : IOcelotBuilder
     {
@@ -117,6 +118,7 @@ namespace Ocelot.DependencyInjection
             _services.TryAddSingleton<IHttpHandlerOptionsCreator, HttpHandlerOptionsCreator>();
             _services.TryAddSingleton<IDownstreamAddressesCreator, DownstreamAddressesCreator>();
             _services.TryAddSingleton<IDelegatingHandlerHandlerFactory, DelegatingHandlerHandlerFactory>();
+            _services.TryAddSingleton<IDownstreamRequestBaseHostProvider, DownstreamRequestBaseHostProvider>();
 
             if (UsingEurekaServiceDiscoveryProvider(configurationRoot))
             {

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -42,7 +42,7 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
             if (ServiceFabricRequest(context))
             {
                 var pathAndQuery = CreateServiceFabricUri(context, response);
-                context.DownstreamRequest.AbsolutePath = pathAndQuery.path;
+                context.DownstreamRequest.AbsolutePath = (context.DownstreamRequest.ApplicationName ?? string.Empty) + pathAndQuery.path;
                 context.DownstreamRequest.Query = pathAndQuery.query;
             }
             else
@@ -51,14 +51,14 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
                 if(ContainsQueryString(dsPath))
                 {
-                    context.DownstreamRequest.AbsolutePath = GetPath(dsPath);
+                    context.DownstreamRequest.AbsolutePath = (context.DownstreamRequest.ApplicationName ?? string.Empty) + GetPath(dsPath);
                     context.DownstreamRequest.Query = GetQueryString(dsPath);
                 }
                 else
                 {
                     RemoveQueryStringParametersThatHaveBeenUsedInTemplate(context);
 
-                    context.DownstreamRequest.AbsolutePath = dsPath.Value;
+                    context.DownstreamRequest.AbsolutePath = (context.DownstreamRequest.ApplicationName ?? string.Empty) + dsPath.Value;
                 }
             }
 

--- a/src/Ocelot/LoadBalancer/Providers/BaseHostInfo.cs
+++ b/src/Ocelot/LoadBalancer/Providers/BaseHostInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Ocelot.LoadBalancer.Providers
+{
+    public class BaseHostInfo
+    {
+        public string BaseHost { get; set; }
+        public string ApplicationName { get; set; }
+    }
+}

--- a/src/Ocelot/LoadBalancer/Providers/DownstreamRequestBaseHostProvider.cs
+++ b/src/Ocelot/LoadBalancer/Providers/DownstreamRequestBaseHostProvider.cs
@@ -1,0 +1,42 @@
+﻿namespace Ocelot.LoadBalancer.Providers
+{
+    public class DownstreamRequestBaseHostProvider : IDownstreamRequestBaseHostProvider
+    {
+        private const string DoubleSlashes = "://";
+
+        /// <summary>
+        /// Gets the base host information.
+        /// </summary>
+        /// <param name="downstreamHost">The downstream host.</param>
+        /// <remarks>Parses out base host address and application name from host address with sub apllication name, e.g. 'hostaddress/app' 
+        /// and returns 'hostaddress' as base host address and '/app' as an application name to be later used for proper downstream request creation.</remarks>
+        /// <returns><see cref="BaseHostInfo"/></returns>
+        public BaseHostInfo GetBaseHostInfo(string downstreamHost)
+        {
+            var doubleSlashesIndex = downstreamHost.IndexOf(DoubleSlashes);
+            var start = (doubleSlashesIndex != -1) ? doubleSlashesIndex + DoubleSlashes.Length : 0;
+            var end = downstreamHost.IndexOf("/", start);
+            if (end == -1)
+            {
+                end = downstreamHost.Length;
+            }
+
+            var baseHost = downstreamHost.Substring(start, end - start);
+
+            var portIndex = baseHost.IndexOf(":");
+            if (portIndex != -1)
+            {
+                var portEnd = (portIndex != -1) ? portIndex : baseHost.Length;
+                baseHost = baseHost.Substring(0, portEnd);
+            }
+
+            var appName = downstreamHost.Substring(end, downstreamHost.Length - end);
+
+            return new BaseHostInfo()
+            {
+                BaseHost = baseHost,
+                ApplicationName = appName
+            };
+        }
+    }
+}

--- a/src/Ocelot/LoadBalancer/Providers/IDownstreamRequestBaseHostProvider.cs
+++ b/src/Ocelot/LoadBalancer/Providers/IDownstreamRequestBaseHostProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace Ocelot.LoadBalancer.Providers
+{
+    public interface IDownstreamRequestBaseHostProvider
+    {
+        BaseHostInfo GetBaseHostInfo(string downstreamHost);
+    }
+}

--- a/src/Ocelot/Request/Middleware/DownstreamRequest.cs
+++ b/src/Ocelot/Request/Middleware/DownstreamRequest.cs
@@ -33,6 +33,8 @@ namespace Ocelot.Request.Middleware
 
         public int Port { get; set; }
 
+        public string ApplicationName { get; set; }
+
         public string AbsolutePath { get; set; }
 
         public string Query { get; set; }

--- a/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/LoadBalancer/LoadBalancerMiddlewareTests.cs
@@ -12,6 +12,7 @@ namespace Ocelot.UnitTests.LoadBalancer
     using Ocelot.Errors;
     using Ocelot.LoadBalancer.LoadBalancers;
     using Ocelot.LoadBalancer.Middleware;
+    using Ocelot.LoadBalancer.Providers;
     using Ocelot.Logging;
     using Ocelot.Request.Middleware;
     using Ocelot.Responses;
@@ -34,6 +35,7 @@ namespace Ocelot.UnitTests.LoadBalancer
         private LoadBalancingMiddleware _middleware;
         private DownstreamContext _downstreamContext;
         private OcelotRequestDelegate _next;
+        private IDownstreamRequestBaseHostProvider _baseHostProvider;
 
         public LoadBalancerMiddlewareTests()
         {
@@ -47,6 +49,7 @@ namespace Ocelot.UnitTests.LoadBalancer
             _loggerFactory.Setup(x => x.CreateLogger<LoadBalancingMiddleware>()).Returns(_logger.Object);
             _next = context => Task.CompletedTask;
             _downstreamContext.DownstreamRequest = new DownstreamRequest(_downstreamRequest);
+            _baseHostProvider = new DownstreamRequestBaseHostProvider();
         }
 
         [Fact]
@@ -110,7 +113,7 @@ namespace Ocelot.UnitTests.LoadBalancer
 
         private void WhenICallTheMiddleware()
         {
-            _middleware = new LoadBalancingMiddleware(_next, _loggerFactory.Object, _loadBalancerHouse.Object);
+            _middleware = new LoadBalancingMiddleware(_next, _loggerFactory.Object, _loadBalancerHouse.Object, _baseHostProvider);
             _middleware.Invoke(_downstreamContext).GetAwaiter().GetResult();
         }
 


### PR DESCRIPTION
Added `IDownstreamRequestBaseHostProvider `to resolve actual downstream host and application name from downstream host address with sub application name in it

New Feature support path's in service discovery provider addresses

## Proposed Changes
This will handle downstream hosts with sub application name in it, e.g. www.foo.com/app
`DownstreamRequestBaseHostProvider `will set `DownstreamRequest.Host` value to "www.foo.com" and `DownstreamRequest.ApplicationName` to "/app".

`DownstreamRequest.ApplicationName` will be later used (if set) to prefix the actual `AbsoluteUrl `of the downstream request.

So, given:
Downstream route: "/api/test"
Proxy Host: "http://localhost:5555/"
Downstream Host: "www.foo.com/appname"
Downstream Port: 443
Downstream Schema: "https"

The downstream request will be:
`"https://www.foo.com:443/appname/api/test"`


