### PR TITLE
Add DownstreamHttpVersion property for Http/2 WebServer

### DIFF
--- a/src/Ocelot/Configuration/Builder/DownstreamReRouteBuilder.cs
+++ b/src/Ocelot/Configuration/Builder/DownstreamReRouteBuilder.cs
@@ -1,5 +1,6 @@
 using Ocelot.Configuration.Creator;
 using Ocelot.Values;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -42,6 +43,7 @@ namespace Ocelot.Configuration.Builder
         private bool _dangerousAcceptAnyServerCertificateValidator;
         private SecurityOptions _securityOptions;
         private string _downstreamHttpMethod;
+        private string _downstreamHttpVersion;
 
         public DownstreamReRouteBuilder()
         {
@@ -255,6 +257,12 @@ namespace Ocelot.Configuration.Builder
             return this;
         }
 
+        public DownstreamReRouteBuilder WithHttpVersion(string httpVersion)
+        {
+            _downstreamHttpVersion = httpVersion;
+            return this;
+        }
+
         public DownstreamReRoute Build()
         {
             return new DownstreamReRoute(
@@ -290,7 +298,8 @@ namespace Ocelot.Configuration.Builder
                 _addHeadersToUpstream,
                 _dangerousAcceptAnyServerCertificateValidator,
                 _securityOptions,
-                _downstreamHttpMethod);
+                _downstreamHttpMethod,
+                _downstreamHttpVersion);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/ReRoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ReRoutesCreator.cs
@@ -138,6 +138,7 @@ namespace Ocelot.Configuration.Creator
                 .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
                 .WithDangerousAcceptAnyServerCertificateValidator(fileReRoute.DangerousAcceptAnyServerCertificateValidator)
                 .WithSecurityOptions(securityOptions)
+                .WithHttpVersion(fileReRoute.DownstreamHttpVersion)
                 .WithDownStreamHttpMethod(fileReRoute.DownstreamHttpMethod)
                 .Build();
 

--- a/src/Ocelot/Configuration/DownstreamReRoute.cs
+++ b/src/Ocelot/Configuration/DownstreamReRoute.cs
@@ -1,6 +1,7 @@
 namespace Ocelot.Configuration
 {
     using Creator;
+    using System;
     using System.Collections.Generic;
     using Values;
 
@@ -39,7 +40,8 @@ namespace Ocelot.Configuration
             List<AddHeader> addHeadersToUpstream,
             bool dangerousAcceptAnyServerCertificateValidator,
             SecurityOptions securityOptions,
-            string downstreamHttpMethod)
+            string downstreamHttpMethod,
+            string downstreamHttpVersion)
         {
             DangerousAcceptAnyServerCertificateValidator = dangerousAcceptAnyServerCertificateValidator;
             AddHeadersToDownstream = addHeadersToDownstream;
@@ -74,6 +76,7 @@ namespace Ocelot.Configuration
             AddHeadersToUpstream = addHeadersToUpstream;
             SecurityOptions = securityOptions;
             DownstreamHttpMethod = downstreamHttpMethod;
+            DownstreamHttpVersion = downstreamHttpVersion;
         }
 
         public string Key { get; }
@@ -109,5 +112,6 @@ namespace Ocelot.Configuration
         public bool DangerousAcceptAnyServerCertificateValidator { get; }
         public SecurityOptions SecurityOptions { get; }
         public string DownstreamHttpMethod { get; }
+        public string DownstreamHttpVersion { get;  }
     }
 }

--- a/src/Ocelot/Configuration/File/FileReRoute.cs
+++ b/src/Ocelot/Configuration/File/FileReRoute.cs
@@ -56,5 +56,6 @@ namespace Ocelot.Configuration.File
         public int Timeout { get; set; }
         public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
         public FileSecurityOptions SecurityOptions { get; set; }
+        public string DownstreamHttpVersion { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/Validator/ReRouteFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/ReRouteFluentValidator.cs
@@ -83,6 +83,11 @@
                 RuleForEach(reRoute => reRoute.DownstreamHostAndPorts)
                     .SetValidator(hostAndPortValidator);
             });
+
+            When(reRoute => !string.IsNullOrEmpty(reRoute.DownstreamHttpVersion), () =>
+            {
+                RuleFor(r => r.DownstreamHttpVersion).Matches("^[0-9]([.,][0-9]{1,1})?$");
+            });
         }
 
         private async Task<bool> IsSupportedAuthenticationProviders(FileAuthenticationOptions authenticationOptions, CancellationToken cancellationToken)

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -20,11 +20,17 @@
         {
             try
             {
+                if (!Version.TryParse(downstreamReRoute.DownstreamHttpVersion, out Version version))
+                {
+                    version = new Version(1, 1);
+                }
+                
                 var requestMessage = new HttpRequestMessage()
                 {
                     Content = await MapContent(request),
                     Method = MapMethod(request, downstreamReRoute),
-                    RequestUri = MapUri(request)
+                    RequestUri = MapUri(request),
+                    Version = version,
                 };
 
                 MapHeaders(request, requestMessage);


### PR DESCRIPTION
# New Feature
Refer to #1124 proposal.
We add DownstreamHttpVersion property on ReRoute for edit Http Version.

@TomPallister we need support for Unit Testing.
I tried this feature on my machine, but we need to insert correct testing.