### PR TITLE
fix issue #661 for Advanced aggregations

### DIFF
--- a/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
@@ -4,6 +4,7 @@
     using System.Net.Http;
     using Ocelot.Values;
     using System.Linq;
+    using Ocelot.Configuration.File;
 
     public class ReRouteBuilder
     {
@@ -11,11 +12,13 @@
         private List<HttpMethod> _upstreamHttpMethod;
         private string _upstreamHost;
         private List<DownstreamReRoute> _downstreamReRoutes;
+        private List<AggregateReRouteConfig> _downstreamReRoutesConfig;
         private string _aggregator;
 
         public ReRouteBuilder()
         {
             _downstreamReRoutes = new List<DownstreamReRoute>();
+            _downstreamReRoutesConfig = new List<AggregateReRouteConfig>();
         }
 
         public ReRouteBuilder WithDownstreamReRoute(DownstreamReRoute value)
@@ -48,6 +51,12 @@
             return this;
         }
 
+        public ReRouteBuilder WithAggregateReRouteConfig(List<AggregateReRouteConfig> aggregateReRouteConfigs)
+        {
+            _downstreamReRoutesConfig = aggregateReRouteConfigs;
+            return this;
+        }
+
         public ReRouteBuilder WithAggregator(string aggregator)
         {
             _aggregator = aggregator;
@@ -57,7 +66,8 @@
         public ReRoute Build()
         {
             return new ReRoute(
-                _downstreamReRoutes, 
+                _downstreamReRoutes,
+                _downstreamReRoutesConfig,
                 _upstreamHttpMethod, 
                 _upstreamTemplatePattern, 
                 _upstreamHost,

--- a/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
@@ -24,14 +24,18 @@ namespace Ocelot.Configuration.Creator
 
         private ReRoute SetUpAggregateReRoute(IEnumerable<ReRoute> reRoutes, FileAggregateReRoute aggregateReRoute, FileGlobalConfiguration globalConfiguration)
         {
-            var applicableReRoutes = reRoutes
-                .SelectMany(x => x.DownstreamReRoute)
-                .Where(r => aggregateReRoute.ReRouteKeys.Contains(r.Key))
-                .ToList();
+            var applicableReRoutes = new List<DownstreamReRoute>();
+            var allReRoutes = reRoutes.SelectMany(x => x.DownstreamReRoute);
 
-            if (applicableReRoutes.Count != aggregateReRoute.ReRouteKeys.Count)
+            foreach (var reRouteKey in aggregateReRoute.ReRouteKeys)
             {
-                return null;
+                var selec = allReRoutes.FirstOrDefault(q => q.Key == reRouteKey);
+                if (selec == null)
+                {
+                    return null;
+                }
+
+                applicableReRoutes.Add(selec);
             }
 
             var upstreamTemplatePattern = _creator.Create(aggregateReRoute);
@@ -40,6 +44,7 @@ namespace Ocelot.Configuration.Creator
                 .WithUpstreamHttpMethod(aggregateReRoute.UpstreamHttpMethod)
                 .WithUpstreamPathTemplate(upstreamTemplatePattern)
                 .WithDownstreamReRoutes(applicableReRoutes)
+                .WithAggregateReRouteConfig(aggregateReRoute.ReRouteKeysConfig)
                 .WithUpstreamHost(aggregateReRoute.UpstreamHost)
                 .WithAggregator(aggregateReRoute.Aggregator)
                 .Build();

--- a/src/Ocelot/Configuration/File/AggregateReRouteConfig.cs
+++ b/src/Ocelot/Configuration/File/AggregateReRouteConfig.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ocelot.Configuration.File
+{
+    public class AggregateReRouteConfig
+    {
+        public string ReRouteKey { get; set; }
+        public string Parameter { get; set; }
+        public string JsonPath { get; set; }
+    }
+}

--- a/src/Ocelot/Configuration/File/FileAggregateReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileAggregateReRoute.cs
@@ -5,6 +5,7 @@ namespace Ocelot.Configuration.File
     public class FileAggregateReRoute : IReRoute
     {
         public List<string> ReRouteKeys { get;set; }
+        public List<AggregateReRouteConfig> ReRouteKeysConfig { get;set; }
         public string UpstreamPathTemplate { get;set; }
         public string UpstreamHost { get; set; }
         public bool ReRouteIsCaseSensitive { get; set; }
@@ -17,5 +18,5 @@ namespace Ocelot.Configuration.File
         }
 
         public int Priority {get;set;} = 1;
-    }
+    }   
 }

--- a/src/Ocelot/Configuration/ReRoute.cs
+++ b/src/Ocelot/Configuration/ReRoute.cs
@@ -2,11 +2,13 @@
 {
     using System.Collections.Generic;
     using System.Net.Http;
+    using Ocelot.Configuration.File;
     using Ocelot.Values;
 
     public class ReRoute
     {
-        public ReRoute(List<DownstreamReRoute> downstreamReRoute, 
+        public ReRoute(List<DownstreamReRoute> downstreamReRoute,
+            List<AggregateReRouteConfig> downstreamReRouteConfig,
             List<HttpMethod> upstreamHttpMethod, 
             UpstreamPathTemplate upstreamTemplatePattern, 
             string upstreamHost,
@@ -14,6 +16,7 @@
         {
             UpstreamHost = upstreamHost;
             DownstreamReRoute = downstreamReRoute;
+            DownstreamReRouteConfig = downstreamReRouteConfig;
             UpstreamHttpMethod = upstreamHttpMethod;
             UpstreamTemplatePattern = upstreamTemplatePattern;
             Aggregator = aggregator;
@@ -23,6 +26,7 @@
         public List<HttpMethod> UpstreamHttpMethod { get; private set; }
         public string UpstreamHost { get; private set; }
         public List<DownstreamReRoute> DownstreamReRoute { get; private set; }
+        public List<AggregateReRouteConfig> DownstreamReRouteConfig { get; private set; }
         public string Aggregator {get; private set;}
     }
 }

--- a/src/Ocelot/Middleware/Multiplexer/InMemoryResponseAggregatorFactory.cs
+++ b/src/Ocelot/Middleware/Multiplexer/InMemoryResponseAggregatorFactory.cs
@@ -5,12 +5,12 @@ namespace Ocelot.Middleware.Multiplexer
     public class InMemoryResponseAggregatorFactory : IResponseAggregatorFactory
     {
         private readonly UserDefinedResponseAggregator _userDefined;
-        private readonly SimpleJsonResponseAggregator _simple;
+        private readonly IResponseAggregator _simple;
 
-        public InMemoryResponseAggregatorFactory(IDefinedAggregatorProvider provider)
+        public InMemoryResponseAggregatorFactory(IDefinedAggregatorProvider provider, IResponseAggregator responseAggregator)
         {
             _userDefined = new UserDefinedResponseAggregator(provider);
-            _simple = new SimpleJsonResponseAggregator();
+            _simple = responseAggregator;
         }
 
         public IResponseAggregator Get(ReRoute reRoute)

--- a/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
+++ b/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
@@ -2,37 +2,80 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Ocelot.Configuration;
+using Ocelot.DownstreamRouteFinder.UrlMatcher;
 
 namespace Ocelot.Middleware.Multiplexer
 {
     public class Multiplexer : IMultiplexer
     {
         private readonly IResponseAggregatorFactory _factory;
+        private readonly Logging.IOcelotLoggerFactory _logger;
 
-        public Multiplexer(IResponseAggregatorFactory factory)
+        public Multiplexer(IResponseAggregatorFactory factory, Logging.IOcelotLoggerFactory logger)
         {
             _factory = factory;
+            _logger = logger;
         }
 
         public async Task Multiplex(DownstreamContext context, ReRoute reRoute, OcelotRequestDelegate next)
         {
-            var tasks = new Task<DownstreamContext>[reRoute.DownstreamReRoute.Count];
-
-            for (var i = 0; i < reRoute.DownstreamReRoute.Count; i++)
+            var downstreamContextMain = new DownstreamContext(context.HttpContext)
             {
-                var downstreamContext = new DownstreamContext(context.HttpContext)
-                {
-                    TemplatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues,
-                    Configuration = context.Configuration,
-                    DownstreamReRoute = reRoute.DownstreamReRoute[i],
-                };
+                TemplatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues,
+                Configuration = context.Configuration,
+                DownstreamReRoute = reRoute.DownstreamReRoute[0],
+            };
+            var mainResponse = await Fire(downstreamContextMain, next);
 
-                tasks[i] = Fire(downstreamContext, next);
+            if (reRoute.DownstreamReRoute.Count == 1)
+            {
+                MapNotAggregate(context, new List<DownstreamContext>() { mainResponse });
+                return;
+            }
+
+            var reRouteKeysConfigs = reRoute.DownstreamReRouteConfig;
+
+            var tasks = new List<Task<DownstreamContext>>();
+
+            var content = await mainResponse.DownstreamResponse.Content.ReadAsStringAsync();
+            var jObject = Newtonsoft.Json.Linq.JToken.Parse(content);
+
+            for (var i = 1; i < reRoute.DownstreamReRoute.Count; i++)
+            {
+                var templatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues;
+                var downstreamReRoute = reRoute.DownstreamReRoute[i];
+                var matchAdvancedAgg = reRouteKeysConfigs.FirstOrDefault(q => q.ReRouteKey == downstreamReRoute.Key);
+                if (matchAdvancedAgg != null)
+                {
+                    var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath);
+
+                    foreach (var value in values)
+                    {
+                        var downstreamContext = new DownstreamContext(context.HttpContext)
+                        {
+                            TemplatePlaceholderNameAndValues = templatePlaceholderNameAndValues,
+                            Configuration = context.Configuration,
+                            DownstreamReRoute = downstreamReRoute,
+                        };
+                        downstreamContext.TemplatePlaceholderNameAndValues.Add(new PlaceholderNameAndValue("{" + matchAdvancedAgg.Parameter + "}", value.ToString()));
+                        tasks.Add(Fire(downstreamContext, next));
+                    }
+                }
+                else
+                {
+                    var downstreamContext = new DownstreamContext(context.HttpContext)
+                    {
+                        TemplatePlaceholderNameAndValues = templatePlaceholderNameAndValues,
+                        Configuration = context.Configuration,
+                        DownstreamReRoute = downstreamReRoute,
+                    };
+                    tasks.Add(Fire(downstreamContext, next));
+                }
             }
 
             await Task.WhenAll(tasks);
 
-            var contexts = new List<DownstreamContext>();
+            var contexts = new List<DownstreamContext>() { mainResponse };
 
             foreach (var task in tasks)
             {
@@ -55,7 +98,7 @@ namespace Ocelot.Middleware.Multiplexer
                 MapNotAggregate(context, contexts);
             }
         }
-        
+
         private void MapNotAggregate(DownstreamContext originalContext, List<DownstreamContext> downstreamContexts)
         {
             //assume at least one..if this errors then it will be caught by global exception handler

--- a/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
+++ b/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
@@ -18,37 +18,82 @@ namespace Ocelot.Middleware.Multiplexer
 
         public async Task Multiplex(DownstreamContext context, ReRoute reRoute, OcelotRequestDelegate next)
         {
-            var downstreamContextMain = new DownstreamContext(context.HttpContext)
-            {
-                TemplatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues,
-                Configuration = context.Configuration,
-                DownstreamReRoute = reRoute.DownstreamReRoute[0],
-            };
-            var mainResponse = await Fire(downstreamContextMain, next);
-
-            if (reRoute.DownstreamReRoute.Count == 1)
-            {
-                MapNotAggregate(context, new List<DownstreamContext>() { mainResponse });
-                return;
-            }
-
             var reRouteKeysConfigs = reRoute.DownstreamReRouteConfig;
-
-            var tasks = new List<Task<DownstreamContext>>();
-
-            var content = await mainResponse.DownstreamResponse.Content.ReadAsStringAsync();
-            var jObject = Newtonsoft.Json.Linq.JToken.Parse(content);
-
-            for (var i = 1; i < reRoute.DownstreamReRoute.Count; i++)
+            if (reRouteKeysConfigs == null || !reRouteKeysConfigs.Any())
             {
-                var templatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues;
-                var downstreamReRoute = reRoute.DownstreamReRoute[i];
-                var matchAdvancedAgg = reRouteKeysConfigs.FirstOrDefault(q => q.ReRouteKey == downstreamReRoute.Key);
-                if (matchAdvancedAgg != null)
-                {
-                    var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath).Select(s=>s.ToString()).Distinct().ToList();
+                var tasks = new Task<DownstreamContext>[reRoute.DownstreamReRoute.Count];
 
-                    foreach (var value in values)
+                for (var i = 0; i < reRoute.DownstreamReRoute.Count; i++)
+                {
+                    var downstreamContext = new DownstreamContext(context.HttpContext)
+                    {
+                        TemplatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues,
+                        Configuration = context.Configuration,
+                        DownstreamReRoute = reRoute.DownstreamReRoute[i],
+                    };
+
+                    tasks[i] = Fire(downstreamContext, next);
+                }
+
+                await Task.WhenAll(tasks);
+
+                var contexts = new List<DownstreamContext>();
+
+                foreach (var task in tasks)
+                {
+                    var finished = await task;
+                    contexts.Add(finished);
+                }
+
+                await Map(reRoute, context, contexts);
+            }
+            else
+            {
+                var downstreamContextMain = new DownstreamContext(context.HttpContext)
+                {
+                    TemplatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues,
+                    Configuration = context.Configuration,
+                    DownstreamReRoute = reRoute.DownstreamReRoute[0],
+                };
+                var mainResponse = await Fire(downstreamContextMain, next);
+
+                if (reRoute.DownstreamReRoute.Count == 1)
+                {
+                    MapNotAggregate(context, new List<DownstreamContext>() { mainResponse });
+                    return;
+                }
+
+                var tasks = new List<Task<DownstreamContext>>();
+                if (mainResponse.DownstreamResponse == null)
+                {
+                    return;
+                }
+
+                var content = await mainResponse.DownstreamResponse.Content.ReadAsStringAsync();
+                var jObject = Newtonsoft.Json.Linq.JToken.Parse(content);
+
+                for (var i = 1; i < reRoute.DownstreamReRoute.Count; i++)
+                {
+                    var templatePlaceholderNameAndValues = context.TemplatePlaceholderNameAndValues;
+                    var downstreamReRoute = reRoute.DownstreamReRoute[i];
+                    var matchAdvancedAgg = reRouteKeysConfigs.FirstOrDefault(q => q.ReRouteKey == downstreamReRoute.Key);
+                    if (matchAdvancedAgg != null)
+                    {
+                        var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath).Select(s => s.ToString()).Distinct().ToList();
+
+                        foreach (var value in values)
+                        {
+                            var downstreamContext = new DownstreamContext(context.HttpContext)
+                            {
+                                TemplatePlaceholderNameAndValues = new List<PlaceholderNameAndValue>(templatePlaceholderNameAndValues),
+                                Configuration = context.Configuration,
+                                DownstreamReRoute = downstreamReRoute,
+                            };
+                            downstreamContext.TemplatePlaceholderNameAndValues.Add(new PlaceholderNameAndValue("{" + matchAdvancedAgg.Parameter + "}", value.ToString()));
+                            tasks.Add(Fire(downstreamContext, next));
+                        }
+                    }
+                    else
                     {
                         var downstreamContext = new DownstreamContext(context.HttpContext)
                         {
@@ -56,33 +101,22 @@ namespace Ocelot.Middleware.Multiplexer
                             Configuration = context.Configuration,
                             DownstreamReRoute = downstreamReRoute,
                         };
-                        downstreamContext.TemplatePlaceholderNameAndValues.Add(new PlaceholderNameAndValue("{" + matchAdvancedAgg.Parameter + "}", value.ToString()));
                         tasks.Add(Fire(downstreamContext, next));
                     }
                 }
-                else
+
+                await Task.WhenAll(tasks);
+
+                var contexts = new List<DownstreamContext>() { mainResponse };
+
+                foreach (var task in tasks)
                 {
-                    var downstreamContext = new DownstreamContext(context.HttpContext)
-                    {
-                        TemplatePlaceholderNameAndValues = new List<PlaceholderNameAndValue>(templatePlaceholderNameAndValues),
-                        Configuration = context.Configuration,
-                        DownstreamReRoute = downstreamReRoute,
-                    };
-                    tasks.Add(Fire(downstreamContext, next));
+                    var finished = await task;
+                    contexts.Add(finished);
                 }
+
+                await Map(reRoute, context, contexts);
             }
-
-            await Task.WhenAll(tasks);
-
-            var contexts = new List<DownstreamContext>() { mainResponse };
-
-            foreach (var task in tasks)
-            {
-                var finished = await task;
-                contexts.Add(finished);
-            }
-
-            await Map(reRoute, context, contexts);
         }
 
         private async Task Map(ReRoute reRoute, DownstreamContext context, List<DownstreamContext> contexts)

--- a/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
+++ b/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
@@ -48,7 +48,7 @@ namespace Ocelot.Middleware.Multiplexer
                 var matchAdvancedAgg = reRouteKeysConfigs.FirstOrDefault(q => q.ReRouteKey == downstreamReRoute.Key);
                 if (matchAdvancedAgg != null)
                 {
-                    var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath);
+                    var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath).Select(s=>s.ToString()).Distinct().ToList();
 
                     foreach (var value in values)
                     {

--- a/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
+++ b/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 
@@ -53,7 +54,7 @@ namespace Ocelot.Middleware.Multiplexer
                     {
                         var downstreamContext = new DownstreamContext(context.HttpContext)
                         {
-                            TemplatePlaceholderNameAndValues = templatePlaceholderNameAndValues,
+                            TemplatePlaceholderNameAndValues = new List<PlaceholderNameAndValue>(templatePlaceholderNameAndValues),
                             Configuration = context.Configuration,
                             DownstreamReRoute = downstreamReRoute,
                         };
@@ -65,7 +66,7 @@ namespace Ocelot.Middleware.Multiplexer
                 {
                     var downstreamContext = new DownstreamContext(context.HttpContext)
                     {
-                        TemplatePlaceholderNameAndValues = templatePlaceholderNameAndValues,
+                        TemplatePlaceholderNameAndValues = new List<PlaceholderNameAndValue>(templatePlaceholderNameAndValues),
                         Configuration = context.Configuration,
                         DownstreamReRoute = downstreamReRoute,
                     };

--- a/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
+++ b/src/Ocelot/Middleware/Multiplexer/Multiplexer.cs
@@ -10,12 +10,10 @@ namespace Ocelot.Middleware.Multiplexer
     public class Multiplexer : IMultiplexer
     {
         private readonly IResponseAggregatorFactory _factory;
-        private readonly Logging.IOcelotLoggerFactory _logger;
 
-        public Multiplexer(IResponseAggregatorFactory factory, Logging.IOcelotLoggerFactory logger)
+        public Multiplexer(IResponseAggregatorFactory factory)
         {
             _factory = factory;
-            _logger = logger;
         }
 
         public async Task Multiplex(DownstreamContext context, ReRoute reRoute, OcelotRequestDelegate next)

--- a/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
+++ b/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -21,19 +22,54 @@ namespace Ocelot.Middleware.Multiplexer
 
             contentBuilder.Append("{");
 
-            for (var i = 0; i < downstreamContexts.Count; i++)
+            var responceKeys = downstreamContexts.Select(s => s.DownstreamReRoute.Key).Distinct().ToList();
+
+            for (var k = 0; k < responceKeys.Count; k++)
             {
-                if (downstreamContexts[i].IsError)
+                var contexts = downstreamContexts.Where(w => w.DownstreamReRoute.Key == responceKeys[k]).ToList();
+                if (contexts.Count == 1)
                 {
-                    MapAggregateError(originalContext, downstreamContexts, i);
-                    return;
+                    if (contexts[0].IsError)
+                    {
+                        MapAggregateError(originalContext, contexts[0]);
+                        return;
+                    }
+
+                    var content = await contexts[0].DownstreamResponse.Content.ReadAsStringAsync();
+                    contentBuilder.Append($"\"{responceKeys[k]}\":{content}");
+
+                }
+                else
+                {
+                    contentBuilder.Append($"\"{responceKeys[k]}\":");
+                    contentBuilder.Append("[");
+
+                    for (var i = 0; i < contexts.Count; i++)
+                    {
+                        if (contexts[i].IsError)
+                        {
+                            MapAggregateError(originalContext, contexts[i]);
+                            return;
+                        }
+
+                        var content = await contexts[i].DownstreamResponse.Content.ReadAsStringAsync();
+                        if (string.IsNullOrWhiteSpace(content))
+                        {
+                            continue;
+                        }
+
+                        contentBuilder.Append($"{content}");
+
+                        if (i + 1 < contexts.Count)
+                        {
+                            contentBuilder.Append(",");
+                        }
+                    }
+
+                    contentBuilder.Append("]");
                 }
 
-                var content = await downstreamContexts[i].DownstreamResponse.Content.ReadAsStringAsync();
-
-                contentBuilder.Append($"\"{downstreamContexts[i].DownstreamReRoute.Key}\":{content}");
-
-                if (i + 1 < downstreamContexts.Count)
+                if (k + 1 < responceKeys.Count)
                 {
                     contentBuilder.Append(",");
                 }
@@ -43,16 +79,16 @@ namespace Ocelot.Middleware.Multiplexer
 
             var stringContent = new StringContent(contentBuilder.ToString())
             {
-                Headers = {ContentType = new MediaTypeHeaderValue("application/json")}
+                Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
             };
 
             originalContext.DownstreamResponse = new DownstreamResponse(stringContent, HttpStatusCode.OK, new List<KeyValuePair<string, IEnumerable<string>>>(), "cannot return from aggregate..which reason phrase would you use?");
         }
 
-        private static void MapAggregateError(DownstreamContext originalContext, List<DownstreamContext> downstreamContexts, int i)
+        private static void MapAggregateError(DownstreamContext originalContext, DownstreamContext downstreamContext)
         {
-            originalContext.Errors.AddRange(downstreamContexts[i].Errors);
-            originalContext.DownstreamResponse = downstreamContexts[i].DownstreamResponse;
+            originalContext.Errors.AddRange(downstreamContext.Errors);
+            originalContext.DownstreamResponse = downstreamContext.DownstreamResponse;
         }
     }
 }

--- a/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
+++ b/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
@@ -24,9 +24,9 @@ namespace Ocelot.Middleware.Multiplexer
 
             var responseKeys = downstreamContexts.Select(s => s.DownstreamReRoute.Key).Distinct().ToList();
 
-            for (var k = 0; k < responceKeys.Count; k++)
+            for (var k = 0; k < responseKeys.Count; k++)
             {
-                var contexts = downstreamContexts.Where(w => w.DownstreamReRoute.Key == responceKeys[k]).ToList();
+                var contexts = downstreamContexts.Where(w => w.DownstreamReRoute.Key == responseKeys[k]).ToList();
                 if (contexts.Count == 1)
                 {
                     if (contexts[0].IsError)
@@ -36,12 +36,12 @@ namespace Ocelot.Middleware.Multiplexer
                     }
 
                     var content = await contexts[0].DownstreamResponse.Content.ReadAsStringAsync();
-                    contentBuilder.Append($"\"{responceKeys[k]}\":{content}");
+                    contentBuilder.Append($"\"{responseKeys[k]}\":{content}");
 
                 }
                 else
                 {
-                    contentBuilder.Append($"\"{responceKeys[k]}\":");
+                    contentBuilder.Append($"\"{responseKeys[k]}\":");
                     contentBuilder.Append("[");
 
                     for (var i = 0; i < contexts.Count; i++)
@@ -69,7 +69,7 @@ namespace Ocelot.Middleware.Multiplexer
                     contentBuilder.Append("]");
                 }
 
-                if (k + 1 < responceKeys.Count)
+                if (k + 1 < responseKeys.Count)
                 {
                     contentBuilder.Append(",");
                 }

--- a/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
+++ b/src/Ocelot/Middleware/Multiplexer/SimpleJsonResponseAggregator.cs
@@ -22,7 +22,7 @@ namespace Ocelot.Middleware.Multiplexer
 
             contentBuilder.Append("{");
 
-            var responceKeys = downstreamContexts.Select(s => s.DownstreamReRoute.Key).Distinct().ToList();
+            var responseKeys = downstreamContexts.Select(s => s.DownstreamReRoute.Key).Distinct().ToList();
 
             for (var k = 0; k < responceKeys.Count; k++)
             {

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -189,8 +189,8 @@ namespace Ocelot.AcceptanceTests
                             UpstreamHost = "localhost",
                             ReRouteKeys = new List<string>
                             {
-                                "Tom",
-                                "Laura"
+                                "Laura",
+                                "Tom"
                             },
                             Aggregator = "FakeDefinedAggregator"
                         }
@@ -258,8 +258,8 @@ namespace Ocelot.AcceptanceTests
                             UpstreamHost = "localhost",
                             ReRouteKeys = new List<string>
                             {
-                                "Tom",
-                                "Laura"
+                                "Laura",
+                                "Tom"
                             }
                         }
                     }
@@ -326,8 +326,9 @@ namespace Ocelot.AcceptanceTests
                             UpstreamHost = "localhost",
                             ReRouteKeys = new List<string>
                             {
-                                "Tom",
-                                "Laura"
+                                "Laura",
+                                "Tom"
+                                
                             }
                         }
                     }
@@ -394,8 +395,8 @@ namespace Ocelot.AcceptanceTests
                             UpstreamHost = "localhost",
                             ReRouteKeys = new List<string>
                             {
-                                "Tom",
-                                "Laura"
+                                "Laura",
+                                "Tom"
                             }
                         }
                     }
@@ -462,8 +463,8 @@ namespace Ocelot.AcceptanceTests
                             UpstreamHost = "localhost",
                             ReRouteKeys = new List<string>
                             {
-                                "Tom",
-                                "Laura"
+                                "Laura",
+                                "Tom"
                             }
                         }
                     }

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -142,6 +142,100 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
+        public void should_return_response_200_with_advanced_aggregate_configs()
+        {
+            var configuration = new FileConfiguration
+            {
+                ReRoutes = new List<FileReRoute>
+                    {
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamScheme = "http",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = 51889,
+                                }
+                            },
+                            UpstreamPathTemplate = "/Comments",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                            Key = "Comments"
+                        },
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/users/{userId}",
+                            DownstreamScheme = "http",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = 51888,
+                                }
+                            },
+                            UpstreamPathTemplate = "/UserDetails",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                            Key = "UserDetails"
+                        },
+                        new FileReRoute
+                        {
+                            DownstreamPathTemplate = "/posts/{postId}",
+                            DownstreamScheme = "http",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = 51887,
+                                }
+                            },
+                            UpstreamPathTemplate = "/PostDetails",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                            Key = "PostDetails"
+                        }
+                    },
+                Aggregates = new List<FileAggregateReRoute>
+                    {
+                        new FileAggregateReRoute
+                        {
+                            UpstreamPathTemplate = "/",
+                            UpstreamHost = "localhost",
+                            ReRouteKeys = new List<string>
+                            {
+                                "Comments",
+                                "UserDetails",
+                                "PostDetails"
+                            },
+                            ReRouteKeysConfig = new List<AggregateReRouteConfig>()
+                            {
+                                new AggregateReRouteConfig(){ReRouteKey = "UserDetails",JsonPath = "$[*].writerId",Parameter = "userId"},
+                                new AggregateReRouteConfig(){ReRouteKey = "PostDetails",JsonPath = "$[*].postId",Parameter = "postId"}
+                            },
+                        }
+                    }
+            };
+
+            var userDetailsResponseContent = @"{""id"":1,""firstName"":""abolfazl"",""lastName"":""rajabpour""}";
+            var postDetailsResponseContent = @"{""id"":1,""title"":""post1""}";
+            var commentsResponseContent = @"[{""id"":1,""writerId"":1,""postId"":2,""text"":""text1""},{""id"":2,""writerId"":1,""postId"":2,""text"":""text2""}]";
+
+            var expected = "{\"Comments\":" + commentsResponseContent + ",\"UserDetails\":" + userDetailsResponseContent + ",\"PostDetails\":" + postDetailsResponseContent + "}";
+
+            this.Given(x => x.GivenServiceOneIsRunning("http://localhost:51889", "/", 200, commentsResponseContent))
+                .Given(x => x.GivenServiceTwoIsRunning("http://localhost:51888", "/users/1", 200, userDetailsResponseContent))
+                .Given(x => x.GivenServiceTwoIsRunning("http://localhost:51887", "/posts/2", 200, postDetailsResponseContent))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .BDDfy();
+        }
+
+        [Fact]
         public void should_return_response_200_with_simple_url_user_defined_aggregate()
         {
             var configuration = new FileConfiguration
@@ -328,7 +422,7 @@ namespace Ocelot.AcceptanceTests
                             {
                                 "Laura",
                                 "Tom"
-                                
+
                             }
                         }
                     }

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -173,7 +173,7 @@ namespace Ocelot.AcceptanceTests
                                 new FileHostAndPort
                                 {
                                     Host = "localhost",
-                                    Port = 51888,
+                                    Port = 51890,
                                 }
                             },
                             UpstreamPathTemplate = "/UserDetails",
@@ -225,7 +225,7 @@ namespace Ocelot.AcceptanceTests
             var expected = "{\"Comments\":" + commentsResponseContent + ",\"UserDetails\":" + userDetailsResponseContent + ",\"PostDetails\":" + postDetailsResponseContent + "}";
 
             this.Given(x => x.GivenServiceOneIsRunning("http://localhost:51889", "/", 200, commentsResponseContent))
-                .Given(x => x.GivenServiceTwoIsRunning("http://localhost:51888", "/users/1", 200, userDetailsResponseContent))
+                .Given(x => x.GivenServiceTwoIsRunning("http://localhost:51890", "/users/1", 200, userDetailsResponseContent))
                 .Given(x => x.GivenServiceTwoIsRunning("http://localhost:51887", "/posts/2", 200, postDetailsResponseContent))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())

--- a/test/Ocelot.UnitTests/Middleware/ResponseAggregatorFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Middleware/ResponseAggregatorFactoryTests.cs
@@ -13,12 +13,13 @@ namespace Ocelot.UnitTests.Middleware
         private readonly InMemoryResponseAggregatorFactory _factory;
         private Mock<IDefinedAggregatorProvider> _provider;
         private ReRoute _reRoute;
-        private IResponseAggregator _aggregator;
+        private Mock<IResponseAggregator> _aggregator;
 
         public ResponseAggregatorFactoryTests()
         {
             _provider = new Mock<IDefinedAggregatorProvider>();
-            _factory = new InMemoryResponseAggregatorFactory(_provider.Object);
+            _aggregator = new Mock<IResponseAggregator>();
+            _factory = new InMemoryResponseAggregatorFactory(_provider.Object, _aggregator);
         }
         
         [Fact]

--- a/test/Ocelot.UnitTests/Middleware/ResponseAggregatorFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Middleware/ResponseAggregatorFactoryTests.cs
@@ -13,12 +13,12 @@ namespace Ocelot.UnitTests.Middleware
         private readonly InMemoryResponseAggregatorFactory _factory;
         private Mock<IDefinedAggregatorProvider> _provider;
         private ReRoute _reRoute;
-        private Mock<IResponseAggregator> _aggregator;
+        private IResponseAggregator _aggregator;
 
         public ResponseAggregatorFactoryTests()
         {
             _provider = new Mock<IDefinedAggregatorProvider>();
-            _aggregator = new Mock<IResponseAggregator>();
+            _aggregator = new SimpleJsonResponseAggregator();
             _factory = new InMemoryResponseAggregatorFactory(_provider.Object, _aggregator);
         }
         


### PR DESCRIPTION
fix issue #661 for Advanced aggregations.
this changes adds extra options for aggregation based on first ReRouteKeys.

## Proposed Changes

example ocelot config:



    "Aggregates": [
    {
      "ReRouteKeys": [
        "comments",
        "userDetails",
        "postDetails"
      ],
      "ReRouteKeysConfig": [
        {
          "ReRouteKey": "userDetails",
          "Parameter": "userId",
          "JsonPath": "$[*].writerId"
        },
        {
          "ReRouteKey": "postDetails",
          "Parameter": "postId",
          "JsonPath": "$[*].postId"
        }
      ],
      "UpstreamPathTemplate": "/v1/lastComments/"
    }
    ]
