### PR TITLE
fix the instantiation of the object is not instantiated's bug.

### DIFF
--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -39,6 +39,9 @@ namespace Ocelot.Responder.Middleware
                 
                 SetErrorResponse(context.HttpContext, context.Errors);
             }
+            else if (context.DownstreamResponse == null)
+            {//If the pipeline is forced to terminate without any processing, the instantiation of the object is not instantiated.
+            }
             else
             {
                 Logger.LogDebug("no pipeline errors, setting and returning completed response");


### PR DESCRIPTION
If the pipeline is forced to terminate without any processing, the instantiation of the object is not instantiated.

Fixes / New Feature #
[](https://github.com/ThreeMammals/Ocelot/issues/653)
## Proposed Changes

  -
  -
  -
