### PR TITLE
Ignore response content if null (fix #785)

### DIFF
--- a/src/Ocelot/Responder/HttpContextResponder.cs
+++ b/src/Ocelot/Responder/HttpContextResponder.cs
@@ -32,6 +32,15 @@ namespace Ocelot.Responder
                 AddHeaderIfDoesntExist(context, httpResponseHeader);
             }
 
+            SetStatusCode(context, (int)response.StatusCode);
+
+            context.Response.HttpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase = response.ReasonPhrase;
+
+            if (response.Content is null)
+            {
+                return;
+            }
+
             foreach (var httpResponseHeader in response.Content.Headers)
             {
                 AddHeaderIfDoesntExist(context, new Header(httpResponseHeader.Key, httpResponseHeader.Value));
@@ -43,10 +52,6 @@ namespace Ocelot.Responder
             {
                 AddHeaderIfDoesntExist(context, new Header("Content-Length", new []{ response.Content.Headers.ContentLength.ToString() }) );
             }
-
-            SetStatusCode(context, (int)response.StatusCode);
-
-            context.Response.HttpContext.Features.Get<IHttpResponseFeature>().ReasonPhrase = response.ReasonPhrase;
 
             using(content)
             {

--- a/test/Ocelot.UnitTests/Responder/HttpContextResponderTests.cs
+++ b/test/Ocelot.UnitTests/Responder/HttpContextResponderTests.cs
@@ -40,6 +40,23 @@ namespace Ocelot.UnitTests.Responder
         }
 
         [Fact]
+        public void should_ignore_content_if_null()
+        {
+            var httpContext = new DefaultHttpContext();
+            var response = new DownstreamResponse(null, HttpStatusCode.OK,
+                new List<KeyValuePair<string, IEnumerable<string>>>(), "some reason");
+
+            Should.NotThrow(() =>
+            {
+                _responder
+                    .SetResponseOnHttpContext(httpContext, response)
+                    .GetAwaiter()
+                    .GetResult()
+                ;
+            });
+        }
+
+        [Fact]
         public void should_have_content_length()
         {
             var httpContext = new DefaultHttpContext();


### PR DESCRIPTION
Fixes #785

## Proposed Changes

Ignore HttpResponse.Content in HttpContextResponder if Content is null