### PR TITLE
Fix to AddOcelot(), Config File Merge

### DIFF
--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -42,14 +42,14 @@ namespace Ocelot.DependencyInjection
 
             string subConfigPattern = $@"^ocelot\.([a-zA-Z0-9]+|[a-zA-Z0-9]+\.{env?.EnvironmentName})\.json$";
 
-            var reg = new System.Text.RegularExpressions.Regex(subConfigPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Singleline);
+            var reg = new Regex(subConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
             var files = new DirectoryInfo(folder)
                 .EnumerateFiles()
                 .Where(fi => reg.IsMatch(fi.Name))
                 .ToList();
 
-            var fileConfiguration = new Ocelot.Configuration.File.FileConfiguration();
+            var fileConfiguration = new FileConfiguration();
 
             foreach (var file in files)
             {
@@ -60,7 +60,7 @@ namespace Ocelot.DependencyInjection
 
                 var lines = File.ReadAllText(file.FullName);
 
-                var config = Newtonsoft.Json.JsonConvert.DeserializeObject<Ocelot.Configuration.File.FileConfiguration>(lines);
+                var config = JsonConvert.DeserializeObject<FileConfiguration>(lines);
 
                 if (file.Name.Equals(globalConfigFile, StringComparison.OrdinalIgnoreCase))
                 {
@@ -71,7 +71,7 @@ namespace Ocelot.DependencyInjection
                 fileConfiguration.ReRoutes.AddRange(config.ReRoutes);
             }
 
-            var json = Newtonsoft.Json.JsonConvert.SerializeObject(fileConfiguration);
+            var json = JsonConvert.SerializeObject(fileConfiguration);
 
             File.WriteAllText(primaryConfigFile, json);
 

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -40,18 +40,16 @@ namespace Ocelot.DependencyInjection
 
             const string globalConfigFile = "ocelot.global.json";
 
-            const string subConfigPattern = @"^ocelot\.[a-zA-Z0-9]+\.json$";
+            string subConfigPattern = $@"^ocelot\.([a-zA-Z0-9]+|[a-zA-Z0-9]+\.{env?.EnvironmentName})\.json$";
 
-            string excludeConfigName = env?.EnvironmentName != null ? $"ocelot.{env.EnvironmentName}.json" : string.Empty;
-
-            var reg = new Regex(subConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var reg = new System.Text.RegularExpressions.Regex(subConfigPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Singleline);
 
             var files = new DirectoryInfo(folder)
                 .EnumerateFiles()
-                .Where(fi => reg.IsMatch(fi.Name) && (fi.Name != excludeConfigName))
+                .Where(fi => reg.IsMatch(fi.Name))
                 .ToList();
 
-            var fileConfiguration = new FileConfiguration();
+            var fileConfiguration = new Ocelot.Configuration.File.FileConfiguration();
 
             foreach (var file in files)
             {
@@ -62,7 +60,7 @@ namespace Ocelot.DependencyInjection
 
                 var lines = File.ReadAllText(file.FullName);
 
-                var config = JsonConvert.DeserializeObject<FileConfiguration>(lines);
+                var config = Newtonsoft.Json.JsonConvert.DeserializeObject<Ocelot.Configuration.File.FileConfiguration>(lines);
 
                 if (file.Name.Equals(globalConfigFile, StringComparison.OrdinalIgnoreCase))
                 {
@@ -73,7 +71,7 @@ namespace Ocelot.DependencyInjection
                 fileConfiguration.ReRoutes.AddRange(config.ReRoutes);
             }
 
-            var json = JsonConvert.SerializeObject(fileConfiguration);
+            var json = Newtonsoft.Json.JsonConvert.SerializeObject(fileConfiguration);
 
             File.WriteAllText(primaryConfigFile, json);
 


### PR DESCRIPTION
Fixes / New Feature #296

@CesarD recently brought up a bug in a reply to the old #296  issue. I ran into this issue myself in my own project and made some adjustments to accommodate.

## Proposed Changes

  - AddOcelot() now includes the correct config file with the specified environment
     - This was done by removing the excludeConfigName variable and altering the regex
     - The files that will be included would look something like this (assuming a Development env) ocelot.json, ocelot.api.json, ocelot.api.Development.json, etc.
