### PR TITLE
Fix incorrect command rendered

### DIFF
--- a/docs/features/kubernetes.rst
+++ b/docs/features/kubernetes.rst
@@ -25,7 +25,7 @@ If you have services deployed in kubernetes you will normally use the naming ser
 You can replicate a Permissive. Using RBAC role bindings.
 `Permissive RBAC Permissions <https://kubernetes.io/docs/reference/access-authn-authz/rbac/#permissive-rbac-permissions>`_, k8s api server and token will read from pod .
 
-.. code-block::json
+.. code-block::bash
 kubectl create clusterrolebinding permissive-binding  --clusterrole=cluster-admin  --user=admin  --user=kubelet --group=system:serviceaccounts
 
 The following example shows how to set up a ReRoute that will work in kubernetes. The most important thing is the ServiceName which is made up of the 


### PR DESCRIPTION
When you read docs the command about enabling RBAC permissions for Kubernetes integration are badly rendered.

Fixes / New Feature #
Fix error displaying incorrect command on official site.

## Proposed Changes

  - Change from code snippet json to bash to improve readability
