### PR TITLE
Upstream header routing

### DIFF
--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -3,9 +3,9 @@ Routing
 
 Ocelot's primary functionality is to take incoming http requests and forward them on
 to a downstream service. Ocelot currently only supports this in the form of another http request (in the future
-this could be any transport mechanism). 
+this could be any transport mechanism).
 
-Ocelot's describes the routing of one request to another as a ReRoute. In order to get 
+Ocelot's describes the routing of one request to another as a ReRoute. In order to get
 anything working in Ocelot you need to set up a ReRoute in the configuration.
 
 .. code-block:: json
@@ -32,18 +32,18 @@ To configure a ReRoute you need to add one to the ReRoutes json array.
         "UpstreamHttpMethod": [ "Put", "Delete" ]
     }
 
-The DownstreamPathTemplate, DownstreamScheme and DownstreamHostAndPorts define the URL that a request will be forwarded to. 
+The DownstreamPathTemplate, DownstreamScheme and DownstreamHostAndPorts define the URL that a request will be forwarded to.
 
-DownstreamHostAndPorts is a collection that defines the host and port of any downstream services that you wish to forward requests to. 
+DownstreamHostAndPorts is a collection that defines the host and port of any downstream services that you wish to forward requests to.
 Usually this will just contain a single entry but sometimes you might want to load balance requests to your downstream services and Ocelot allows you add more than one entry and then select a load balancer.
 
-The UpstreamPathTemplate is the URL that Ocelot will use to identify which DownstreamPathTemplate to use for a given request. 
-The UpstreamHttpMethod is used so Ocelot can distinguish between requests with different HTTP verbs to the same URL. You can set a specific list of HTTP Methods or set an empty list to allow any of them. 
+The UpstreamPathTemplate is the URL that Ocelot will use to identify which DownstreamPathTemplate to use for a given request.
+The UpstreamHttpMethod is used so Ocelot can distinguish between requests with different HTTP verbs to the same URL. You can set a specific list of HTTP Methods or set an empty list to allow any of them.
 
 In Ocelot you can add placeholders for variables to your Templates in the form of {something}.
 The placeholder variable needs to be present in both the DownstreamPathTemplate and UpstreamPathTemplate properties. When it is Ocelot will attempt to substitute the value in the UpstreamPathTemplate placeholder into the DownstreamPathTemplate for each request Ocelot processes.
 
-You can also do a catch all type of ReRoute e.g. 
+You can also do a catch all type of ReRoute e.g.
 
 .. code-block:: json
 
@@ -72,7 +72,7 @@ In order to change this you can specify on a per ReRoute basis the following set
     "ReRouteIsCaseSensitive": true
 
 This means that when Ocelot tries to match the incoming upstream url with an upstream template the
-evaluation will be case sensitive. 
+evaluation will be case sensitive.
 
 Catch All
 ^^^^^^^^^
@@ -96,7 +96,7 @@ If you set up your config like below, all requests will be proxied straight thro
         "UpstreamHttpMethod": [ "Get" ]
     }
 
-The catch all has a lower priority than any other ReRoute. If you also have the ReRoute below in your config then Ocelot would match it before the catch all. 
+The catch all has a lower priority than any other ReRoute. If you also have the ReRoute below in your config then Ocelot would match it before the catch all.
 
 .. code-block:: json
 
@@ -113,7 +113,7 @@ The catch all has a lower priority than any other ReRoute. If you also have the 
         "UpstreamHttpMethod": [ "Get" ]
     }
 
-Upstream Host 
+Upstream Host
 ^^^^^^^^^^^^^
 
 This feature allows you to have ReRoutes based on the upstream host. This works by looking at the host header the client has used and then using this as part of the information we use to identify a ReRoute.
@@ -138,7 +138,7 @@ In order to use this feature please add the following to your config.
 
 The ReRoute above will only be matched when the host header value is somedomain.com.
 
-If you do not set UpstreamHost on a ReRoute then any host header will match it. This means that if you have two ReRoutes that are the same, apart from the UpstreamHost, where one is null and the other set Ocelot will favour the one that has been set. 
+If you do not set UpstreamHost on a ReRoute then any host header will match it. This means that if you have two ReRoutes that are the same, apart from the UpstreamHost, where one is null and the other set Ocelot will favour the one that has been set.
 
 This feature was requested as part of `Issue 216 <https://github.com/ThreeMammals/Ocelot/pull/216>`_ .
 
@@ -166,7 +166,7 @@ e.g. you could have
         "Priority": 0
     }
 
-and 
+and
 
 .. code-block:: json
 
@@ -181,9 +181,9 @@ matched /goods/{catchAll} (because this is the first ReRoute in the list!).
 Dynamic Routing
 ^^^^^^^^^^^^^^^
 
-This feature was requested in `issue 340 <https://github.com/ThreeMammals/Ocelot/issues/340>`_. 
+This feature was requested in `issue 340 <https://github.com/ThreeMammals/Ocelot/issues/340>`_.
 
-The idea is to enable dynamic routing when using a service discovery provider so you don't have to provide the ReRoute config. See the docs :ref:`service-discovery` if 
+The idea is to enable dynamic routing when using a service discovery provider so you don't have to provide the ReRoute config. See the docs :ref:`service-discovery` if
 this sounds interesting to you.
 
 Query Strings
@@ -241,5 +241,38 @@ Ocelot will also allow you to put query string parameters in the UpstreamPathTem
         }
     }
 
-In this example Ocelot will only match requests that have a matching url path and the query string starts with unitId=something. You can have other queries after this
-but you must start with the matching parameter. Also Ocelot will swap the {unitId} parameter from the query string and use it in the downstream request path. 
+In this example Ocelot will only match requests that have a matching url path and the query string starts with unitId=something. You can have other queries after this but you must start with the matching parameter. Also Ocelot will swap the {unitId} parameter from the query string and use it in the downstream request path.
+
+Upstream header-based routing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This feature was requested in `issue 360 <https://github.com/ThreeMammals/Ocelot/issues/360>`_ and `issue 624 <https://github.com/ThreeMammals/Ocelot/issues/624>`_.
+
+Ocelot allows you to define a ReRoute with upstream headers, each of which may define a set of accepted values. If a ReRoute has a set of upstream headers defined in it, it will no longer match a request's upstream path based solely on upstream path template. The request must also contain one or more headers required by the ReRoute for a match.
+
+A sample configuration might look like the following:
+
+.. code-block:: json
+
+    {
+        "ReRoutes": [
+            {
+                "UpstreamHeaderRoutingOptions": {
+                    "Headers": {
+                        "X-API-Version": [ "1", "2" ],
+                        "X-Tennant-Id": [ "tennantId" ]
+                    },
+                    "CombinationMode": "all"
+                }
+            }
+        ]
+    }
+
+The ``UpstreamHeaderRoutingOptions`` block defines two attributes -- the ``Headers`` block and the ``CombinationMode`` attribute. The ``Headers`` attribute defines required header names as keys and lists of acceptable header values as values. During route matching, both header names and values are matched in *case insensitive* manner. Please note that if a header has more than one acceptable value configured, presence of any of those values in a request is sufficient for a header to be a match.
+
+The second attribute, ``CombinationMode``, defines how the route finder will determine whether a particular header configuration in a request matches a ReRoute's header configuration. The attribute accepts two values:
+
+* ``"Any"`` causes the route finder to match a ReRoute if any value of any configured header is present in a request
+* ``"All"`` causes the route finder to match a ReRoute only if any value of *all* configured headers is present in a request
+
+The value for this attribute is case-insensitive and, if not specified, ``"Any"`` is used as the default.

--- a/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/ReRouteBuilder.cs
@@ -14,6 +14,7 @@
         private List<DownstreamReRoute> _downstreamReRoutes;
         private List<AggregateReRouteConfig> _downstreamReRoutesConfig;
         private string _aggregator;
+        private UpstreamHeaderRoutingOptions _upstreamHeaderRoutingOptions;
 
         public ReRouteBuilder()
         {
@@ -63,6 +64,12 @@
             return this;
         }
 
+        public ReRouteBuilder WithUpstreamHeaderRoutingOptions(UpstreamHeaderRoutingOptions routingOptions)
+        {
+            _upstreamHeaderRoutingOptions = routingOptions;
+            return this;
+        }
+
         public ReRoute Build()
         {
             return new ReRoute(
@@ -71,8 +78,8 @@
                 _upstreamHttpMethod,
                 _upstreamTemplatePattern,
                 _upstreamHost,
-                _aggregator
-                );
+                _aggregator,
+                _upstreamHeaderRoutingOptions);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/IUpstreamHeaderRoutingOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IUpstreamHeaderRoutingOptionsCreator.cs
@@ -1,0 +1,9 @@
+using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration.Creator
+{
+    public interface IUpstreamHeaderRoutingOptionsCreator
+    {
+        UpstreamHeaderRoutingOptions Create(FileUpstreamHeaderRoutingOptions options);
+    }
+}

--- a/src/Ocelot/Configuration/Creator/ReRoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ReRoutesCreator.cs
@@ -22,6 +22,7 @@ namespace Ocelot.Configuration.Creator
         private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
         private readonly IReRouteKeyCreator _reRouteKeyCreator;
         private readonly ISecurityOptionsCreator _securityOptionsCreator;
+        private readonly IUpstreamHeaderRoutingOptionsCreator _upstreamHeaderRoutingOptionsCreator;
 
         public ReRoutesCreator(
             IClaimsToThingCreator claimsToThingCreator,
@@ -37,7 +38,8 @@ namespace Ocelot.Configuration.Creator
             IDownstreamAddressesCreator downstreamAddressesCreator,
             ILoadBalancerOptionsCreator loadBalancerOptionsCreator,
             IReRouteKeyCreator reRouteKeyCreator,
-            ISecurityOptionsCreator securityOptionsCreator
+            ISecurityOptionsCreator securityOptionsCreator,
+            IUpstreamHeaderRoutingOptionsCreator upstreamHeaderRoutingOptionsCreator
             )
         {
             _reRouteKeyCreator = reRouteKeyCreator;
@@ -55,6 +57,7 @@ namespace Ocelot.Configuration.Creator
             _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
             _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
             _securityOptionsCreator = securityOptionsCreator;
+            _upstreamHeaderRoutingOptionsCreator = upstreamHeaderRoutingOptionsCreator;
         }
 
         public List<ReRoute> Create(FileConfiguration fileConfiguration)
@@ -144,11 +147,14 @@ namespace Ocelot.Configuration.Creator
         {
             var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileReRoute);
 
+            var upstreamHeaderRoutingOptions = _upstreamHeaderRoutingOptionsCreator.Create(fileReRoute.UpstreamHeaderRoutingOptions);
+
             var reRoute = new ReRouteBuilder()
                 .WithUpstreamHttpMethod(fileReRoute.UpstreamHttpMethod)
                 .WithUpstreamPathTemplate(upstreamTemplatePattern)
                 .WithDownstreamReRoute(downstreamReRoutes)
                 .WithUpstreamHost(fileReRoute.UpstreamHost)
+                .WithUpstreamHeaderRoutingOptions(upstreamHeaderRoutingOptions)
                 .Build();
 
             return reRoute;

--- a/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
@@ -16,7 +16,8 @@ namespace Ocelot.Configuration.Creator
                     Enum.Parse(typeof(UpstreamHeaderRoutingCombinationMode), options.CombinationMode, true);
             }
 
-            Dictionary<string, HashSet<string>> headers = options.Headers.ToDictionary(kv => kv.Key.ToLowerInvariant(), kv => kv.Value);
+            Dictionary<string, HashSet<string>> headers = options.Headers.ToDictionary(
+                kv => kv.Key.ToLowerInvariant(), kv => new HashSet<string>(kv.Value));
 
             return new UpstreamHeaderRoutingOptions(headers, mode);
         }

--- a/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration.Creator
+{
+    public class UpstreamHeaderRoutingOptionsCreator : IUpstreamHeaderRoutingOptionsCreator
+    {
+        public UpstreamHeaderRoutingOptions Create(FileUpstreamHeaderRoutingOptions options)
+        {
+            UpstreamHeaderRoutingCombinationMode mode = UpstreamHeaderRoutingCombinationMode.Any;
+            if (options.CombinationMode.Length > 0)
+            {
+                mode = (UpstreamHeaderRoutingCombinationMode)
+                    Enum.Parse(typeof(UpstreamHeaderRoutingCombinationMode), options.CombinationMode, true);
+            }
+
+            Dictionary<string, HashSet<string>> headers = options.Headers.ToDictionary(kv => kv.Key.ToLowerInvariant(), kv => kv.Value);
+
+            return new UpstreamHeaderRoutingOptions(headers, mode);
+        }
+    }
+}

--- a/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamHeaderRoutingOptionsCreator.cs
@@ -17,7 +17,8 @@ namespace Ocelot.Configuration.Creator
             }
 
             Dictionary<string, HashSet<string>> headers = options.Headers.ToDictionary(
-                kv => kv.Key.ToLowerInvariant(), kv => new HashSet<string>(kv.Value));
+                kv => kv.Key.ToLowerInvariant(),
+                kv => new HashSet<string>(kv.Value.Select(v => v.ToLowerInvariant())));
 
             return new UpstreamHeaderRoutingOptions(headers, mode);
         }

--- a/src/Ocelot/Configuration/File/FileReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileReRoute.cs
@@ -22,6 +22,7 @@ namespace Ocelot.Configuration.File
             DelegatingHandlers = new List<string>();
             LoadBalancerOptions = new FileLoadBalancerOptions();
             SecurityOptions = new FileSecurityOptions();
+            UpstreamHeaderRoutingOptions = new FileUpstreamHeaderRoutingOptions();
             Priority = 1;
         }
 
@@ -53,5 +54,6 @@ namespace Ocelot.Configuration.File
         public int Timeout { get; set; }
         public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
         public FileSecurityOptions SecurityOptions { get; set; }
+        public FileUpstreamHeaderRoutingOptions UpstreamHeaderRoutingOptions { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileUpstreamHeaderRoutingOptions.cs
+++ b/src/Ocelot/Configuration/File/FileUpstreamHeaderRoutingOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Ocelot.Configuration.File
+{
+    public class FileUpstreamHeaderRoutingOptions
+    {
+        public FileUpstreamHeaderRoutingOptions()
+        {
+            Headers = new Dictionary<string, List<string>>();
+            CombinationMode = "";
+        }
+
+        public Dictionary<string, List<string>> Headers { get; set; }
+
+        public string CombinationMode { get; set; }
+    }
+}

--- a/src/Ocelot/Configuration/ReRoute.cs
+++ b/src/Ocelot/Configuration/ReRoute.cs
@@ -12,7 +12,8 @@
             List<HttpMethod> upstreamHttpMethod,
             UpstreamPathTemplate upstreamTemplatePattern,
             string upstreamHost,
-            string aggregator)
+            string aggregator,
+            UpstreamHeaderRoutingOptions upstreamHeaderRoutingOptions)
         {
             UpstreamHost = upstreamHost;
             DownstreamReRoute = downstreamReRoute;
@@ -20,6 +21,7 @@
             UpstreamHttpMethod = upstreamHttpMethod;
             UpstreamTemplatePattern = upstreamTemplatePattern;
             Aggregator = aggregator;
+            UpstreamHeaderRoutingOptions = upstreamHeaderRoutingOptions;
         }
 
         public UpstreamPathTemplate UpstreamTemplatePattern { get; private set; }
@@ -28,5 +30,6 @@
         public List<DownstreamReRoute> DownstreamReRoute { get; private set; }
         public List<AggregateReRouteConfig> DownstreamReRouteConfig { get; private set; }
         public string Aggregator { get; private set; }
+        public UpstreamHeaderRoutingOptions UpstreamHeaderRoutingOptions { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/UpstreamHeaderRoutingCombinationMode.cs
+++ b/src/Ocelot/Configuration/UpstreamHeaderRoutingCombinationMode.cs
@@ -1,0 +1,8 @@
+namespace Ocelot.Configuration
+{
+    public enum UpstreamHeaderRoutingCombinationMode
+    {
+        Any = 0,
+        All = 1,
+    }
+}

--- a/src/Ocelot/Configuration/UpstreamHeaderRoutingOptions.cs
+++ b/src/Ocelot/Configuration/UpstreamHeaderRoutingOptions.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Ocelot.Configuration
+{
+    public class UpstreamHeaderRoutingOptions
+    {
+        public UpstreamHeaderRoutingOptions(Dictionary<string, HashSet<string>> headers, UpstreamHeaderRoutingCombinationMode mode)
+        {
+            Headers = new UpstreamRoutingHeaders(headers);
+            Mode = mode;
+        }
+
+        public UpstreamRoutingHeaders Headers { get; private set; }
+
+        public UpstreamHeaderRoutingCombinationMode Mode { get; private set; }
+    }
+}

--- a/src/Ocelot/Configuration/UpstreamHeaderRoutingOptions.cs
+++ b/src/Ocelot/Configuration/UpstreamHeaderRoutingOptions.cs
@@ -10,6 +10,8 @@ namespace Ocelot.Configuration
             Mode = mode;
         }
 
+        public bool Enabled() => !Headers.Empty();
+
         public UpstreamRoutingHeaders Headers { get; private set; }
 
         public UpstreamHeaderRoutingCombinationMode Mode { get; private set; }

--- a/src/Ocelot/Configuration/UpstreamRoutingHeaders.cs
+++ b/src/Ocelot/Configuration/UpstreamRoutingHeaders.cs
@@ -48,6 +48,40 @@ namespace Ocelot.Configuration
             return true;
         }
 
-        private Dictionary<string, HashSet<string>> Headers;
+        public override bool Equals(object obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+
+            if (!(obj is UpstreamRoutingHeaders))
+            {
+                return false;
+            }
+
+            UpstreamRoutingHeaders another = (UpstreamRoutingHeaders)obj;
+            if (Headers.Count != another.Headers.Count)
+            {
+                return false;
+            }
+
+            foreach (var item in Headers)
+            {
+                if (!another.Headers.TryGetValue(item.Key, out var anotherValue))
+                {
+                    return false;
+                }
+
+                if (!item.Value.SetEquals(anotherValue))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public Dictionary<string, HashSet<string>> Headers { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/UpstreamRoutingHeaders.cs
+++ b/src/Ocelot/Configuration/UpstreamRoutingHeaders.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace Ocelot.Configuration
+{
+    public class UpstreamRoutingHeaders
+    {
+        public UpstreamRoutingHeaders(Dictionary<string, HashSet<string>> headers)
+        {
+            Headers = headers;
+        }
+
+        public bool Empty() => Headers.Count == 0;
+
+        public bool HasAnyOf(IHeaderDictionary requestHeaders)
+        {
+            foreach (KeyValuePair<string, HashSet<string>> h in Headers)
+            {
+                if (requestHeaders.TryGetValue(h.Key, out var values))
+                {
+                    HashSet<string> requestHeaderValues = new HashSet<string>(values);
+                    if (h.Value.Overlaps(requestHeaderValues))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool HasAllOf(IHeaderDictionary requestHeaders)
+        {
+            foreach (KeyValuePair<string, HashSet<string>> h in Headers)
+            {
+                if (!requestHeaders.TryGetValue(h.Key, out var values))
+                {
+                    return false;
+                }
+
+                HashSet<string> requestHeaderValues = new HashSet<string>(values);
+                if (!h.Value.Overlaps(requestHeaderValues))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private Dictionary<string, HashSet<string>> Headers;
+    }
+}

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -72,6 +72,7 @@ namespace Ocelot.DependencyInjection
             Services.TryAddSingleton<IClaimsToThingCreator, ClaimsToThingCreator>();
             Services.TryAddSingleton<IAuthenticationOptionsCreator, AuthenticationOptionsCreator>();
             Services.TryAddSingleton<IUpstreamTemplatePatternCreator, UpstreamTemplatePatternCreator>();
+            Services.TryAddSingleton<IUpstreamHeaderRoutingOptionsCreator, UpstreamHeaderRoutingOptionsCreator>();
             Services.TryAddSingleton<IRequestIdKeyCreator, RequestIdKeyCreator>();
             Services.TryAddSingleton<IServiceProviderConfigurationCreator, ServiceProviderConfigurationCreator>();
             Services.TryAddSingleton<IQoSOptionsCreator, QoSOptionsCreator>();

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteCreator.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteCreator.cs
@@ -8,6 +8,7 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.AspNetCore.Http;
     using UrlMatcher;
 
     public class DownstreamRouteCreator : IDownstreamRouteProvider
@@ -21,7 +22,13 @@
             _cache = new ConcurrentDictionary<string, OkResponse<DownstreamRoute>>();
         }
 
-        public Response<DownstreamRoute> Get(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost)
+        public Response<DownstreamRoute> Get(
+            string upstreamUrlPath,
+            string upstreamQueryString,
+            string upstreamHttpMethod,
+            IInternalConfiguration configuration,
+            string upstreamHost,
+            IHeaderDictionary requestHeaders)
         {
             var serviceName = GetServiceName(upstreamUrlPath);
 

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -57,7 +57,7 @@ namespace Ocelot.DownstreamRouteFinder.Finder
         {
             return (reRoute.UpstreamHttpMethod.Count == 0 || RouteHasHttpMethod(reRoute, httpMethod)) &&
                    (string.IsNullOrEmpty(reRoute.UpstreamHost) || reRoute.UpstreamHost == upstreamHost) &&
-                   (reRoute.UpstreamHeaderRoutingOptions.Headers.Empty() || RouteHasRequiredUpstreamHeaders(reRoute, requestHeaders));
+                   (reRoute.UpstreamHeaderRoutingOptions == null || !reRoute.UpstreamHeaderRoutingOptions.Enabled() || RouteHasRequiredUpstreamHeaders(reRoute, requestHeaders));
         }
 
         private bool RouteHasHttpMethod(ReRoute reRoute, string httpMethod)

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -67,15 +67,18 @@ namespace Ocelot.DownstreamRouteFinder.Finder
 
         private bool RouteHasRequiredUpstreamHeaders(ReRoute reRoute, IHeaderDictionary requestHeaders)
         {
+            bool result = false;
             switch (reRoute.UpstreamHeaderRoutingOptions.Mode)
             {
                 case UpstreamHeaderRoutingCombinationMode.Any:
-                    return reRoute.UpstreamHeaderRoutingOptions.Headers.HasAnyOf(requestHeaders);
+                    result = reRoute.UpstreamHeaderRoutingOptions.Headers.HasAnyOf(requestHeaders);
+                    break;
                 case UpstreamHeaderRoutingCombinationMode.All:
-                    return reRoute.UpstreamHeaderRoutingOptions.Headers.HasAllOf(requestHeaders);
+                    result = reRoute.UpstreamHeaderRoutingOptions.Headers.HasAllOf(requestHeaders);
+                    break;
             }
 
-            return false;
+            return result;
         }
 
         private DownstreamRoute GetPlaceholderNamesAndValues(string path, string query, ReRoute reRoute)

--- a/src/Ocelot/DownstreamRouteFinder/Finder/IDownstreamRouteProvider.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/IDownstreamRouteProvider.cs
@@ -1,10 +1,17 @@
 ﻿using Ocelot.Configuration;
 using Ocelot.Responses;
+using Microsoft.AspNetCore.Http;
 
 namespace Ocelot.DownstreamRouteFinder.Finder
 {
     public interface IDownstreamRouteProvider
     {
-        Response<DownstreamRoute> Get(string upstreamUrlPath, string upstreamQueryString, string upstreamHttpMethod, IInternalConfiguration configuration, string upstreamHost);
+        Response<DownstreamRoute> Get(
+            string upstreamUrlPath,
+            string upstreamQueryString,
+            string upstreamHttpMethod,
+            IInternalConfiguration configuration,
+            string upstreamHost,
+            IHeaderDictionary requestHeaders);
     }
 }

--- a/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
@@ -37,7 +37,11 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
             var provider = _factory.Get(context.Configuration);
 
-            var downstreamRoute = provider.Get(upstreamUrlPath, upstreamQueryString, context.HttpContext.Request.Method, context.Configuration, upstreamHost);
+            var downstreamRoute = provider.Get(
+                upstreamUrlPath, upstreamQueryString,
+                context.HttpContext.Request.Method,
+                context.Configuration, upstreamHost,
+                context.HttpContext.Request.Headers);
 
             if (downstreamRoute.IsError)
             {

--- a/test/Ocelot.UnitTests/Configuration/ReRoutesCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/ReRoutesCreatorTests.cs
@@ -30,6 +30,7 @@
         private Mock<ILoadBalancerOptionsCreator> _lboCreator;
         private Mock<IReRouteKeyCreator> _rrkCreator;
         private Mock<ISecurityOptionsCreator> _soCreator;
+        private Mock<IUpstreamHeaderRoutingOptionsCreator> _uhroCreator;
         private FileConfiguration _fileConfig;
         private ReRouteOptions _rro;
         private string _requestId;
@@ -46,6 +47,7 @@
         private LoadBalancerOptions _lbo;
         private List<ReRoute> _result;
         private SecurityOptions _securityOptions;
+        private UpstreamHeaderRoutingOptions _upstreamHeaderRoutingOptions;
 
         public ReRoutesCreatorTests()
         {
@@ -63,6 +65,7 @@
             _lboCreator = new Mock<ILoadBalancerOptionsCreator>();
             _rrkCreator = new Mock<IReRouteKeyCreator>();
             _soCreator = new Mock<ISecurityOptionsCreator>();
+            _uhroCreator = new Mock<IUpstreamHeaderRoutingOptionsCreator>();
 
             _creator = new ReRoutesCreator(
                 _cthCreator.Object,
@@ -78,7 +81,8 @@
                 _daCreator.Object,
                 _lboCreator.Object,
                 _rrkCreator.Object,
-                _soCreator.Object
+                _soCreator.Object,
+                _uhroCreator.Object
                 );
         }
 

--- a/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
@@ -1,8 +1,64 @@
+using System.Collections.Generic;
+using Ocelot.Configuration.File;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration;
+using Xunit;
+using TestStack.BDDfy;
+using Shouldly;
 
 namespace Ocelot.UnitTests.Configuration
 {
     public class UpstreamHeaderRoutingOptionsCreatorTests
     {
+        private FileUpstreamHeaderRoutingOptions _fileUpstreamHeaderRoutingOptions;
+        private IUpstreamHeaderRoutingOptionsCreator _creator;
+        private UpstreamHeaderRoutingOptions _upstreamHeaderRoutingOptions;
 
+        public UpstreamHeaderRoutingOptionsCreatorTests()
+        {
+            _creator = new UpstreamHeaderRoutingOptionsCreator();
+        }
+
+        [Fact]
+        public void should_create_upstream_routing_header_options()
+        {
+            UpstreamHeaderRoutingOptions expected = new UpstreamHeaderRoutingOptions(
+                headers: new Dictionary<string, HashSet<string>>()
+                {
+                    { "header1", new HashSet<string>() { "value1", "value2" }},
+                    { "header2", new HashSet<string>() { "value3" }},
+                },
+                mode: UpstreamHeaderRoutingCombinationMode.All
+            );
+
+            this.Given(_ => GivenTheseFileUpstreamHeaderRoutingOptions())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenTheCreatedMatchesThis(expected))
+                .BDDfy();
+        }
+
+        private void GivenTheseFileUpstreamHeaderRoutingOptions()
+        {
+            _fileUpstreamHeaderRoutingOptions = new FileUpstreamHeaderRoutingOptions()
+            {
+                Headers = new Dictionary<string, List<string>>()
+                {
+                    { "header1", new List<string>() { "value1", "value2" }},
+                    { "header2", new List<string>() { "value3" }},
+                },
+                CombinationMode = "all",
+            };
+        }
+
+        private void WhenICreate()
+        {
+            _upstreamHeaderRoutingOptions = _creator.Create(_fileUpstreamHeaderRoutingOptions);
+        }
+
+        private void ThenTheCreatedMatchesThis(UpstreamHeaderRoutingOptions expected)
+        {
+            _upstreamHeaderRoutingOptions.Headers.ShouldBe(expected.Headers);
+            _upstreamHeaderRoutingOptions.Mode.ShouldBe(expected.Mode);
+        }
     }
 }

--- a/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
@@ -1,0 +1,8 @@
+
+namespace Ocelot.UnitTests.Configuration
+{
+    public class UpstreamHeaderRoutingOptionsCreatorTests
+    {
+
+    }
+}

--- a/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamHeaderRoutingOptionsCreatorTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Creator;
 using Ocelot.Configuration;
@@ -43,8 +44,8 @@ namespace Ocelot.UnitTests.Configuration
             {
                 Headers = new Dictionary<string, List<string>>()
                 {
-                    { "header1", new List<string>() { "value1", "value2" }},
-                    { "header2", new List<string>() { "value3" }},
+                    { "Header1", new List<string>() { "Value1", "Value2" }},
+                    { "Header2", new List<string>() { "Value3" }},
                 },
                 CombinationMode = "all",
             };
@@ -57,7 +58,13 @@ namespace Ocelot.UnitTests.Configuration
 
         private void ThenTheCreatedMatchesThis(UpstreamHeaderRoutingOptions expected)
         {
-            _upstreamHeaderRoutingOptions.Headers.ShouldBe(expected.Headers);
+            _upstreamHeaderRoutingOptions.Headers.Headers.Count.ShouldBe(expected.Headers.Headers.Count);
+            foreach (KeyValuePair<string, HashSet<string>> pair in _upstreamHeaderRoutingOptions.Headers.Headers)
+            {
+                expected.Headers.Headers.TryGetValue(pair.Key, out var expectedValue).ShouldBe(true);
+                expectedValue.SetEquals(pair.Value).ShouldBe(true);
+            }
+
             _upstreamHeaderRoutingOptions.Mode.ShouldBe(expected.Mode);
         }
     }

--- a/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Xunit;
 using TestStack.BDDfy;
+using Shouldly;
 using Ocelot.Configuration;
 
 namespace Ocelot.UnitTests.Configuration
@@ -84,8 +86,8 @@ namespace Ocelot.UnitTests.Configuration
         {
             _headersDictionary = new Dictionary<string, HashSet<string>>()
             {
-                { "testHeader1", new HashSet<string>() { "testHeader1Value1", "testHeader1Value2" } },
-                { "testHeader2", new HashSet<string>() { "testHeader1Value1", "testHeader2Value2" } },
+                { "testheader1", new HashSet<string>() { "testheader1value1", "testheader1value2" } },
+                { "testheader2", new HashSet<string>() { "testheader1Value1", "testheader2value2" } },
             };
         }
 
@@ -125,17 +127,17 @@ namespace Ocelot.UnitTests.Configuration
 
         private void ThenEmptyIs(bool expected)
         {
-            Assert.True(_upstreamRoutingHeaders.Empty() == expected);
+            _upstreamRoutingHeaders.Empty().ShouldBe(expected);
         }
 
         private void ThenHasAnyOfIs(bool expected)
         {
-            Assert.True(_upstreamRoutingHeaders.HasAnyOf(_requestHeaders) == expected);
+            _upstreamRoutingHeaders.HasAnyOf(_requestHeaders).ShouldBe(expected);
         }
 
         private void ThenHasAllOfIs(bool expected)
         {
-            Assert.True(_upstreamRoutingHeaders.HasAllOf(_requestHeaders) == expected);
+            _upstreamRoutingHeaders.HasAllOf(_requestHeaders).ShouldBe(expected);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
@@ -10,9 +10,7 @@ namespace Ocelot.UnitTests.Configuration
     public class UpstreamRoutingHeadersTests
     {
         private Dictionary<string, HashSet<string>> _headersDictionary;
-
         private UpstreamRoutingHeaders _upstreamRoutingHeaders;
-
         private IHeaderDictionary _requestHeaders;
 
         [Fact]

--- a/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamRoutingHeadersTests.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+using TestStack.BDDfy;
+using Ocelot.Configuration;
+
+namespace Ocelot.UnitTests.Configuration
+{
+    public class UpstreamRoutingHeadersTests
+    {
+        private Dictionary<string, HashSet<string>> _headersDictionary;
+
+        private UpstreamRoutingHeaders _upstreamRoutingHeaders;
+
+        private IHeaderDictionary _requestHeaders;
+
+        [Fact]
+        public void should_create_empty_headers()
+        {
+            this.Given(_ => GivenEmptyHeaderDictionary())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenEmptyIs(true))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_preset_headers()
+        {
+            this.Given(_ => GivenPresetHeaderDictionary())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenEmptyIs(false))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_not_match_mismatching_request_headers()
+        {
+            this.Given(_ => GivenPresetHeaderDictionary())
+                .And(_ => AndGivenMismatchingRequestHeaders())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenHasAnyOfIs(false))
+                .And(_ => ThenHasAllOfIs(false))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_not_match_matching_header_with_mismatching_value()
+        {
+            this.Given(_ => GivenPresetHeaderDictionary())
+                .And(_ => AndGivenOneMatchingHeaderWithMismatchingValue())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenHasAnyOfIs(false))
+                .And(_ => ThenHasAllOfIs(false))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_match_any_header_not_all()
+        {
+            this.Given(_ => GivenPresetHeaderDictionary())
+                .And(_ => AndGivenOneMatchingHeaderWithMatchingValue())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenHasAnyOfIs(true))
+                .And(_ => ThenHasAllOfIs(false))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_match_any_and_all_headers()
+        {
+            this.Given(_ => GivenPresetHeaderDictionary())
+                .And(_ => AndGivenTwoMatchingHeadersWithMatchingValues())
+                .When(_ => WhenICreate())
+                .Then(_ => ThenHasAnyOfIs(true))
+                .And(_ => ThenHasAllOfIs(true))
+                .BDDfy();
+        }
+
+        private void GivenEmptyHeaderDictionary()
+        {
+            _headersDictionary = new Dictionary<string, HashSet<string>>();
+        }
+
+        private void GivenPresetHeaderDictionary()
+        {
+            _headersDictionary = new Dictionary<string, HashSet<string>>()
+            {
+                { "testHeader1", new HashSet<string>() { "testHeader1Value1", "testHeader1Value2" } },
+                { "testHeader2", new HashSet<string>() { "testHeader1Value1", "testHeader2Value2" } },
+            };
+        }
+
+        private void AndGivenMismatchingRequestHeaders()
+        {
+            _requestHeaders = new HeaderDictionary() {
+                { "someHeader", new StringValues(new string[]{ "someHeaderValue" })},
+            };
+        }
+
+        private void AndGivenOneMatchingHeaderWithMismatchingValue()
+        {
+            _requestHeaders = new HeaderDictionary() {
+                { "testHeader1", new StringValues(new string[]{ "mismatchingValue" })},
+            };
+        }
+
+        private void AndGivenOneMatchingHeaderWithMatchingValue()
+        {
+            _requestHeaders = new HeaderDictionary() {
+                { "testHeader1", new StringValues(new string[]{ "testHeader1Value1" })},
+            };
+        }
+
+        private void AndGivenTwoMatchingHeadersWithMatchingValues()
+        {
+            _requestHeaders = new HeaderDictionary() {
+                { "testHeader1", new StringValues(new string[]{ "testHeader1Value1", "bogusValue" })},
+                { "testHeader2", new StringValues(new string[]{ "bogusValue", "testHeader2Value2" })},
+            };
+        }
+
+        private void WhenICreate()
+        {
+            _upstreamRoutingHeaders = new UpstreamRoutingHeaders(_headersDictionary);
+        }
+
+        private void ThenEmptyIs(bool expected)
+        {
+            Assert.True(_upstreamRoutingHeaders.Empty() == expected);
+        }
+
+        private void ThenHasAnyOfIs(bool expected)
+        {
+            Assert.True(_upstreamRoutingHeaders.HasAnyOf(_requestHeaders) == expected);
+        }
+
+        private void ThenHasAllOfIs(bool expected)
+        {
+            Assert.True(_upstreamRoutingHeaders.HasAllOf(_requestHeaders) == expected);
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteCreatorTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteCreatorTests.cs
@@ -13,6 +13,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
     using System.Net.Http;
     using TestStack.BDDfy;
     using Xunit;
+    using Microsoft.AspNetCore.Http;
 
     public class DownstreamRouteCreatorTests
     {
@@ -28,6 +29,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private Mock<IQoSOptionsCreator> _qosOptionsCreator;
         private Response<DownstreamRoute> _resultTwo;
         private string _upstreamQuery;
+        private readonly IHeaderDictionary _upstreamHeaders;
 
         public DownstreamRouteCreatorTests()
         {
@@ -39,6 +41,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 .Setup(x => x.Create(It.IsAny<QoSOptions>(), It.IsAny<string>(), It.IsAny<List<string>>()))
                 .Returns(_qoSOptions);
             _creator = new DownstreamRouteCreator(_qosOptionsCreator.Object);
+            _upstreamHeaders = new HeaderDictionary();
         }
 
         [Fact]
@@ -284,12 +287,12 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
 
         private void WhenICreate()
         {
-            _result = _creator.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _configuration, _upstreamHost);
+            _result = _creator.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _configuration, _upstreamHost, _upstreamHeaders);
         }
 
         private void WhenICreateAgain()
         {
-            _resultTwo = _creator.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _configuration, _upstreamHost);
+            _resultTwo = _creator.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _configuration, _upstreamHost, _upstreamHeaders);
         }
 
         private void ThenTheDownstreamRoutesAreTheSameReference()

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderMiddlewareTests.cs
@@ -83,7 +83,7 @@
         {
             _downstreamRoute = new OkResponse<DownstreamRoute>(downstreamRoute);
             _finder
-                .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IInternalConfiguration>(), It.IsAny<string>()))
+                .Setup(x => x.Get(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IInternalConfiguration>(), It.IsAny<string>(), It.IsAny<HeaderDictionary>()))
                 .Returns(_downstreamRoute);
         }
 

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -8,6 +8,7 @@ using Ocelot.Responses;
 using Ocelot.Values;
 using Shouldly;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -26,12 +27,14 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private string _upstreamHttpMethod;
         private string _upstreamHost;
         private string _upstreamQuery;
+        private IHeaderDictionary _requestHeaders;
 
         public DownstreamRouteFinderTests()
         {
             _mockMatcher = new Mock<IUrlPathToUrlTemplateMatcher>();
             _finder = new Mock<IPlaceholderNameAndValueFinder>();
             _downstreamRouteFinder = new Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteFinder(_mockMatcher.Object, _finder.Object);
+            _requestHeaders = new HeaderDictionary();
         }
 
         [Fact]
@@ -749,7 +752,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
 
         private void WhenICallTheFinder()
         {
-            _result = _downstreamRouteFinder.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _config, _upstreamHost);
+            _result = _downstreamRouteFinder.Get(_upstreamUrlPath, _upstreamQuery, _upstreamHttpMethod, _config, _upstreamHost, _requestHeaders);
         }
 
         private void ThenTheFollowingIsReturned(DownstreamRoute expected)

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -9,6 +9,7 @@ using Ocelot.Values;
 using Shouldly;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -27,6 +28,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private string _upstreamHttpMethod;
         private string _upstreamHost;
         private string _upstreamQuery;
+        private UpstreamHeaderRoutingOptions _upstreamHeaderRoutingOptions;
         private IHeaderDictionary _requestHeaders;
 
         public DownstreamRouteFinderTests()
@@ -34,7 +36,6 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
             _mockMatcher = new Mock<IUrlPathToUrlTemplateMatcher>();
             _finder = new Mock<IPlaceholderNameAndValueFinder>();
             _downstreamRouteFinder = new Ocelot.DownstreamRouteFinder.Finder.DownstreamRouteFinder(_mockMatcher.Object, _finder.Object);
-            _requestHeaders = new HeaderDictionary();
         }
 
         [Fact]
@@ -68,6 +69,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 }, string.Empty, serviceProviderConfig))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
                         new ReRouteBuilder()
@@ -114,6 +116,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 }, string.Empty, serviceProviderConfig))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
                         new ReRouteBuilder()
@@ -153,6 +156,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
@@ -195,6 +199,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
@@ -238,6 +243,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
@@ -288,6 +294,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
@@ -325,9 +332,9 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                  ))
                  .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(false))))
                  .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                 .And(x => x.GivenEmptyRequestHeaders())
                  .When(x => x.WhenICallTheFinder())
-                 .Then(
-                     x => x.ThenAnErrorResponseIsReturned())
+                 .Then(x => x.ThenAnErrorResponseIsReturned())
                  .And(x => x.ThenTheUrlMatcherIsCalledCorrectly())
                  .BDDfy();
         }
@@ -357,6 +364,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
@@ -398,6 +406,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(new List<PlaceholderNameAndValue>(),
@@ -439,6 +448,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                     ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                  .Then(x => x.ThenAnErrorResponseIsReturned())
                  .And(x => x.ThenTheUrlMatcherIsNotCalled())
@@ -471,6 +481,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
@@ -514,6 +525,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
@@ -566,6 +578,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(x => x.ThenAnErrorResponseIsReturned())
                 .And(x => x.ThenTheUrlMatcherIsNotCalled())
@@ -596,6 +609,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(x => x.ThenAnErrorResponseIsReturned())
                 .And(x => x.ThenTheUrlMatcherIsNotCalled())
@@ -626,6 +640,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .And(x => x.ThenTheUrlMatcherIsCalledCorrectly(1, 0))
                 .BDDfy();
@@ -666,6 +681,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 ))
                 .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
                 .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
                 .When(x => x.WhenICallTheFinder())
                 .Then(
                     x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
@@ -685,6 +701,115 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_not_return_route_with_upstream_header_routing_options_enabled_and_no_request_headers()
+        {
+            var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
+
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("matchInUrlMatcher/"))
+                .And(x => x.GivenTheTemplateVariableAndNameFinderReturns(
+                        new OkResponse<List<PlaceholderNameAndValue>>(
+                            new List<PlaceholderNameAndValue>())))
+                .And(x => x.GivenUpstreamHeaderRoutingOptions())
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                    {
+                        new ReRouteBuilder()
+                            .WithDownstreamReRoute(new DownstreamReRouteBuilder()
+                                .WithDownstreamPathTemplate("someDownstreamPath")
+                                .WithUpstreamHttpMethod(new List<string> { "Get" })
+                                .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                                .Build())
+                            .WithUpstreamHttpMethod(new List<string> { "Get" })
+                            .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                            .WithUpstreamHeaderRoutingOptions(_upstreamHeaderRoutingOptions)
+                            .Build()
+                    }, string.Empty, serviceProviderConfig
+                ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenEmptyRequestHeaders())
+                .When(x => x.WhenICallTheFinder())
+                .Then(x => x.ThenAnErrorResponseIsReturned())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_not_return_route_with_upstream_header_routing_options_enabled_and_non_matching_request_headers()
+        {
+            var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
+
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("matchInUrlMatcher/"))
+                .And(x => x.GivenTheTemplateVariableAndNameFinderReturns(
+                        new OkResponse<List<PlaceholderNameAndValue>>(
+                            new List<PlaceholderNameAndValue>())))
+                .And(x => x.GivenUpstreamHeaderRoutingOptions())
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                    {
+                        new ReRouteBuilder()
+                            .WithDownstreamReRoute(new DownstreamReRouteBuilder()
+                                .WithDownstreamPathTemplate("someDownstreamPath")
+                                .WithUpstreamHttpMethod(new List<string> { "Get" })
+                                .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                                .Build())
+                            .WithUpstreamHttpMethod(new List<string> { "Get" })
+                            .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                            .WithUpstreamHeaderRoutingOptions(_upstreamHeaderRoutingOptions)
+                            .Build()
+                    }, string.Empty, serviceProviderConfig
+                ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenNonEmptyNonMatchingRequestHeaders())
+                .When(x => x.WhenICallTheFinder())
+                .Then(x => x.ThenAnErrorResponseIsReturned())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_route_with_upstream_header_routing_options_enabled_and_matching_request_headers()
+        {
+            var serviceProviderConfig = new ServiceProviderConfigurationBuilder().Build();
+
+            this.Given(x => x.GivenThereIsAnUpstreamUrlPath("matchInUrlMatcher/"))
+                .And(x => x.GivenTheTemplateVariableAndNameFinderReturns(
+                        new OkResponse<List<PlaceholderNameAndValue>>(
+                            new List<PlaceholderNameAndValue>())))
+                .And(x => x.GivenUpstreamHeaderRoutingOptions())
+                .And(x => x.GivenTheConfigurationIs(new List<ReRoute>
+                    {
+                        new ReRouteBuilder()
+                            .WithDownstreamReRoute(new DownstreamReRouteBuilder()
+                                .WithDownstreamPathTemplate("someDownstreamPath")
+                                .WithUpstreamHttpMethod(new List<string> { "Get" })
+                                .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                                .Build())
+                            .WithUpstreamHttpMethod(new List<string> { "Get" })
+                            .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                            .WithUpstreamHeaderRoutingOptions(_upstreamHeaderRoutingOptions)
+                            .Build()
+                    }, string.Empty, serviceProviderConfig
+                ))
+                .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+                .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
+                .And(x => x.GivenNonEmptyMatchingRequestHeaders())
+                .When(x => x.WhenICallTheFinder())
+                .Then(
+                    x => x.ThenTheFollowingIsReturned(new DownstreamRoute(
+                            new List<PlaceholderNameAndValue>(),
+                            new ReRouteBuilder()
+                                .WithDownstreamReRoute(new DownstreamReRouteBuilder()
+                                    .WithDownstreamPathTemplate("someDownstreamPath")
+                                    .WithUpstreamHttpMethod(new List<string> { "Get" })
+                                    .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                                    .Build())
+                                .WithUpstreamHttpMethod(new List<string> { "Get" })
+                                .WithUpstreamPathTemplate(new UpstreamPathTemplate("someUpstreamPath", 1, false, "someUpstreamPath"))
+                                .Build()
+                )))
+                .And(x => x.ThenTheUrlMatcherIsCalledCorrectly())
+                .BDDfy();
+        }
+
         private void GivenTheUpstreamHostIs(string upstreamHost)
         {
             _upstreamHost = upstreamHost;
@@ -700,6 +825,36 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder
         private void GivenTheUpstreamHttpMethodIs(string upstreamHttpMethod)
         {
             _upstreamHttpMethod = upstreamHttpMethod;
+        }
+
+        private void GivenUpstreamHeaderRoutingOptions()
+        {
+            var headers = new Dictionary<string, HashSet<string>>()
+            {
+                { "header", new HashSet<string>() { "value" }},
+            };
+            _upstreamHeaderRoutingOptions = new UpstreamHeaderRoutingOptions(headers, UpstreamHeaderRoutingCombinationMode.All);
+        }
+
+        private void GivenEmptyRequestHeaders()
+        {
+            _requestHeaders = new HeaderDictionary();
+        }
+
+        private void GivenNonEmptyNonMatchingRequestHeaders()
+        {
+            _requestHeaders = new HeaderDictionary()
+            {
+                { "header", new StringValues(new string[]{ "mismatch" }) },
+            };
+        }
+
+        private void GivenNonEmptyMatchingRequestHeaders()
+        {
+            _requestHeaders = new HeaderDictionary()
+            {
+                { "header", new StringValues(new string[]{ "value" }) },
+            };
         }
 
         private void ThenAnErrorResponseIsReturned()


### PR DESCRIPTION
# Fixes / New Feature

Addition of support for request re-routing based also on upstream header configuration as per issues #360 and #624 

## Proposed Changes

  - Implementation of support for re-routing based on request's header configuration
  - Update of relevant tests to cover the new functionality
  - Update of relevant documentation to make clear how to make use of the new functionality

Downstream URL placeholder replacement mentioned in issue #360 is not yet supported although I do have plans to add support for that as well.
