### PR TITLE
update cliamsParser

### DIFF
--- a/src/Ocelot/Infrastructure/Claims/Parser/ClaimsParser.cs
+++ b/src/Ocelot/Infrastructure/Claims/Parser/ClaimsParser.cs
@@ -1,6 +1,7 @@
 ﻿namespace Ocelot.Infrastructure.Claims.Parser
 {
-    using Microsoft.Extensions.Primitives;    using Responses;
+    using Microsoft.Extensions.Primitives;
+    using Responses;
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;

--- a/src/Ocelot/Infrastructure/Claims/Parser/ClaimsParser.cs
+++ b/src/Ocelot/Infrastructure/Claims/Parser/ClaimsParser.cs
@@ -1,7 +1,6 @@
 ﻿namespace Ocelot.Infrastructure.Claims.Parser
 {
-    using Errors;
-    using Responses;
+    using Microsoft.Extensions.Primitives;    using Responses;
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;
@@ -45,11 +44,11 @@
 
         private Response<string> GetValue(IEnumerable<Claim> claims, string key)
         {
-            var claim = claims.FirstOrDefault(c => c.Type == key);
+            var claimValues = claims.Where(c => c.Type == key).Select(c => c.Value).ToArray();
 
-            if (claim != null)
+            if (claimValues.Length > 0)
             {
-                return new OkResponse<string>(claim.Value);
+                return new OkResponse<string>(new StringValues(claimValues).ToString());
             }
 
             return new ErrorResponse<string>(new CannotFindClaimError($"Cannot find claim for key: {key}"));


### PR DESCRIPTION
Fixes / New Feature #

fixes #693 

I think it's more suitable to return a `StringValues` other than `string` for `IClaimsParser`,  because of header/query parameter type, but to be compatible with current api,  still return a string
