### PR TITLE
Do not crash host on Dispose

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,4 @@
-﻿#tool "nuget:?package=GitVersion.CommandLine"
+﻿#tool "nuget:?package=GitVersion.CommandLine&version=5.0.1"
 #tool "nuget:?package=GitReleaseNotes"
 #addin nuget:?package=Cake.Json
 #addin nuget:?package=Newtonsoft.Json

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -105,7 +105,8 @@ namespace Ocelot.Configuration.Repository
 
         public void Dispose()
         {
-            _timer.Dispose();
+            _timer?.Dispose();
+            _timer = null;
         }
     }
 }


### PR DESCRIPTION
During the .NET Core 3.0 upgrade I introduced this Dispose method on the FileConfigurationPoller. It turns out that the implementation was a bit problematic, because of the timer hasn't been created yet (since that happens in the StartAsync) and the instance is being disposed it throws an exception here.

In our case, this happened because Consul wasn't available at the time our Ocelot based application was starting. This caused an exception during startup, but the actual exception was being masked by this bug since the host was being disposed due to a startup error, but it couldn't be properly disposed due to this bug. This failed spectacularly in our production environment because our API gateway failed to start.