### PR TITLE
解决 options.IgnoredRoutesRegexPatterns 选项失效的bug

### DIFF
--- a/src/Ocelot.Provider.Consul/Consul.cs
+++ b/src/Ocelot.Provider.Consul/Consul.cs
@@ -26,11 +26,11 @@
 
         public async Task<List<Service>> Get()
         {
-            var queryResult = await _consul.Health.Service(_config.KeyOfServiceInConsul, string.Empty, true);
+            var queryResult = await _consul?.Health?.Service(_config?.KeyOfServiceInConsul, string.Empty, true);
 
             var services = new List<Service>();
 
-            foreach (var serviceEntry in queryResult.Response)
+            foreach (var serviceEntry in queryResult?.Response ?? new ServiceEntry[] { })
             {
                 if (IsValid(serviceEntry))
                 {

--- a/src/Ocelot.Tracing.Butterfly/ButterflyTracer.cs
+++ b/src/Ocelot.Tracing.Butterfly/ButterflyTracer.cs
@@ -30,7 +30,7 @@
         public void Event(HttpContext httpContext, string @event)
         {
             //IgnoredRoutesRegexPatterns 选项过滤
-            var patterns = _options.IgnoredRoutesRegexPatterns;
+            var patterns = _options?.IgnoredRoutesRegexPatterns;
             if (patterns == null || patterns.Any(x => Regex.IsMatch(httpContext.Request.Path, x)))
             {
                 return;

--- a/src/Ocelot.Tracing.Butterfly/ButterflyTracer.cs
+++ b/src/Ocelot.Tracing.Butterfly/ButterflyTracer.cs
@@ -24,7 +24,7 @@
         public ButterflyTracer(IServiceProvider services)
         {
             _tracer = services.GetService<IServiceTracer>();
-            _options = services.GetService<IOptions<ButterflyOptions>>().Value;
+            _options = services.GetService<IOptions<ButterflyOptions>>()?.Value;
         }
 
         public void Event(HttpContext httpContext, string @event)


### PR DESCRIPTION
配置了过滤 /health 的检查链接，但是在Butterfly中还是发现了大量的 /health 请求的记录
```C#
services.AddOcelot()
    .AddButterfly(option =>
    {
        option.CollectorUrl = Configuration["TracingCenter:Uri"];
        option.Service = Configuration["TracingCenter:Name"];
        option.IgnoredRoutesRegexPatterns = new[] { "/favicon.ico", "/health" };
    });
```

![01](https://user-images.githubusercontent.com/1501040/63206083-abdb6400-c0e0-11e9-97e8-fabd0952a7f4.png)

![02](https://user-images.githubusercontent.com/1501040/63206088-b8f85300-c0e0-11e9-809a-ba81981392a3.png)

