### PR TITLE
Update qualityofservice.rst

### DIFF
--- a/docs/features/qualityofservice.rst
+++ b/docs/features/qualityofservice.rst
@@ -26,15 +26,15 @@ Then add the following section to a ReRoute configuration.
 
     "QoSOptions": {
         "ExceptionsAllowedBeforeBreaking":3,
-        "DurationOfBreak":5,
+        "DurationOfBreak":1000,
         "TimeoutValue":5000
     }
 
 You must set a number greater than 0 against ExceptionsAllowedBeforeBreaking for this rule to be 
-implemented. Duration of break is how long the circuit breaker will stay open for after it is tripped.
+implemented. Duration of break means the circuit breaker will stay open for 1 second after it is tripped.
 TimeoutValue means if a request takes more than 5 seconds it will automatically be timed out. 
 
-You can set the TimeoutValue in isoldation of the ExceptionsAllowedBeforeBreaking and DurationOfBreak options. 
+You can set the TimeoutValue in isolation of the ExceptionsAllowedBeforeBreaking and DurationOfBreak options. 
 
 .. code-block:: json
 


### PR DESCRIPTION
- Fixed typo, corrected spelling for isolation
- Updated `QoSOptions` example by setting the `DurationOfBreak` to 1000 ms instead of 5 ms. Also, updated the explanation for `DurationOfBreak` since it was not clear from the documentation that `DurationOfBreak` is in ms. From example, it appear to be required to set in second which is not the case.