### PR TITLE
Add ConfigAwarePlaceholders class

### DIFF
--- a/src/Ocelot/DependencyInjection/IOcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/IOcelotBuilder.cs
@@ -24,5 +24,7 @@ namespace Ocelot.DependencyInjection
 
         IOcelotBuilder AddTransientDefinedAggregator<T>()
             where T : class, IDefinedAggregator;
+
+        IOcelotBuilder AddConfigPlaceholders();
     }
 }

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -37,6 +37,7 @@ namespace Ocelot.DependencyInjection
     using Ocelot.Security.IPSecurity;
     using Ocelot.ServiceDiscovery;
     using System;
+    using System.Linq;
     using System.Net.Http;
     using System.Reflection;
 
@@ -207,6 +208,22 @@ namespace Ocelot.DependencyInjection
                 Services.AddTransient<DelegatingHandler, THandler>();
             }
 
+            return this;
+        }
+
+        public IOcelotBuilder AddConfigPlaceholders()
+        {
+            var service = Services.First(x => x.ServiceType == typeof(IPlaceholders));
+            var placeholders = (IPlaceholders)service.ImplementationInstance;
+
+            var descriptor = new ServiceDescriptor(
+                typeof(IPlaceholders),
+                serviceProvider =>
+                    new ConfigAwarePlaceholders(serviceProvider.GetService<IConfiguration>(), placeholders),
+                ServiceLifetime.Singleton
+            );
+
+            Services.Replace(descriptor);
             return this;
         }
     }

--- a/src/Ocelot/Infrastructure/ConfigAwarePlaceholders.cs
+++ b/src/Ocelot/Infrastructure/ConfigAwarePlaceholders.cs
@@ -1,0 +1,61 @@
+namespace Ocelot.Infrastructure
+{
+    using System;
+    using System.Text.RegularExpressions;
+    using Microsoft.Extensions.Configuration;
+    using Request.Middleware;
+    using Responses;
+
+    public class ConfigAwarePlaceholders : IPlaceholders
+    {
+        private readonly IConfiguration _configuration;
+        private readonly IPlaceholders _placeholders;
+
+        public ConfigAwarePlaceholders(IConfiguration configuration, IPlaceholders placeholders)
+        {
+            _configuration = configuration;
+            _placeholders = placeholders;
+        }
+        
+        public Response<string> Get(string key)
+        {
+            var placeholderResponse = _placeholders.Get(key);
+
+            if (!placeholderResponse.IsError)
+            {
+                return placeholderResponse;
+            }
+
+            return GetFromConfig(CleanKey(key));
+        }
+
+        public Response<string> Get(string key, DownstreamRequest request)
+        {
+            var placeholderResponse = _placeholders.Get(key, request);
+            
+            if (!placeholderResponse.IsError)
+            {
+                return placeholderResponse;
+            }
+
+            return GetFromConfig(CleanKey(key));
+        }
+
+        public Response Add(string key, Func<Response<string>> func)
+            => _placeholders.Add(key, func);
+
+        public Response Remove(string key)
+            => _placeholders.Remove(key);
+
+        private string CleanKey(string key) 
+            => Regex.Replace(key, @"[{}]", string.Empty, RegexOptions.None);
+
+        private Response<string> GetFromConfig(string key)
+        {
+            var valueFromConfig = _configuration[key];
+            return valueFromConfig == null
+                ? (Response<string>) new ErrorResponse<string>(new CouldNotFindPlaceholderError(key))
+                : new OkResponse<string>(valueFromConfig);
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/DependencyInjection/OcelotBuilderTests.cs
+++ b/test/Ocelot.UnitTests/DependencyInjection/OcelotBuilderTests.cs
@@ -14,6 +14,7 @@ namespace Ocelot.UnitTests.DependencyInjection
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using Ocelot.Infrastructure;
     using TestStack.BDDfy;
     using Xunit;
     using static Ocelot.UnitTests.Middleware.UserDefinedResponseAggregatorTests;
@@ -136,6 +137,16 @@ namespace Ocelot.UnitTests.DependencyInjection
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_replace_iplaceholder()
+        {
+            this.Given(x => x.WhenISetUpOcelotServices())
+                .When(x => AddConfigPlaceholders())
+                .Then(x => ThenAnExceptionIsntThrown())
+                .And(x => ThenTheIPlaceholderInstanceIsReplaced())
+                .BDDfy();
+        }
+
         private void AddSingletonDefinedAggregator<T>()
             where T : class, IDefinedAggregator
         {
@@ -146,6 +157,11 @@ namespace Ocelot.UnitTests.DependencyInjection
             where T : class, IDefinedAggregator
         {
             _ocelotBuilder.AddTransientDefinedAggregator<T>();
+        }
+
+        private void AddConfigPlaceholders()
+        {
+            _ocelotBuilder.AddConfigPlaceholders();
         }
 
         private void ThenTheSpecificHandlersAreTransient()
@@ -233,6 +249,13 @@ namespace Ocelot.UnitTests.DependencyInjection
         private void ThenAnOcelotBuilderIsReturned()
         {
             _ocelotBuilder.ShouldBeOfType<OcelotBuilder>();
+        }
+
+        private void ThenTheIPlaceholderInstanceIsReplaced()
+        {
+            _serviceProvider = _services.BuildServiceProvider();
+            var placeholders = _serviceProvider.GetService<IPlaceholders>();
+            placeholders.ShouldBeOfType<ConfigAwarePlaceholders>();
         }
 
         private void WhenISetUpOcelotServices()

--- a/test/Ocelot.UnitTests/Infrastructure/ConfigAwarePlaceholdersTests.cs
+++ b/test/Ocelot.UnitTests/Infrastructure/ConfigAwarePlaceholdersTests.cs
@@ -1,0 +1,78 @@
+namespace Ocelot.UnitTests.Infrastructure
+{
+    using System;
+    using Moq;
+    using Ocelot.Infrastructure;
+    using Responses;
+    using Shouldly;
+    using Microsoft.Extensions.Configuration;
+    using Xunit;
+
+    public class ConfigAwarePlaceholdersTests
+    {
+        private readonly IPlaceholders _placeholders;
+        private readonly Mock<IPlaceholders> _basePlaceholders;
+
+        public ConfigAwarePlaceholdersTests()
+        {
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddJsonFile("appsettings.json");
+            var configuration = configurationBuilder.Build();
+
+            _basePlaceholders = new Mock<IPlaceholders>();
+            _placeholders = new ConfigAwarePlaceholders(configuration, _basePlaceholders.Object);
+        }
+
+        [Fact]
+        public void should_return_value_from_underlying_placeholders()
+        {
+            var baseUrl = "http://www.bbc.co.uk";
+            const string key = "{BaseUrl}";
+            
+            _basePlaceholders.Setup(x => x.Get(key)).Returns(new OkResponse<string>(baseUrl));
+            var result = _placeholders.Get(key);
+            result.Data.ShouldBe(baseUrl);
+        }
+
+        [Fact]
+        public void should_return_value_from_config_with_same_name_as_placeholder_if_underlying_placeholder_not_found()
+        {
+            const string expected = "http://foo-bar.co.uk";
+            var baseUrl = "http://www.bbc.co.uk";
+            const string key = "{BaseUrl}";
+            
+            _basePlaceholders.Setup(x => x.Get(key)).Returns(new ErrorResponse<string>(new FakeError()));
+            var result = _placeholders.Get(key);
+            result.Data.ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("{TestConfig}")]
+        [InlineData("{TestConfigNested:Child}")]
+        public void should_return_value_from_config(string key)
+        {
+            const string expected = "foo";
+            
+            _basePlaceholders.Setup(x => x.Get(key)).Returns(new ErrorResponse<string>(new FakeError()));
+            var result = _placeholders.Get(key);
+            result.Data.ShouldBe(expected);
+        }
+
+        [Fact]
+        public void should_call_underyling_when_added()
+        {
+            const string key = "{Test}";
+            Func<Response<string>> func = () => new OkResponse<string>("test)");
+            _placeholders.Add(key, func);
+            _basePlaceholders.Verify(p => p.Add(key, func), Times.Once);
+        }
+
+        [Fact]
+        public void should_call_underyling_when_removed()
+        {
+            const string key = "{Test}";
+            _placeholders.Remove(key);
+            _basePlaceholders.Verify(p => p.Remove(key), Times.Once);
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/appsettings.json
+++ b/test/Ocelot.UnitTests/appsettings.json
@@ -20,5 +20,10 @@
       "port": 5000,
       "hostName": "localhost"
     }
+  },
+  "BaseUrl": "http://foo-bar.co.uk",
+  "TestConfig": "foo",
+  "TestConfigNested":{
+    "Child": "foo"
   }
 }


### PR DESCRIPTION
This allows placeholder values to be sourced from IConfiguration in
addition to set values.

New Feature

## Proposed Changes

I found myself writing a few `DelegatingHandlers` for appending headers for downstream calls using values from `IConfiguration`. This PR contains a new implementation of `IPlaceholders`. 

This decorates and replaces the `IPlaceholders` instaces in the IoC container to allow the existing placeholders to be used (it checks these first). The idea is to have config like:

```json
"UpstreamHeaderTransform": {
    "x-api-key": "{DownstreamService:ApiKey}"
}
```

I've added `AddConfigPlaceholders()` to `IOcelotBuilder` but I wasn't sure if that was the correct location, or if somewhere else would work.