### PR TITLE
Checkin for caching the template matching for significant route finde…

### DIFF
--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -28,7 +28,7 @@ namespace Ocelot.DownstreamRouteFinder.Finder
 
             foreach (var reRoute in applicableReRoutes)
             {
-                var urlMatch = _urlMatcher.Match(upstreamUrlPath, upstreamQueryString, reRoute.UpstreamTemplatePattern.Template, reRoute.UpstreamTemplatePattern.ContainsQueryString);
+                var urlMatch = _urlMatcher.Match(upstreamUrlPath, upstreamQueryString, reRoute.UpstreamTemplatePattern);
 
                 if (urlMatch.Data.Match)
                 {

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/IUrlPathToUrlTemplateMatcher.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/IUrlPathToUrlTemplateMatcher.cs
@@ -1,9 +1,10 @@
 using Ocelot.Responses;
+using Ocelot.Values;
 
 namespace Ocelot.DownstreamRouteFinder.UrlMatcher
 {
     public interface IUrlPathToUrlTemplateMatcher
      {
-        Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, string upstreamUrlPathTemplate, bool containsQueryString);
+        Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate);
      }
 } 

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcher.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcher.cs
@@ -1,22 +1,21 @@
 ﻿using System.Text.RegularExpressions;
 using Ocelot.Responses;
+using Ocelot.Values;
 
 namespace Ocelot.DownstreamRouteFinder.UrlMatcher
 {
     public class RegExUrlMatcher : IUrlPathToUrlTemplateMatcher
     {
-        public Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, string upstreamUrlPathTemplate, bool containsQueryString)
+        public Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate)
         {
-            var regex = new Regex(upstreamUrlPathTemplate);
-
-            if (!containsQueryString)
+            if (!pathTemplate.ContainsQueryString)
             {
-                return regex.IsMatch(upstreamUrlPath)
+                return pathTemplate.Pattern.IsMatch(upstreamUrlPath)
                     ? new OkResponse<UrlMatch>(new UrlMatch(true))
                     : new OkResponse<UrlMatch>(new UrlMatch(false));
             }
 
-            return regex.IsMatch($"{upstreamUrlPath}{upstreamQueryString}") 
+            return pathTemplate.Pattern.IsMatch($"{upstreamUrlPath}{upstreamQueryString}") 
                 ? new OkResponse<UrlMatch>(new UrlMatch(true)) 
                 : new OkResponse<UrlMatch>(new UrlMatch(false));
         }

--- a/src/Ocelot/Values/UpstreamPathTemplate.cs
+++ b/src/Ocelot/Values/UpstreamPathTemplate.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Ocelot.Values
 {
     public class UpstreamPathTemplate
@@ -8,6 +10,9 @@ namespace Ocelot.Values
             Priority = priority;
             ContainsQueryString = containsQueryString;
             OriginalValue = originalValue;
+            Pattern = template == null ? 
+                new Regex("$^", RegexOptions.Compiled | RegexOptions.Singleline) : 
+                new Regex(template, RegexOptions.Compiled | RegexOptions.Singleline);
         }
 
         public string Template { get; }
@@ -17,5 +22,7 @@ namespace Ocelot.Values
         public bool ContainsQueryString { get; }
 
         public string OriginalValue { get; }
+        
+        public Regex Pattern { get; }
     }
 }

--- a/test/Ocelot.Benchmarks/UrlPathToUrlPathTemplateMatcherBenchmarks.cs
+++ b/test/Ocelot.Benchmarks/UrlPathToUrlPathTemplateMatcherBenchmarks.cs
@@ -5,6 +5,7 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Validators;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
+using Ocelot.Values;
 
 namespace Ocelot.Benchmarks
 {
@@ -12,8 +13,8 @@ namespace Ocelot.Benchmarks
     public class UrlPathToUrlPathTemplateMatcherBenchmarks : ManualConfig
     {
         private RegExUrlMatcher _urlPathMatcher;
+        private UpstreamPathTemplate _pathTemplate;
         private string _downstreamUrlPath;
-        private string _downstreamUrlPathTemplate;
         private string _upstreamQuery;
 
         public UrlPathToUrlPathTemplateMatcherBenchmarks()
@@ -27,14 +28,14 @@ namespace Ocelot.Benchmarks
         public void SetUp()
         {
             _urlPathMatcher = new RegExUrlMatcher();
+            _pathTemplate = new UpstreamPathTemplate("api/product/products/{productId}/variants/", 0, false, null);
             _downstreamUrlPath = "api/product/products/1/variants/?soldout=false";
-            _downstreamUrlPathTemplate = "api/product/products/{productId}/variants/";
         }
 
         [Benchmark(Baseline = true)]
         public void Baseline()
         {
-            _urlPathMatcher.Match(_downstreamUrlPath, _upstreamQuery, _downstreamUrlPathTemplate, false);
+            _urlPathMatcher.Match(_downstreamUrlPath, _upstreamQuery, _pathTemplate);
         }
 
         // * Summary *

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -624,7 +624,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
                 .When(x => x.WhenICallTheFinder())
-                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(1))
+                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(1, 0))
                 .BDDfy();
         }
 
@@ -677,7 +677,8 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                             .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "test"))
                             .Build()
                     )))
-                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(2))
+                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(1, 0))
+                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(1, 1))
                 .BDDfy();
         }
 
@@ -706,32 +707,32 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private void ThenTheUrlMatcherIsCalledCorrectly()
         {
             _mockMatcher
-                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern.Template, _reRoutesConfig[0].UpstreamTemplatePattern.ContainsQueryString), Times.Once);
+                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern), Times.Once);
         }
 
-        private void ThenTheUrlMatcherIsCalledCorrectly(int times)
+        private void ThenTheUrlMatcherIsCalledCorrectly(int times, int index = 0)
         {
             _mockMatcher
-                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern.OriginalValue, _reRoutesConfig[0].UpstreamTemplatePattern.ContainsQueryString), Times.Exactly(times));
+                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[index].UpstreamTemplatePattern), Times.Exactly(times));
         }
 
         private void ThenTheUrlMatcherIsCalledCorrectly(string expectedUpstreamUrlPath)
         {
             _mockMatcher
-                .Verify(x => x.Match(expectedUpstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern.OriginalValue, _reRoutesConfig[0].UpstreamTemplatePattern.ContainsQueryString), Times.Once);
+                .Verify(x => x.Match(expectedUpstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern), Times.Once);
         }
 
         private void ThenTheUrlMatcherIsNotCalled()
         {
             _mockMatcher
-                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern.OriginalValue, _reRoutesConfig[0].UpstreamTemplatePattern.ContainsQueryString), Times.Never);
+                .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _reRoutesConfig[0].UpstreamTemplatePattern), Times.Never);
         }
 
         private void GivenTheUrlMatcherReturns(Response<UrlMatch> match)
         {
             _match = match;
             _mockMatcher
-                .Setup(x => x.Match(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Setup(x => x.Match(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UpstreamPathTemplate>()))
                 .Returns(_match);
         }
 

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
@@ -1,5 +1,6 @@
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Responses;
+using Ocelot.Values;
 using Shouldly;
 using TestStack.BDDfy;
 using Xunit;
@@ -270,7 +271,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
 
         private void WhenIMatchThePaths()
         {
-            _result = _urlMatcher.Match(_path, _queryString, _downstreamPathTemplate, _containsQueryString);
+            _result = _urlMatcher.Match(_path, _queryString, new UpstreamPathTemplate(_downstreamPathTemplate, 0, _containsQueryString, _downstreamPathTemplate));
         }
 
         private void ThenTheResultIsTrue()


### PR DESCRIPTION
This PR includes a change that represents a significant improvement in both memory allocation and Op/s for matching URLs for routing requests. This is achieved by compiling the Regex used to match a route at template construction time instead of on the fly with each request. This allows the regex engine to optimize the pattern matching quite a bit. There was a change to the signature for IUrlPathToUrlTemplateMatcher needed to achieve this, but it is functionally the same. All tests are passing, though many tests had to be modified to use the new signature. Benchmarks attached below.

Fixes / New Feature #

Performance enhancements.

## Proposed Changes

Prior to these changes, 3.29KB is allocated per request and 274K Op/s is achieved.
```

// * Summary *

BenchmarkDotNet=v0.10.14, OS=manjaro 
AMD Ryzen 7 2700U with Radeon Vega Mobile Gfx, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.500
  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT


   Method |     Mean |     Error |    StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |      Op/s | Scaled |  Gen 0 | Allocated |
--------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|----------:|-------:|-------:|----------:|
 Baseline | 3.643 us | 0.0096 us | 0.0085 us | 0.0023 us | 3.627 us | 3.636 us | 3.642 us | 3.651 us | 3.655 us | 274,525.0 |   1.00 | 6.4163 |   3.29 KB |
```

With these changes, only 96B is allocated per request and 10,876K Op/s is achieved.

```
// * Summary *

BenchmarkDotNet=v0.10.14, OS=manjaro 
AMD Ryzen 7 2700U with Radeon Vega Mobile Gfx, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.500
  [Host]     : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.6 (CoreCLR 4.6.27019.06, CoreFX 4.6.27019.05), 64bit RyuJIT


   Method |     Mean |    Error |   StdDev |    StdErr |      Min |       Q1 |   Median |       Q3 |      Max |         Op/s | Scaled |  Gen 0 | Allocated |
--------- |---------:|---------:|---------:|----------:|---------:|---------:|---------:|---------:|---------:|-------------:|-------:|-------:|----------:|
 Baseline | 91.94 ns | 1.862 ns | 4.773 ns | 0.5439 ns | 83.93 ns | 89.62 ns | 91.32 ns | 93.40 ns | 114.8 ns | 10,876,595.7 |   1.00 | 0.1826 |      96 B |
```