### PR TITLE
Follow up #1172 #1849: Fix cache issue. IP filtering helpers

### DIFF
--- a/src/Ocelot/Cache/DefaultCacheKeyGenerator.cs
+++ b/src/Ocelot/Cache/DefaultCacheKeyGenerator.cs
@@ -6,8 +6,9 @@ namespace Ocelot.Cache;
 public class DefaultCacheKeyGenerator : ICacheKeyGenerator
 {
     public const char Delimiter = '-';
-    
-    public async ValueTask<string> GenerateRequestCacheKey(DownstreamRequest downstreamRequest, DownstreamRoute downstreamRoute)
+
+    // TODO: Split the code into protected virtual methods for easier fine-tuning
+    public virtual async ValueTask<string> GenerateRequestCacheKey(DownstreamRequest downstreamRequest, DownstreamRoute downstreamRoute)
     {
         var builder = new StringBuilder()
             .Append(downstreamRequest.Method)

--- a/src/Ocelot/Cache/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/OutputCacheMiddleware.cs
@@ -57,11 +57,17 @@ public class OutputCacheMiddleware : OcelotMiddleware
         }
 
         var downstreamResponse = httpContext.Items.DownstreamResponse();
-        cached = await CreateCachedResponse(downstreamResponse);
-
-        var ttl = TimeSpan.FromSeconds(options.TtlSeconds);
-        _outputCache.Add(downStreamRequestCacheKey, cached, options.Region, ttl);
-        Logger.LogDebug(() => $"Finished response added to cache for the '{downstreamUrlKey}' key.");
+        if (downstreamResponse.StatusCode == HttpStatusCode.OK)
+        {
+            cached = await CreateCachedResponse(downstreamResponse);
+            var ttl = TimeSpan.FromSeconds(options.TtlSeconds);
+            _outputCache.Add(downStreamRequestCacheKey, cached, options.Region, ttl);
+            Logger.LogDebug(() => $"Finished response added to cache for the '{downstreamUrlKey}' key.");
+        }
+        else
+        {
+            Logger.LogDebug($"HTTP request failed: could not create cache for the '{downstreamUrlKey}' key.");
+        }
     }
 
     private static void SetHttpResponseMessageThisRequest(HttpContext context, DownstreamResponse response)

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -2,7 +2,6 @@
 using Ocelot.Configuration;
 using Ocelot.Middleware;
 using Ocelot.Responses;
-using System.Threading.Tasks;
 
 namespace Ocelot.Security.IPSecurity;
 

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -2,6 +2,7 @@
 using Ocelot.Configuration;
 using Ocelot.Middleware;
 using Ocelot.Responses;
+using System.Threading.Tasks;
 
 namespace Ocelot.Security.IPSecurity;
 

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -9,7 +9,7 @@ public class IPSecurityPolicy : ISecurityPolicy
 {
     public Response Security(DownstreamRoute downstreamRoute, HttpContext context)
     {
-        var clientIp = context.Connection.RemoteIpAddress;
+        var clientIp = context.GetClientIpAddress();
         var options = downstreamRoute.SecurityOptions;
         if (options == null || clientIp == null)
         {
@@ -18,7 +18,7 @@ public class IPSecurityPolicy : ISecurityPolicy
 
         if (options.IPBlockedList?.Count > 0)
         {
-            if (options.IPBlockedList.Contains(clientIp.ToString()))
+            if (options.IPBlockedList.Contains(clientIp))
             {
                 var error = new UnauthenticatedError($"This request rejects access to {clientIp} IP");
                 return new ErrorResponse(error);
@@ -27,7 +27,7 @@ public class IPSecurityPolicy : ISecurityPolicy
 
         if (options.IPAllowedList?.Count > 0)
         {
-            if (!options.IPAllowedList.Contains(clientIp.ToString()))
+            if (!options.IPAllowedList.Contains(clientIp))
             {
                 var error = new UnauthenticatedError($"{clientIp} does not allow access, the request is invalid");
                 return new ErrorResponse(error);

--- a/src/Ocelot/Security/SecurityPolicyExtensions.cs
+++ b/src/Ocelot/Security/SecurityPolicyExtensions.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ocelot.Security
+{
+    public static class SecurityPolicyExtensions
+    {
+        public static string GetClientIpAddress(this HttpContext httpContext, bool tryUseXForwardHeader = true)
+        {
+
+            string ip = null;
+            if (httpContext == null)
+            {
+                return ip;
+            }
+            // X-Forwarded-For =>  Using the First entry in the list
+            if (string.IsNullOrWhiteSpace(ip) && tryUseXForwardHeader)
+            {
+                ip = httpContext.GetHeaderValue("X-Forwarded-For").SplitCsv().FirstOrDefault();
+            }
+            // RemoteIpAddress is always null in DNX RC1 Update1 (bug).
+            if (string.IsNullOrWhiteSpace(ip) && httpContext.Connection?.RemoteIpAddress != null)
+            {
+                ip = httpContext.Connection.RemoteIpAddress.ToString();
+            }
+            if (string.IsNullOrWhiteSpace(ip))
+            {
+                ip = httpContext.GetHeaderValue("REMOTE_ADDR");
+            } 
+            if (ip == "::1")
+            {
+                ip = "127.0.0.1";
+            }
+            return ip;
+        }
+     
+
+
+        public static string GetHeaderValue(this HttpContext httpContext, string headerName)
+        {
+            if (httpContext?.Request?.Headers?.TryGetValue(headerName, out StringValues values) ?? false)
+            {
+                return values.ToString();
+            }
+            return string.Empty;
+        }
+
+        public static List<string> SplitCsv(this string csvList, bool nullOrWhitespaceInputReturnsNull = false)
+        {
+            if (string.IsNullOrWhiteSpace(csvList))
+            {
+                return nullOrWhitespaceInputReturnsNull ? null : new List<string>();
+            }
+
+            return csvList
+                .TrimEnd(',')
+                .Split(',')
+                .AsEnumerable()
+                .Select(s => s.Trim())
+                .ToList();
+        }
+    }
+}

--- a/src/Ocelot/Security/SecurityPolicyExtensions.cs
+++ b/src/Ocelot/Security/SecurityPolicyExtensions.cs
@@ -1,66 +1,68 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Ocelot.Security
+namespace Ocelot.Security;
+
+public static class SecurityPolicyExtensions
 {
-    public static class SecurityPolicyExtensions
+    public static string GetClientIpAddress(this HttpContext httpContext, bool tryUseXForwardHeader = true)
     {
-        public static string GetClientIpAddress(this HttpContext httpContext, bool tryUseXForwardHeader = true)
+        if (httpContext == null)
         {
-
-            string ip = null;
-            if (httpContext == null)
-            {
-                return ip;
-            }
-            // X-Forwarded-For =>  Using the First entry in the list
-            if (string.IsNullOrWhiteSpace(ip) && tryUseXForwardHeader)
-            {
-                ip = httpContext.GetHeaderValue("X-Forwarded-For").SplitCsv().FirstOrDefault();
-            }
-            // RemoteIpAddress is always null in DNX RC1 Update1 (bug).
-            if (string.IsNullOrWhiteSpace(ip) && httpContext.Connection?.RemoteIpAddress != null)
-            {
-                ip = httpContext.Connection.RemoteIpAddress.ToString();
-            }
-            if (string.IsNullOrWhiteSpace(ip))
-            {
-                ip = httpContext.GetHeaderValue("REMOTE_ADDR");
-            } 
-            if (ip == "::1")
-            {
-                ip = "127.0.0.1";
-            }
-            return ip;
-        }
-     
-
-
-        public static string GetHeaderValue(this HttpContext httpContext, string headerName)
-        {
-            if (httpContext?.Request?.Headers?.TryGetValue(headerName, out StringValues values) ?? false)
-            {
-                return values.ToString();
-            }
-            return string.Empty;
+            return null;
         }
 
-        public static List<string> SplitCsv(this string csvList, bool nullOrWhitespaceInputReturnsNull = false)
-        {
-            if (string.IsNullOrWhiteSpace(csvList))
-            {
-                return nullOrWhitespaceInputReturnsNull ? null : new List<string>();
-            }
+        string ip = null;
 
-            return csvList
-                .TrimEnd(',')
-                .Split(',')
-                .AsEnumerable()
-                .Select(s => s.Trim())
-                .ToList();
+        // X-Forwarded-For =>  Using the First entry in the list
+        if (string.IsNullOrWhiteSpace(ip) && tryUseXForwardHeader)
+        {
+            ip = httpContext.GetHeaderValue("X-Forwarded-For").SplitCsv().FirstOrDefault();
         }
+
+        // RemoteIpAddress is always null in DNX RC1 Update1 (bug).
+        if (string.IsNullOrWhiteSpace(ip) && httpContext.Connection?.RemoteIpAddress != null)
+        {
+            ip = httpContext.Connection.RemoteIpAddress.ToString();
+        }
+
+        if (string.IsNullOrWhiteSpace(ip))
+        {
+            ip = httpContext.GetHeaderValue("REMOTE_ADDR");
+        } 
+
+        if (ip == "::1")
+        {
+            ip = "127.0.0.1";
+        }
+
+        return ip;
+    }
+
+    public static string GetHeaderValue(this HttpContext httpContext, string headerName)
+    {
+        if (httpContext?.Request?.Headers?.TryGetValue(headerName, out StringValues values) ?? false)
+        {
+            return values.ToString();
+        }
+
+        return string.Empty;
+    }
+
+    public static List<string> SplitCsv(this string csvList, bool nullOrWhitespaceInputReturnsNull = false)
+    {
+        if (string.IsNullOrWhiteSpace(csvList))
+        {
+            return nullOrWhitespaceInputReturnsNull ? null : new List<string>();
+        }
+
+        return csvList
+            .TrimEnd(',')
+            .Split(',')
+            .AsEnumerable()
+            .Select(s => s.Trim())
+            .ToList();
     }
 }

--- a/src/Ocelot/Security/SecurityPolicyExtensions.cs
+++ b/src/Ocelot/Security/SecurityPolicyExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Ocelot.Security;
 

--- a/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Cache/OutputCacheMiddlewareTests.cs
@@ -134,6 +134,7 @@ public class OutputCacheMiddlewareTests : UnitTest
         // Arrange
         CachedResponse cached = null;
         GivenThereIsACachedResponse(cached);
+        GivenResponseIsNotCached(new HttpResponseMessage(HttpStatusCode.OK));
         GivenTheDownstreamRouteIs();
 
         // Act


### PR DESCRIPTION

## Proposed Changes
- Add content language header to `CacheKeyGenerator`
- IP filtering tries to find exact client (proxy, firewall, loadbalance)
- Schema can be modified by a service discovery provider
- Cache only if HTTP status is OK
