### PR TITLE
Make rate-limiting client whitelist dynamic

### DIFF
--- a/src/Ocelot/Configuration/Builder/RateLimitOptionsBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/RateLimitOptionsBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Ocelot.Configuration.Builder
 {
@@ -7,6 +8,7 @@ namespace Ocelot.Configuration.Builder
         private bool _enableRateLimiting;
         private string _clientIdHeader;
         private List<string> _clientWhitelist;
+        private Func<List<string>> _getClientWhitelist;
         private bool _disableRateLimitHeaders;
         private string _quotaExceededMessage;
         private string _rateLimitCounterPrefix;
@@ -19,15 +21,15 @@ namespace Ocelot.Configuration.Builder
             return this;
         }
 
-        public RateLimitOptionsBuilder WithClientIdHeader(string clientIdheader)
+        public RateLimitOptionsBuilder WithClientIdHeader(string clientIdHeader)
         {
-            _clientIdHeader = clientIdheader;
+            _clientIdHeader = clientIdHeader;
             return this;
         }
 
-        public RateLimitOptionsBuilder WithClientWhiteList(List<string> clientWhitelist)
+        public RateLimitOptionsBuilder WithClientWhiteList(Func<List<string>> getClientWhitelist)
         {
-            _clientWhitelist = clientWhitelist;
+            _getClientWhitelist = getClientWhitelist;
             return this;
         }
 
@@ -63,7 +65,7 @@ namespace Ocelot.Configuration.Builder
 
         public RateLimitOptions Build()
         {
-            return new RateLimitOptions(_enableRateLimiting, _clientIdHeader, _clientWhitelist,
+            return new RateLimitOptions(_enableRateLimiting, _clientIdHeader, _getClientWhitelist,
                 _disableRateLimitHeaders, _quotaExceededMessage, _rateLimitCounterPrefix,
                 _rateLimitRule, _httpStatusCode);
         }

--- a/src/Ocelot/Configuration/Creator/RateLimitOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RateLimitOptionsCreator.cs
@@ -11,7 +11,7 @@ namespace Ocelot.Configuration.Creator
             {
                 return new RateLimitOptionsBuilder()
                     .WithClientIdHeader(globalConfiguration.RateLimitOptions.ClientIdHeader)
-                    .WithClientWhiteList(fileRateLimitRule.ClientWhitelist)
+                    .WithClientWhiteList(() => fileRateLimitRule.ClientWhitelist)
                     .WithDisableRateLimitHeaders(globalConfiguration.RateLimitOptions.DisableRateLimitHeaders)
                     .WithEnableRateLimiting(fileRateLimitRule.EnableRateLimiting)
                     .WithHttpStatusCode(globalConfiguration.RateLimitOptions.HttpStatusCode)

--- a/src/Ocelot/Configuration/RateLimitOptions.cs
+++ b/src/Ocelot/Configuration/RateLimitOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Ocelot.Configuration
 {
@@ -7,12 +8,14 @@ namespace Ocelot.Configuration
     /// </summary>
     public class RateLimitOptions
     {
-        public RateLimitOptions(bool enbleRateLimiting, string clientIdHeader, List<string> clientWhitelist, bool disableRateLimitHeaders,
+        private readonly Func<List<string>> _getClientWhitelist;
+
+        public RateLimitOptions(bool enableRateLimiting, string clientIdHeader, Func<List<string>> getClientWhitelist, bool disableRateLimitHeaders,
             string quotaExceededMessage, string rateLimitCounterPrefix, RateLimitRule rateLimitRule, int httpStatusCode)
         {
-            EnableRateLimiting = enbleRateLimiting;
+            EnableRateLimiting = enableRateLimiting;
             ClientIdHeader = clientIdHeader;
-            ClientWhitelist = clientWhitelist ?? new List<string>();
+            _getClientWhitelist = getClientWhitelist;
             DisableRateLimitHeaders = disableRateLimitHeaders;
             QuotaExceededMessage = quotaExceededMessage;
             RateLimitCounterPrefix = rateLimitCounterPrefix;
@@ -22,7 +25,10 @@ namespace Ocelot.Configuration
 
         public RateLimitRule RateLimitRule { get; private set; }
 
-        public List<string> ClientWhitelist { get; private set; }
+        /// <summary>
+        /// Gets the list of white listed clients
+        /// </summary>
+        public List<string> ClientWhitelist { get => _getClientWhitelist(); }
 
         /// <summary>
         /// Gets or sets the HTTP header that holds the client identifier, by default is X-ClientId

--- a/test/Ocelot.UnitTests/Configuration/RateLimitOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RateLimitOptionsCreatorTests.cs
@@ -50,7 +50,7 @@ namespace Ocelot.UnitTests.Configuration
             };
             var expected = new RateLimitOptionsBuilder()
                 .WithClientIdHeader("ClientIdHeader")
-                .WithClientWhiteList(fileReRoute.RateLimitOptions.ClientWhitelist)
+                .WithClientWhiteList(() => fileReRoute.RateLimitOptions.ClientWhitelist)
                 .WithDisableRateLimitHeaders(true)
                 .WithEnableRateLimiting(true)
                 .WithHttpStatusCode(200)

--- a/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/RateLimit/ClientRateLimitMiddlewareTests.cs
@@ -54,7 +54,7 @@ namespace Ocelot.UnitTests.RateLimit
 
             var downstreamReRoute = new DownstreamReRouteBuilder()
                 .WithEnableRateLimiting(true)
-                .WithRateLimitOptions(new RateLimitOptions(true, "ClientId", new List<string>(), false, "", "", new RateLimitRule("1s", 100, 3), 429))
+                .WithRateLimitOptions(new RateLimitOptions(true, "ClientId", () => new List<string>(), false, "", "", new RateLimitRule("1s", 100, 3), 429))
                 .WithUpstreamHttpMethod(new List<string> { "Get" })
                 .WithUpstreamPathTemplate(upstreamTemplate)
                 .Build();
@@ -82,7 +82,7 @@ namespace Ocelot.UnitTests.RateLimit
                      .WithDownstreamReRoute(new DownstreamReRouteBuilder()
                          .WithEnableRateLimiting(true)
                          .WithRateLimitOptions(
-                             new Ocelot.Configuration.RateLimitOptions(true, "ClientId", new List<string>() { "ocelotclient2" }, false, "", "", new RateLimitRule("1s", 100, 3), 429))
+                             new Ocelot.Configuration.RateLimitOptions(true, "ClientId", () => new List<string>() { "ocelotclient2" }, false, "", "", new RateLimitRule("1s", 100, 3), 429))
                          .WithUpstreamHttpMethod(new List<string> { "Get" })
                          .Build())
                      .WithUpstreamHttpMethod(new List<string> { "Get" })


### PR DESCRIPTION
### New Feature
Make rate-limiting client whitelist `RateLimitOptions.ClientWhiteList` dynamic

### Use case
Currently, a running application using ocelot rate-limiting with client whitelist would have to be stopped & restarted to update the client whitelist. This feature allows a user to pass a lambda expression (e.g an expression to fetch the whitelist from a database table that is frequently updated) to the `RateLimitOptions` constructor so that the `RateLimitOptions.ClientWhiteList` field getter can execute the lambda to fetch an updated whitelist each time the field is accessed.

### Changes
* Refactor `RateLimitOptions.ClientWhiteList`
* Fix typo in variable `enbleRateLimiting`
* Fix case in variable `clientIdheader`

### Breaking changes
Users will have to refactor all usage of the methods below:
1. `RateLimitOptions()`
   
   ```c#
   RateLimitOptions(true, "ClientId", new List<string>() { "ocelotclient2" }, ...)
   ```
   becomes
   ```c#
   RateLimitOptions(true, "ClientId", () => new List<string>() { "ocelotclient2" }, ...)
   ```
2. `RateLimitOptionsBuilder.WithClientWhiteList`

   ```c#
   RateLimitOptionsBuilder.WithClientWhiteList(fileRateLimitRule.ClientWhitelist)
   ```
   becomes
   ```c#
   RateLimitOptionsBuilder.WithClientWhiteList(() => fileRateLimitRule.ClientWhitelist)
   ```