### PR TITLE
Fixed Typo and formatting

### DIFF
--- a/docs/features/ratelimiting.rst
+++ b/docs/features/ratelimiting.rst
@@ -18,9 +18,13 @@ OK so to get rate limiting working for a ReRoute you need to add the following j
     }  
 
 ClientWhitelist - This is an array that contains the whitelist of the client. It means that the client in this array will not be affected by the rate limiting.
+
 EnableRateLimiting - This value specifies enable endpoint rate limiting.
+
 Period - This value specifies the period that the limit applies to, such as 1s, 5m, 1h,1d and so on. If you make more requests in the period than the limit allows then you need to wait for PeriodTimespan to elapse before you make another request.
+
 PeriodTimespan - This value specifies that we can retry after a certain number of seconds.
+
 Limit - This value specifies the maximum number of requests that a client can make in a defined period.
 
 You can also set the following in the GlobalConfiguration part of ocelot.json
@@ -34,7 +38,10 @@ You can also set the following in the GlobalConfiguration part of ocelot.json
       "ClientIdHeader" : "Test"
     }  
 
-DisableRateLimitHeaders - This value specifies whether X-Rate-Limit and Rety-After headers are disabled.
+DisableRateLimitHeaders - This value specifies whether X-Rate-Limit and Retry-After headers are disabled.
+
 QuotaExceededMessage - This value specifies the exceeded message.
+
 HttpStatusCode - This value specifies the returned HTTP Status code when rate limiting occurs.
+
 ClientIdHeader - Allows you to specifiy the header that should be used to identify clients. By default it is "ClientId"


### PR DESCRIPTION
Changes done:
- Fixed typo: `Rety-After` to `Retry-After`
- Updated formatting for better readability
