### PR TITLE
add more flexible method to config ocelot pipeline

### DIFF
--- a/src/Ocelot/Middleware/OcelotMiddlewareExtensions.cs
+++ b/src/Ocelot/Middleware/OcelotMiddlewareExtensions.cs
@@ -1,22 +1,22 @@
 ﻿namespace Ocelot.Middleware
 {
-    using System;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Options;
-    using System.Diagnostics;
     using DependencyInjection;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Options;
     using Ocelot.Configuration;
     using Ocelot.Configuration.Creator;
     using Ocelot.Configuration.File;
     using Ocelot.Configuration.Repository;
     using Ocelot.Configuration.Setter;
-    using Ocelot.Responses;
     using Ocelot.Logging;
     using Ocelot.Middleware.Pipeline;
-    using Microsoft.Extensions.DependencyInjection;
+    using Ocelot.Responses;
+    using System;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading.Tasks;
 
     public static class OcelotMiddlewareExtensions
     {
@@ -40,6 +40,30 @@
             ConfigureDiagnosticListener(builder);
 
             return CreateOcelotPipeline(builder, pipelineConfiguration);
+        }
+
+        public static Task<IApplicationBuilder> UseOcelot(this IApplicationBuilder app, Action<IOcelotPipelineBuilder, OcelotPipelineConfiguration> builderAction)
+            => UseOcelot(app, builderAction, new OcelotPipelineConfiguration());
+
+        public static async Task<IApplicationBuilder> UseOcelot(this IApplicationBuilder app, Action<IOcelotPipelineBuilder, OcelotPipelineConfiguration> builderAction, OcelotPipelineConfiguration configuration)
+        {
+            await CreateConfiguration(app);  // initConfiguration
+
+            ConfigureDiagnosticListener(app);
+
+            var ocelotPipelineBuilder = new OcelotPipelineBuilder(app.ApplicationServices);
+            builderAction?.Invoke(ocelotPipelineBuilder, configuration ?? new OcelotPipelineConfiguration());
+
+            var ocelotDelegate = ocelotPipelineBuilder.Build();
+            app.Properties["analysis.NextMiddlewareName"] = "TransitionToOcelotMiddleware";
+
+            app.Use(async (context, task) =>
+            {
+                var downstreamContext = new DownstreamContext(context);
+                await ocelotDelegate.Invoke(downstreamContext);
+            });
+
+            return app;
         }
 
         private static IApplicationBuilder CreateOcelotPipeline(IApplicationBuilder builder, OcelotPipelineConfiguration pipelineConfiguration)


### PR DESCRIPTION
it's not so easy to custom ocelot pipeline for now, added an extension method to make it easier

with this, you can config ocelot pipeline like this:

``` csharp
app.UseOcelot((builder, pipelineConfiguration) =>
                {
                    // This is registered to catch any global exceptions that are not handled
                    // It also sets the Request Id if anything is set globally
                    builder.UseExceptionHandlerMiddleware();
                    // Allow the user to respond with absolutely anything they want.
                    builder.UseIfNotNull(pipelineConfiguration.PreErrorResponderMiddleware);
                    // This is registered first so it can catch any errors and issue an appropriate response
                    builder.UseResponderMiddleware();
                    builder.UseDownstreamRouteFinderMiddleware();
                    builder.UseDownstreamRequestInitialiser();
                    builder.UseRequestIdMiddleware();
                    builder.UseMiddleware<UrlBasedAuthenticationMiddleware>();
                    // use custom middleware to transform roles
                    builder.UseMiddleware<ClaimsToRequestHeaderMiddleware>();
                    builder.UseLoadBalancingMiddleware();
                    builder.UseDownstreamUrlCreatorMiddleware();
                    builder.UseOutputCacheMiddleware();
                    builder.UseMiddleware<HttpRequesterMiddleware>();
                })
                .Wait();
```
