### PR TITLE
Claim values are now being shown when constructing. ClaimValueNotAuthorisedError.

### DIFF
--- a/src/Ocelot/Authorisation/ClaimsAuthoriser.cs
+++ b/src/Ocelot/Authorisation/ClaimsAuthoriser.cs
@@ -32,7 +32,7 @@ namespace Ocelot.Authorisation
                     if (!authorised)
                     {
                         return new ErrorResponse<bool>(new ClaimValueNotAuthorisedError(
-                                $"claim value: {values.Data} is not the same as required value: {required.Value} for type: {required.Key}"));
+                                $"claim value: {string.Join(", ", values.Data)} is not the same as required value: {required.Value} for type: {required.Key}"));
                     }
                 }
                 else


### PR DESCRIPTION
Fixes issue #678 

## Proposed Changes
ClaimsAuthoriser.cs
` return new ErrorResponse<bool>(new ClaimValueNotAuthorisedError(
                                $"claim value: {string.Join(", ", values.Data)} is not the same as required value: {required.Value} for type: {required.Key}"));`