### PR TITLE
Fix URL for the Ocelot logo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img src="https://threemammals.com/ocelot_logo.png">](https://threemammals.com/ocelot)
+[<img src="https://threemammals.com/images/ocelot_logo.png">](https://threemammals.com/ocelot)
 
 [![CircleCI](https://circleci.com/gh/ThreeMammals/Ocelot/tree/master.svg?style=svg)](https://circleci.com/gh/ThreeMammals/Ocelot/tree/master)
 


### PR DESCRIPTION
The URL for the Ocelot logo was broken as it was missing the `/images/` prefix in the path.