### PR TITLE
Updated Consul discovery to resolve hostname

### DIFF
--- a/src/Ocelot.Provider.Consul/Consul.cs
+++ b/src/Ocelot.Provider.Consul/Consul.cs
@@ -35,8 +35,15 @@
                 if (IsValid(serviceEntry))
                 {
                     var nodes = await _consul.Catalog.Nodes();
-                    var serviceNode = nodes.Response.FirstOrDefault(n => n.Address == serviceEntry.Service.Address);
-                    services.Add(BuildService(serviceEntry, serviceNode));
+                    if (nodes.Response == null)
+                    {
+                        services.Add(BuildService(serviceEntry, null));
+                    }
+                    else
+                    {
+                        var serviceNode = nodes.Response.FirstOrDefault(n => n.Address == serviceEntry.Service.Address);
+                        services.Add(BuildService(serviceEntry, serviceNode));
+                    }
                 }
                 else
                 {

--- a/src/Ocelot.Provider.Consul/Consul.cs
+++ b/src/Ocelot.Provider.Consul/Consul.cs
@@ -34,7 +34,9 @@
             {
                 if (IsValid(serviceEntry))
                 {
-                    services.Add(BuildService(serviceEntry));
+                    var nodes = await _consul.Catalog.Nodes();
+                    var serviceNode = nodes.Response.FirstOrDefault(n => n.Address == serviceEntry.Service.Address);
+                    services.Add(BuildService(serviceEntry, serviceNode));
                 }
                 else
                 {
@@ -45,11 +47,11 @@
             return services.ToList();
         }
 
-        private Service BuildService(ServiceEntry serviceEntry)
+        private Service BuildService(ServiceEntry serviceEntry, Node serviceNode)
         {
             return new Service(
                 serviceEntry.Service.Service,
-                new ServiceHostAndPort(serviceEntry.Service.Address, serviceEntry.Service.Port),
+                new ServiceHostAndPort(serviceNode == null ? serviceEntry.Service.Address : serviceNode.Name, serviceEntry.Service.Port),
                 serviceEntry.Service.ID,
                 GetVersionFromStrings(serviceEntry.Service.Tags),
                 serviceEntry.Service.Tags ?? Enumerable.Empty<string>());


### PR DESCRIPTION
Consul services fail SSL certificate validation since they are only associated with address instead of hostname.

Consul service discovery now registers discovered service with hostname resolved with Consul node list.