### PR TITLE
added authentication middleware for websockets in ocelot pipeline

### DIFF
--- a/src/Ocelot/Middleware/Pipeline/OcelotPipelineExtensions.cs
+++ b/src/Ocelot/Middleware/Pipeline/OcelotPipelineExtensions.cs
@@ -36,6 +36,12 @@ namespace Ocelot.Middleware.Pipeline
                     app.UseDownstreamRouteFinderMiddleware();
                     app.UseDownstreamRequestInitialiser();
                     app.UseLoadBalancingMiddleware();
+
+                    if (pipelineConfiguration.AuthenticationMiddleware == null)
+                        app.UseAuthenticationMiddleware();
+                    else
+                        app.Use(pipelineConfiguration.AuthenticationMiddleware);
+
                     app.UseDownstreamUrlCreatorMiddleware();
                     app.UseWebSocketsProxyMiddleware();
                 });


### PR DESCRIPTION
Just added the same line of codes that is used in the HTTP pipeline to allow users to specify an Authentication Middleware but in websockets

This was basically an answer to my question at #718 