### PR TITLE
Fix code example for SSL Errors

### DIFF
--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -219,6 +219,6 @@ If you want to ignore SSL warnings / errors set the following in your ReRoute co
 
 .. code-block:: json
 
-    "DangerousAcceptAnyServerCertificateValidator": false
+    "DangerousAcceptAnyServerCertificateValidator": true
 
 I don't recommend doing this, I suggest creating your own certificate and then getting it trusted by your local / remote machine if you can.


### PR DESCRIPTION
Hello!:)

This is probably my smallest pull request ever. 😎
I just noticed that the code example for `DangerousAcceptAnyServerCertificateValidator` is broken. I hope it is fine that I didn't bother opening an issue first, this PR message is already about 2 orders of magnitude longer than the actual change I had to make to the rst. 😉 

## Proposed Changes
  - Fix the code example, show that `DangerousAcceptAnyServerCertificateValidator` has to be set to `true `to disable certification validation, rather than `false`.
