### PR TITLE
Make compatible with Steeltoe 2.2 libraries

### DIFF
--- a/src/Ocelot.Provider.Eureka/EurekaMiddlewareConfigurationProvider.cs
+++ b/src/Ocelot.Provider.Eureka/EurekaMiddlewareConfigurationProvider.cs
@@ -5,7 +5,7 @@
     using Configuration.Repository;
     using Microsoft.Extensions.DependencyInjection;
     using Middleware;
-    using Pivotal.Discovery.Client;
+    using Steeltoe.Discovery.Client;
 
     public class EurekaMiddlewareConfigurationProvider
     {

--- a/src/Ocelot.Provider.Eureka/Ocelot.Provider.Eureka.csproj
+++ b/src/Ocelot.Provider.Eureka/Ocelot.Provider.Eureka.csproj
@@ -29,7 +29,7 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Pivotal.Discovery.ClientCore" Version="2.0.1" />
+    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Ocelot.Provider.Eureka/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Eureka/OcelotBuilderExtensions.cs
@@ -5,7 +5,7 @@
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Middleware;
-    using Pivotal.Discovery.Client;
+    using Steeltoe.Discovery.Client;
     using ServiceDiscovery;
 
     public static class OcelotBuilderExtensions


### PR DESCRIPTION
Fixes / New Feature #
Bump up the version to be compatible with newer libraries due to the interface change. Pivotal.ServiceDiscovery packages are deprecated as they are now included as part of Steeltoe.ServiceDiscovery

