### PR TITLE
IOcelotPipelineBuilder.Use(): Return IOcelotPipelineBuilder

### DIFF
--- a/src/Ocelot/Middleware/Pipeline/IOcelotPipelineBuilder.cs
+++ b/src/Ocelot/Middleware/Pipeline/IOcelotPipelineBuilder.cs
@@ -9,7 +9,7 @@ namespace Ocelot.Middleware.Pipeline
     public interface IOcelotPipelineBuilder
     {
         IServiceProvider ApplicationServices { get; }
-        OcelotPipelineBuilder Use(Func<OcelotRequestDelegate, OcelotRequestDelegate> middleware);
+        IOcelotPipelineBuilder Use(Func<OcelotRequestDelegate, OcelotRequestDelegate> middleware);
         OcelotRequestDelegate Build();
         IOcelotPipelineBuilder New();
     }

--- a/src/Ocelot/Middleware/Pipeline/OcelotPipelineBuilder.cs
+++ b/src/Ocelot/Middleware/Pipeline/OcelotPipelineBuilder.cs
@@ -27,7 +27,7 @@ namespace Ocelot.Middleware.Pipeline
 
         public IServiceProvider ApplicationServices { get; }
 
-        public OcelotPipelineBuilder Use(Func<OcelotRequestDelegate, OcelotRequestDelegate> middleware)
+        public IOcelotPipelineBuilder Use(Func<OcelotRequestDelegate, OcelotRequestDelegate> middleware)
         {
             _middlewares.Add(middleware);
             return this;


### PR DESCRIPTION
Fixes ThreeMammals/Ocelot#685

## Proposed Changes

`IOcelotPipelineBuilder.Use()` should return `IOcelotPipelineBuilder`, not the concrete implementation `OcelotPipelineBuilder`

It currently returns the concrete class, which makes it impossible to replace the `OcelotPipelineBuilder`.

We have a use case where we want to use our own pipeline builder (because `OcelotPipelineBuilder` starts with setting the `StatusCode` to `404`, which is inconvenient), which currently is impossible.  The proposed change makes it possible to replace the default pipeline builder.

