### PR TITLE
Fixing a syntax error in qualityofservice.rst

### DIFF
--- a/docs/features/qualityofservice.rst
+++ b/docs/features/qualityofservice.rst
@@ -2,7 +2,7 @@ Quality of Service
 ==================
 
 Ocelot supports one QoS capability at the current time. You can set on a per ReRoute basis if you 
-want to use a circuit breaker when making requests to a downstream service. This uses the an awesome
+want to use a circuit breaker when making requests to a downstream service. This uses an awesome
 .NET library called Polly check them out `here <https://github.com/App-vNext/Polly>`_.
 
 The first thing you need to do if you want to use the administration API is bring in the relavent NuGet package..


### PR DESCRIPTION
Fixes / New Feature #

Fixes a simple syntax error in the QoS docs.

## Proposed Changes

  -
