### PR TITLE
Fix DI Registration for IDownstreamRouteProvider

### DIFF
--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -94,8 +94,8 @@ namespace Ocelot.DependencyInjection
             Services.TryAddSingleton<IUrlPathToUrlTemplateMatcher, RegExUrlMatcher>();
             Services.TryAddSingleton<IPlaceholderNameAndValueFinder, UrlPathPlaceholderNameAndValueFinder>();
             Services.TryAddSingleton<IDownstreamPathPlaceholderReplacer, DownstreamTemplatePathPlaceholderReplacer>();
-            Services.TryAddSingleton<IDownstreamRouteProvider, DownstreamRouteFinder>();
-            Services.TryAddSingleton<IDownstreamRouteProvider, DownstreamRouteCreator>();
+            Services.AddSingleton<IDownstreamRouteProvider, DownstreamRouteFinder>();
+            Services.AddSingleton<IDownstreamRouteProvider, DownstreamRouteCreator>();
             Services.TryAddSingleton<IDownstreamRouteProviderFactory, DownstreamRouteProviderFactory>();
             Services.TryAddSingleton<IHttpRequester, HttpClientHttpRequester>();
             Services.TryAddSingleton<IHttpResponder, HttpContextResponder>();


### PR DESCRIPTION
Fixes #655 

The two singletons registered for `IDownstreamRouteProvider`, `DownstreamRouteFinder` and `DownstreamRouteCreator`, were registered using `TryAddSingleton`. This would cause DownstreamRouteFinder to be instantiated and found but the "Try" made DownstreamRouteCreator not
registered.

## Proposed Changes

  - Change `OcelotBuilder.cs` to use `AddSingleton` for `DownstreamRouteFinder` and `DownstreamRouteCreator`
