### PR TITLE
fix: Value must be greater than zero exception in Polly CircuitBreaker

### DIFF
--- a/src/Ocelot.Provider.Polly/CircuitBreaker.cs
+++ b/src/Ocelot.Provider.Polly/CircuitBreaker.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Linq;
+using Polly;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 
@@ -5,13 +8,16 @@ namespace Ocelot.Provider.Polly
 {
     public class CircuitBreaker
     {
-        public CircuitBreaker(CircuitBreakerPolicy circuitBreakerPolicy, TimeoutPolicy timeoutPolicy)
+        private readonly List<IAsyncPolicy> _policies = new List<IAsyncPolicy>();
+        
+        public CircuitBreaker(params IAsyncPolicy[] policies)
         {
-            CircuitBreakerPolicy = circuitBreakerPolicy;
-            TimeoutPolicy = timeoutPolicy;
+            foreach (var policy in policies.Where(p => p != null))
+            {
+                this._policies.Add(policy);
+            }
         }
-
-        public CircuitBreakerPolicy CircuitBreakerPolicy { get; private set; }
-        public TimeoutPolicy TimeoutPolicy { get; private set; }
+        
+        public IAsyncPolicy[] Policies => this._policies.ToArray();
     }
 }

--- a/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
@@ -25,7 +25,7 @@ namespace Ocelot.Provider.Polly
             try
             {
                 return await Policy
-                    .WrapAsync(_qoSProvider.CircuitBreaker.CircuitBreakerPolicy, _qoSProvider.CircuitBreaker.TimeoutPolicy)
+                    .WrapAsync(_qoSProvider.CircuitBreaker.Policies)
                     .ExecuteAsync(() => base.SendAsync(request,cancellationToken));
             }
             catch (BrokenCircuitException ex)


### PR DESCRIPTION
In [QoS Doc](https://ocelot.readthedocs.io/en/latest/features/qualityofservice.html), it says that I can only config `TimeoutValue` in `QoSOptions`, just like below:
```
"QoSOptions": {
    "TimeoutValue":5000
}
```
But when I did so, it triggered an exception said "Value must be greater than zero." in `PollyQoSProvider..ctor`, so I changed code that would not config CircuitBreaker if `ExceptionsAllowedBeforeBreaking` was not configured.