### PR TITLE
Fix #1088 (Ocelot Administration doesn't work with .NET Core 3.x)

### DIFF
--- a/samples/AdministrationApi/AdministrationApi.csproj
+++ b/samples/AdministrationApi/AdministrationApi.csproj
@@ -3,12 +3,11 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="wwwroot\" />
+    <Folder Include="wwwroot\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Ocelot" Version="14.0.3" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Ocelot.Administration\Ocelot.Administration.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
+    <PackageReference Include="Ocelot" Version="12.0.1"/>
+    <PackageReference Include="Ocelot.Administration" Version="0.1.0"/>
   </ItemGroup>
 </Project>

--- a/samples/AdministrationApi/AdministrationApi.csproj
+++ b/samples/AdministrationApi/AdministrationApi.csproj
@@ -1,13 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="wwwroot\"/>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <ItemGroup>    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Ocelot" Version="14.0.3" />
+
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App"/>
-    <PackageReference Include="Ocelot" Version="12.0.1"/>
-    <PackageReference Include="Ocelot.Administration" Version="0.1.0"/>
+    <ProjectReference Include="..\..\src\Ocelot.Administration\Ocelot.Administration.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/AdministrationApi/AdministrationApi.csproj
+++ b/samples/AdministrationApi/AdministrationApi.csproj
@@ -5,11 +5,9 @@
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
-  <ItemGroup>    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Ocelot" Version="14.0.3" />
-
-  </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Ocelot.Administration\Ocelot.Administration.csproj" />
+    <PackageReference Include="Ocelot" Version="14.0.3" />
+    <PackageReference Include="Ocelot.Administration" Version="14.0.3" />
+
   </ItemGroup>
 </Project>

--- a/samples/AdministrationApi/Program.cs
+++ b/samples/AdministrationApi/Program.cs
@@ -1,19 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Ocelot.Administration;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
-using Ocelot.Administration;
+using System.IO;
 
 namespace AdministrationApi
 {
-  public class Program
+    public class Program
 {
     public static void Main(string[] args)
     {

--- a/samples/AdministrationApi/Program.cs
+++ b/samples/AdministrationApi/Program.cs
@@ -1,14 +1,19 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Ocelot.Administration;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
-using System.IO;
+using Ocelot.Administration;
 
 namespace AdministrationApi
 {
-    public class Program
+  public class Program
 {
     public static void Main(string[] args)
     {

--- a/src/Ocelot.Administration/IdentityServerMiddlewareConfigurationProvider.cs
+++ b/src/Ocelot.Administration/IdentityServerMiddlewareConfigurationProvider.cs
@@ -27,7 +27,13 @@
                     }
 
                     app.UseAuthentication();
-                    app.UseMvc();
+                    app.UseRouting();
+                    app.UseAuthorization();
+                    app.UseEndpoints(endpoints =>
+                    {
+                        endpoints.MapDefaultControllerRoute();
+                        endpoints.MapControllers();
+                    });
                 });
             }
 

--- a/src/Ocelot.Administration/IdentityServerMiddlewareConfigurationProvider.cs
+++ b/src/Ocelot.Administration/IdentityServerMiddlewareConfigurationProvider.cs
@@ -27,13 +27,7 @@
                     }
 
                     app.UseAuthentication();
-                    app.UseRouting();
-                    app.UseAuthorization();
-                    app.UseEndpoints(endpoints =>
-                    {
-                        endpoints.MapDefaultControllerRoute();
-                        endpoints.MapControllers();
-                    });
+                    app.UseMvc();
                 });
             }
 


### PR DESCRIPTION
Fixes:

issue#1088 (Ocelot Administration doesn't work with .NET Core 3.x)

## Proposed Changes

Changed the OcelotMiddlewareConfigurationDelegate configuration to take in account .net Core 3.x breaking changes.