### PR TITLE
Feature/httphandler maxconnectionperserver

### DIFF
--- a/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
@@ -19,7 +19,7 @@
             var useTracing = _tracer != null && options.UseTracing;
 
             return new HttpHandlerOptions(options.AllowAutoRedirect,
-                options.UseCookieContainer, useTracing, options.UseProxy);
+                options.UseCookieContainer, useTracing, options.UseProxy, options.MaxConnectionsPerServer);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HttpHandlerOptionsCreator.cs
@@ -18,8 +18,11 @@
         {
             var useTracing = _tracer != null && options.UseTracing;
 
+            //be sure that maxConnectionPerServer is in correct range of values
+            int maxConnectionPerServer = (options.MaxConnectionsPerServer > 0) ? maxConnectionPerServer = options.MaxConnectionsPerServer : maxConnectionPerServer = int.MaxValue;
+
             return new HttpHandlerOptions(options.AllowAutoRedirect,
-                options.UseCookieContainer, useTracing, options.UseProxy, options.MaxConnectionsPerServer);
+                options.UseCookieContainer, useTracing, options.UseProxy, maxConnectionPerServer);
         }
     }
 }

--- a/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
@@ -7,6 +7,7 @@
             AllowAutoRedirect = false;
             UseCookieContainer = false;
             UseProxy = true;
+            MaxConnectionsPerServer = int.MaxValue;
         }
 
         public bool AllowAutoRedirect { get; set; }
@@ -16,5 +17,7 @@
         public bool UseTracing { get; set; }
 
         public bool UseProxy { get; set; }
+
+        public int MaxConnectionsPerServer { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/HttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptions.cs
@@ -6,32 +6,44 @@
     /// </summary>
     public class HttpHandlerOptions
     {
-        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing, bool useProxy)
+        public HttpHandlerOptions(bool allowAutoRedirect, bool useCookieContainer, bool useTracing, bool useProxy, int maxConnectionsPerServer)
         {
             AllowAutoRedirect = allowAutoRedirect;
             UseCookieContainer = useCookieContainer;
             UseTracing = useTracing;
             UseProxy = useProxy;
+            MaxConnectionsPerServer = maxConnectionsPerServer;
         }
+
 
         /// <summary>
         /// Specify if auto redirect is enabled
         /// </summary>
+        /// <value>AllowAutoRedirect</value>
         public bool AllowAutoRedirect { get; private set; }
 
         /// <summary>
         /// Specify is handler has to use a cookie container
         /// </summary>
+        /// <value>UseCookieContainer</value>
         public bool UseCookieContainer { get; private set; }
 
         /// <summary>
         /// Specify is handler has to use a opentracing
         /// </summary>
+        /// <value>UseTracing</value>
         public bool UseTracing { get; private set; }
 
         /// <summary>
         /// Specify if handler has to use a proxy
         /// </summary>
+        /// <value>UseProxy</value>
         public bool UseProxy { get; private set; }
+
+        /// <summary>
+        /// Specify the maximum of concurrent connection to a network endpoint
+        /// </summary>
+        /// <value>MaxConnectionsPerServer</value>
+        public int MaxConnectionsPerServer { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/HttpHandlerOptionsBuilder.cs
+++ b/src/Ocelot/Configuration/HttpHandlerOptionsBuilder.cs
@@ -6,6 +6,7 @@
         private bool _useCookieContainer;
         private bool _useTracing;
         private bool _useProxy;
+        private int _maxConnectionPerServer;
 
         public HttpHandlerOptionsBuilder WithAllowAutoRedirect(bool input)
         {
@@ -30,10 +31,16 @@
             _useProxy = useProxy;
             return this;
         }
+        public HttpHandlerOptionsBuilder WithUseMaxConnectionPerServer(int maxConnectionPerServer)
+        {
+            _maxConnectionPerServer = maxConnectionPerServer;
+            return this;
+        }
+
 
         public HttpHandlerOptions Build()
         {
-            return new HttpHandlerOptions(_allowAutoRedirect, _useCookieContainer, _useTracing, _useProxy);
+            return new HttpHandlerOptions(_allowAutoRedirect, _useCookieContainer, _useTracing, _useProxy, _maxConnectionPerServer);
         }
     }
 }

--- a/src/Ocelot/Requester/HttpClientBuilder.cs
+++ b/src/Ocelot/Requester/HttpClientBuilder.cs
@@ -90,7 +90,9 @@ namespace Ocelot.Requester
             {
                 AllowAutoRedirect = context.DownstreamReRoute.HttpHandlerOptions.AllowAutoRedirect,
                 UseCookies = context.DownstreamReRoute.HttpHandlerOptions.UseCookieContainer,
-                UseProxy = context.DownstreamReRoute.HttpHandlerOptions.UseProxy
+                UseProxy = context.DownstreamReRoute.HttpHandlerOptions.UseProxy,
+                MaxConnectionsPerServer = context.DownstreamReRoute.HttpHandlerOptions.MaxConnectionsPerServer
+
             };
         }
 
@@ -101,6 +103,7 @@ namespace Ocelot.Requester
                 AllowAutoRedirect = context.DownstreamReRoute.HttpHandlerOptions.AllowAutoRedirect,
                 UseCookies = context.DownstreamReRoute.HttpHandlerOptions.UseCookieContainer,
                 UseProxy = context.DownstreamReRoute.HttpHandlerOptions.UseProxy,
+                MaxConnectionsPerServer = context.DownstreamReRoute.HttpHandlerOptions.MaxConnectionsPerServer,
                 CookieContainer = new CookieContainer()
             };
         }

--- a/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -60,7 +60,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, true, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, true, true, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .And(x => GivenARealTracer())
@@ -73,7 +73,7 @@ namespace Ocelot.UnitTests.Configuration
         public void should_create_options_with_useCookie_false_and_allowAutoRedirect_true_as_default()
         {
             var fileReRoute = new FileReRoute();
-            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -94,7 +94,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -110,7 +110,7 @@ namespace Ocelot.UnitTests.Configuration
                 HttpHandlerOptions = new FileHttpHandlerOptions()
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false, true);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())
@@ -129,7 +129,7 @@ namespace Ocelot.UnitTests.Configuration
                 }
             };
 
-            var expectedOptions = new HttpHandlerOptions(false, false, false, false);
+            var expectedOptions = new HttpHandlerOptions(false, false, false, false, int.MaxValue);
 
             this.Given(x => GivenTheFollowing(fileReRoute))
                 .When(x => WhenICreateHttpHandlerOptions())

--- a/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HttpHandlerOptionsCreatorTests.cs
@@ -137,6 +137,44 @@ namespace Ocelot.UnitTests.Configuration
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_create_options_with_specified_MaxConnectionsPerServer()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                HttpHandlerOptions = new FileHttpHandlerOptions
+                {
+                    MaxConnectionsPerServer = 10
+                }
+            };
+
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, 10);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_options_fixing_specified_MaxConnectionsPerServer_range()
+        {
+            var fileReRoute = new FileReRoute
+            {
+                HttpHandlerOptions = new FileHttpHandlerOptions
+                {
+                    MaxConnectionsPerServer = -1
+                }
+            };
+
+            var expectedOptions = new HttpHandlerOptions(false, false, false, true, int.MaxValue);
+
+            this.Given(x => GivenTheFollowing(fileReRoute))
+                .When(x => WhenICreateHttpHandlerOptions())
+                .Then(x => ThenTheFollowingOptionsReturned(expectedOptions))
+                .BDDfy();
+        }
+
         private void GivenTheFollowing(FileReRoute fileReRoute)
         {
             _fileReRoute = fileReRoute;
@@ -154,6 +192,7 @@ namespace Ocelot.UnitTests.Configuration
             _httpHandlerOptions.UseCookieContainer.ShouldBe(expected.UseCookieContainer);
             _httpHandlerOptions.UseTracing.ShouldBe(expected.UseTracing);
             _httpHandlerOptions.UseProxy.ShouldBe(expected.UseProxy);
+            _httpHandlerOptions.MaxConnectionsPerServer.ShouldBe(expected.MaxConnectionsPerServer);
         }
 
         private void GivenARealTracer()

--- a/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
@@ -52,7 +52,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -88,7 +88,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandlerTwo",
@@ -125,7 +125,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandlerTwo",
@@ -161,7 +161,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -195,7 +195,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .Build();
 
@@ -221,7 +221,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true, int.MaxValue))
                 .WithDelegatingHandlers(new List<string>
                 {
                     "FakeDelegatingHandler",
@@ -249,7 +249,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true, int.MaxValue)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosFactoryReturns(new FakeQoSHandler()))
@@ -269,7 +269,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true, int.MaxValue)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheServiceProviderReturnsNothing())
@@ -289,7 +289,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true, int.MaxValue)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosFactoryReturns(new FakeQoSHandler()))
@@ -309,7 +309,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true)).WithLoadBalancerKey("").Build();
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, false, true, int.MaxValue)).WithLoadBalancerKey("").Build();
 
             this.Given(x => GivenTheFollowingRequest(reRoute))
                 .And(x => GivenTheQosFactoryReturns(new FakeQoSHandler()))
@@ -331,7 +331,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .Build();
 
@@ -361,7 +361,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(true, true, true, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .Build();
 

--- a/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpClientBuilderTests.cs
@@ -52,7 +52,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -73,7 +73,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -99,7 +99,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -126,7 +126,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRouteA = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithContainsQueryString(true).WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -134,7 +134,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRouteB = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithContainsQueryString(true).WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -161,7 +161,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -184,7 +184,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -216,7 +216,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, true, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, true, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -252,7 +252,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(new UpstreamPathTemplateBuilder().WithOriginalValue("").Build())
                 .WithQosOptions(new QoSOptionsBuilder().Build())

--- a/test/Ocelot.UnitTests/Requester/HttpClientHttpRequesterTest.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpClientHttpRequesterTest.cs
@@ -57,7 +57,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(upstreamTemplate)
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -86,7 +86,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(upstreamTemplate)
                 .WithQosOptions(new QoSOptionsBuilder().Build())
@@ -114,7 +114,7 @@ namespace Ocelot.UnitTests.Requester
 
             var reRoute = new DownstreamReRouteBuilder()
                 .WithQosOptions(qosOptions)
-                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true))
+                .WithHttpHandlerOptions(new HttpHandlerOptions(false, false, false, true, int.MaxValue))
                 .WithLoadBalancerKey("")
                 .WithUpstreamPathTemplate(upstreamTemplate)
                 .WithQosOptions(new QoSOptionsBuilder().WithTimeoutValue(1).Build())


### PR DESCRIPTION
allow to limit the number of concurrent tcp connection to a downstream service

Fixes / New Feature #

## Proposed Changes

We are using Ocelot to route http traffic to different http service of our own.
Some of these servces limit the number of concurrent tcp connection. When the number of allowed connection is reach, requests are rejected.
By default, Ocelot instanciate one HttpClient per Downstream route and use most of the default parameters of the HttpClientHandler object passed to its constructor. the defaut value of HttpClientHandler::MaxConnectionPerServer is int.MaxValue.
Our proposition is to allow to set "HttpClientHandler ::MaxConnectionPerServer", adding a new parameter inside Ocelot.Json inside the "HttpHandlerOptions" section. 

implementation : modify HttpClientBuilder and set MaxConnectionPerServer inside HttpClientHandler. MaxConnectionPerServer value is got from HttpHandlerOptions. Also we modify the FileHttpHandlerOptions that read from ocelot.json and instanciate HttpHandlerOptions.

Ocelot.json example:
.
.
{
      "DownstreamPathTemplate": "/test/{appsegment}",
      "DownstreamScheme": "http",
      "DownstreamHostAndPorts": [
        {
          "Host": "empty",
          "Port": 80
        }
      ],
      "HttpHandlerOptions": {
        "MaxConnectionsPerServer": 4
      },
      "UpstreamPathTemplate": "/iNot/{appsegment}",
      "UpstreamHttpMethod": [ "POST", "PUT", "GET" ]
    }
}
.
.
.
	
	

