### PR TITLE
Fixed error message when reroute configuration is not found #650

### DIFF
--- a/src/Ocelot/DownstreamRouteFinder/Finder/UnableToFindDownstreamRouteError.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/UnableToFindDownstreamRouteError.cs
@@ -5,7 +5,7 @@ namespace Ocelot.DownstreamRouteFinder.Finder
     public class UnableToFindDownstreamRouteError : Error
     {
         public UnableToFindDownstreamRouteError(string path, string httpVerb) 
-            : base($"Unable to find downstream route for path: {path}, verb: {httpVerb}", OcelotErrorCode.UnableToFindDownstreamRouteError)
+            : base($"Failed to match ReRoute configuration for upstream path: {path}, verb: {httpVerb}.", OcelotErrorCode.UnableToFindDownstreamRouteError)
         {
         }
     }


### PR DESCRIPTION
Fixes #650

## Proposed Changes
I changed the error message to be clearer that the issue was due to not finding the ReRoute configuration for the upstream path.

I'm a bit conflicted about this change as it seems to simple :) Having said so, it seems that this error is only used for this case.

In addition, whilst looking into this. I got confused by this part in the [DownstreamRouteFinder.cs](https://github.com/ThreeMammals/Ocelot/blob/66b68fc6859af2cf1268083e19cdec49c1631e27/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs).
```
            if (downstreamRoutes.Any())
            {
                var notNullOption = downstreamRoutes.FirstOrDefault(x => !string.IsNullOrEmpty(x.ReRoute.UpstreamHost));
                var nullOption = downstreamRoutes.FirstOrDefault(x => string.IsNullOrEmpty(x.ReRoute.UpstreamHost));

                return notNullOption != null ? new OkResponse<DownstreamRoute>(notNullOption) : new OkResponse<DownstreamRoute>(nullOption);
            }
```
Am I right that this can be replaced with?
```
            if (downstreamRoutes.Any())
            {
                return new OkResponse<DownstreamRoute>(downstreamRoutes.OrderBy(x => !string.IsNullOrEmpty(x.ReRoute.UpstreamHost)).FirstOrDefault());
            }
```