### PR TITLE
Fix: errors when using rate limiting

### DIFF
--- a/src/Ocelot/Errors/OcelotErrorCode.cs
+++ b/src/Ocelot/Errors/OcelotErrorCode.cs
@@ -37,6 +37,7 @@
         CouldNotFindPlaceholderError,
         CouldNotFindAggregatorError,
         CannotAddPlaceholderError,
-        CannotRemovePlaceholderError
+        CannotRemovePlaceholderError,
+        QuotaExceededError
     }
 }

--- a/src/Ocelot/RateLimit/Middleware/ClientRateLimitMiddleware.cs
+++ b/src/Ocelot/RateLimit/Middleware/ClientRateLimitMiddleware.cs
@@ -69,6 +69,9 @@ namespace Ocelot.RateLimit.Middleware
                     
                     // break execution
                     await ReturnQuotaExceededResponse(context.HttpContext, options, retrystring);
+                    
+                    // Set Error
+                    context.Errors.Add(new QuotaExceededError(this.GetResponseMessage(options)));
 
                     return;
                 }
@@ -117,7 +120,7 @@ namespace Ocelot.RateLimit.Middleware
         
         public virtual Task ReturnQuotaExceededResponse(HttpContext httpContext, RateLimitOptions option, string retryAfter)
         {
-            var message = string.IsNullOrEmpty(option.QuotaExceededMessage) ? $"API calls quota exceeded! maximum admitted {option.RateLimitRule.Limit} per {option.RateLimitRule.Period}." : option.QuotaExceededMessage;
+            var message = this.GetResponseMessage(option);
 
             if (!option.DisableRateLimitHeaders)
             {
@@ -126,6 +129,14 @@ namespace Ocelot.RateLimit.Middleware
 
             httpContext.Response.StatusCode = option.HttpStatusCode;
             return httpContext.Response.WriteAsync(message);
+        }
+
+        private string GetResponseMessage(RateLimitOptions option)
+        {
+            var message = string.IsNullOrEmpty(option.QuotaExceededMessage)
+                ? $"API calls quota exceeded! maximum admitted {option.RateLimitRule.Limit} per {option.RateLimitRule.Period}."
+                : option.QuotaExceededMessage;
+            return message;
         }
 
         private Task SetRateLimitHeaders(object rateLimitHeaders)

--- a/src/Ocelot/RateLimit/QuotaExceededError.cs
+++ b/src/Ocelot/RateLimit/QuotaExceededError.cs
@@ -1,0 +1,12 @@
+using Ocelot.Errors;
+
+namespace Ocelot.RateLimit
+{
+    public class QuotaExceededError : Error
+    {
+        public QuotaExceededError(string message)
+            : base(message, OcelotErrorCode.QuotaExceededError)
+        {
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -125,7 +125,7 @@ namespace Ocelot.UnitTests.Responder
             // If this test fails then it's because the number of error codes has changed.
             // You should make the appropriate changes to the test cases here to ensure
             // they cover all the error codes, and then modify this assertion.
-            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(36, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
+            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(37, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
         }
 
         private void ShouldMapErrorToStatusCode(OcelotErrorCode errorCode, HttpStatusCode expectedHttpStatusCode)


### PR DESCRIPTION


Fixes #659 

## Proposed Changes

- Add: QuotaExceededError class for requesting too much
- Add: QuotaExceededError error code
- Add: Add an error when limit is reached
- Reflact: Extract GetResponseMessage method for getting default or configured response message for requesting too much
