### PR TITLE
Caching `ClaimsPrincipal` during authentication and re-caching `FileConfiguration` objects in Consul and Disk File configuration repos

### DIFF
--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -54,7 +54,6 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
         var bytes = queryResult.Response.Value;
         var json = Encoding.UTF8.GetString(bytes);
         var consulConfig = JsonConvert.DeserializeObject<FileConfiguration>(json);
-
         return new OkResponse<FileConfiguration>(consulConfig);
     }
 
@@ -67,11 +66,10 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
             Value = bytes,
         };
 
-            var result = await _consul.KV.Put(kvPair);
-            if (result.Response)
-            {
-                _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(5), _configurationKey);
-
+        var result = await _consul.KV.Put(kvPair);
+        if (result.Response)
+        {
+            _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(5), _configurationKey);
             return new OkResponse();
         }
 

--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -57,6 +57,10 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
         return new OkResponse<FileConfiguration>(consulConfig);
     }
 
+    /// <summary>Default TTL in seconds for caching <see cref="FileConfiguration"/>.</summary>
+    /// <value>An <see cref="int"/> value.</value>
+    public static int CacheTtlSeconds { get; set; } = 5;
+
     public async Task<Response> Set(FileConfiguration ocelotConfiguration)
     {
         var json = JsonConvert.SerializeObject(ocelotConfiguration, Formatting.Indented);
@@ -69,7 +73,7 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
         var result = await _consul.KV.Put(kvPair);
         if (result.Response)
         {
-            _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(5), _configurationKey);
+            _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(CacheTtlSeconds), _configurationKey);
             return new OkResponse();
         }
 

--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -67,10 +67,10 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
             Value = bytes,
         };
 
-        var result = await _consul.KV.Put(kvPair);
-        if (result.Response)
-        {
-            _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(3), _configurationKey);
+            var result = await _consul.KV.Put(kvPair);
+            if (result.Response)
+            {
+                _cache.AddAndDelete(_configurationKey, ocelotConfiguration, TimeSpan.FromSeconds(5), _configurationKey);
 
             return new OkResponse();
         }

--- a/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
+++ b/src/Ocelot.Provider.Consul/ConsulFileConfigurationRepository.cs
@@ -57,8 +57,8 @@ public class ConsulFileConfigurationRepository : IFileConfigurationRepository
         return new OkResponse<FileConfiguration>(consulConfig);
     }
 
-    /// <summary>Default TTL in seconds for caching <see cref="FileConfiguration"/>.</summary>
-    /// <value>An <see cref="int"/> value.</value>
+    /// <summary>Default TTL in seconds for caching <see cref="FileConfiguration"/> in the <see cref="Set(FileConfiguration)"/> method.</summary>
+    /// <value>An <see cref="int"/> value, 5 by default.</value>
     public static int CacheTtlSeconds { get; set; } = 5;
 
     public async Task<Response> Set(FileConfiguration ocelotConfiguration)

--- a/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
+++ b/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Ocelot.Configuration;
 using Ocelot.Logging;
 using Ocelot.Middleware;
 using System;
+using System.Security.Claims;
 
 namespace Ocelot.Authentication.Middleware
 {

--- a/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
+++ b/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
@@ -22,6 +22,10 @@ namespace Ocelot.Authentication.Middleware
             _memoryCache = memoryCache;
         }
 
+        /// <summary>Default TTL in seconds for caching <see cref="ClaimsPrincipal"/> of the current <see cref="AuthenticateResult"/> object.</summary>
+        /// <value>An <see cref="int"/> value, 300 seconds (5 minutes) by default.</value>
+        public static int CacheTtlSeconds { get; set; } = 300;
+
         public async Task Invoke(HttpContext httpContext)
         {
             var request = httpContext.Request;
@@ -43,7 +47,7 @@ namespace Ocelot.Authentication.Middleware
             {
                 var auth = await AuthenticateAsync(httpContext, downstreamRoute);
                 principal = auth.Principal;
-                _memoryCache.Set(cacheKey, principal, TimeSpan.FromMinutes(5));
+                _memoryCache.Set(cacheKey, principal, TimeSpan.FromSeconds(CacheTtlSeconds));
             }
 
             if (principal?.Identity == null)

--- a/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
+++ b/src/Ocelot/Authentication/Middleware/AuthenticationMiddleware.cs
@@ -37,8 +37,8 @@ namespace Ocelot.Authentication.Middleware
             }
 
             Logger.LogInformation(() => $"The path '{path}' is an authenticated route! {MiddlewareName} checking if client is authenticated...");
-            var token = httpContext.Request.Headers.FirstOrDefault(r => r.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase));
-            var cacheKey = "identityToken." + token;
+            var token = httpContext.Request.Headers.Authorization;
+            var cacheKey = $"{nameof(AuthenticationMiddleware)}.{nameof(IHeaderDictionary.Authorization)}:{token}";
             if (!_memoryCache.TryGetValue(cacheKey, out ClaimsPrincipal principal))
             {
                 var auth = await AuthenticateAsync(httpContext, downstreamRoute);

--- a/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
@@ -32,10 +32,12 @@ namespace Ocelot.Configuration.Repository
 
         public DiskFileConfigurationRepository(IWebHostEnvironment hostingEnvironment,
             IOcelotConfigurationChangeTokenSource changeTokenSource,
+            IOcelotCache<FileConfiguration> cache,
             string folder)
         {
             _hostingEnvironment = hostingEnvironment;
             _changeTokenSource = changeTokenSource;
+            _cache = cache;
             Initialize(folder);
         }
 

--- a/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
@@ -51,7 +51,9 @@ namespace Ocelot.Configuration.Repository
             var configuration = _cache.Get(_cacheKey, _cacheKey);
 
             if (configuration != null)
+            {
                 return Task.FromResult<Response<FileConfiguration>>(new OkResponse<FileConfiguration>(configuration));
+            }
 
             string jsonConfiguration;
 

--- a/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
@@ -20,7 +20,7 @@ namespace Ocelot.Configuration.Repository
         private readonly object _lock = new();
 
         public DiskFileConfigurationRepository(IWebHostEnvironment hostingEnvironment,
-            IOcelotConfigurationChangeTokenSource changeTokenSource, Cache.IOcelotCache<FileConfiguration> cache)
+            IOcelotConfigurationChangeTokenSource changeTokenSource, IOcelotCache<FileConfiguration> cache)
         {
             _hostingEnvironment = hostingEnvironment;
             _changeTokenSource = changeTokenSource;

--- a/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
@@ -14,22 +14,25 @@ namespace Ocelot.Configuration.Repository
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly IOcelotConfigurationChangeTokenSource _changeTokenSource;
         private readonly IOcelotCache<FileConfiguration> _cache;
-        private readonly string _cacheKey;
+
         private FileInfo _ocelotFile;
         private FileInfo _environmentFile;
         private readonly object _lock = new();
+        public const string CacheKey = nameof(DiskFileConfigurationRepository);
 
         public DiskFileConfigurationRepository(IWebHostEnvironment hostingEnvironment,
-            IOcelotConfigurationChangeTokenSource changeTokenSource, IOcelotCache<FileConfiguration> cache)
+            IOcelotConfigurationChangeTokenSource changeTokenSource,
+            IOcelotCache<FileConfiguration> cache)
         {
             _hostingEnvironment = hostingEnvironment;
             _changeTokenSource = changeTokenSource;
-            Initialize(AppContext.BaseDirectory);
             _cache = cache;
-            _cacheKey = "InternalDiskFileConfigurationRepository";
+            Initialize(AppContext.BaseDirectory);
         }
 
-        public DiskFileConfigurationRepository(IWebHostEnvironment hostingEnvironment, IOcelotConfigurationChangeTokenSource changeTokenSource, string folder)
+        public DiskFileConfigurationRepository(IWebHostEnvironment hostingEnvironment,
+            IOcelotConfigurationChangeTokenSource changeTokenSource,
+            string folder)
         {
             _hostingEnvironment = hostingEnvironment;
             _changeTokenSource = changeTokenSource;
@@ -48,29 +51,25 @@ namespace Ocelot.Configuration.Repository
 
         public Task<Response<FileConfiguration>> Get()
         {
-            var configuration = _cache.Get(_cacheKey, _cacheKey);
-
+            var configuration = _cache.Get(CacheKey, region: CacheKey);
             if (configuration != null)
             {
                 return Task.FromResult<Response<FileConfiguration>>(new OkResponse<FileConfiguration>(configuration));
             }
 
             string jsonConfiguration;
-
             lock (_lock)
             {
                 jsonConfiguration = FileSys.ReadAllText(_environmentFile.FullName);
             }
 
             var fileConfiguration = JsonConvert.DeserializeObject<FileConfiguration>(jsonConfiguration);
-
             return Task.FromResult<Response<FileConfiguration>>(new OkResponse<FileConfiguration>(fileConfiguration));
         }
 
         public Task<Response> Set(FileConfiguration fileConfiguration)
         {
             var jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration, Formatting.Indented);
-
             lock (_lock)
             {
                 if (_environmentFile.Exists)
@@ -89,9 +88,7 @@ namespace Ocelot.Configuration.Repository
             }
 
             _changeTokenSource.Activate();
-
-            _cache.AddAndDelete(_cacheKey, fileConfiguration, TimeSpan.FromMinutes(5), _cacheKey);
-
+            _cache.AddAndDelete(CacheKey, fileConfiguration, TimeSpan.FromMinutes(5), region: CacheKey);
             return Task.FromResult<Response>(new OkResponse());
         }
     }

--- a/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
+++ b/src/Ocelot/Configuration/Repository/DiskFileConfigurationRepository.cs
@@ -67,6 +67,10 @@ namespace Ocelot.Configuration.Repository
             return Task.FromResult<Response<FileConfiguration>>(new OkResponse<FileConfiguration>(fileConfiguration));
         }
 
+        /// <summary>Default TTL in seconds for caching <see cref="FileConfiguration"/> in the <see cref="Set(FileConfiguration)"/> method.</summary>
+        /// <value>An <see cref="int"/> value, 300 seconds (5 minutes) by default.</value>
+        public static int CacheTtlSeconds { get; set; } = 300;
+
         public Task<Response> Set(FileConfiguration fileConfiguration)
         {
             var jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration, Formatting.Indented);
@@ -88,7 +92,7 @@ namespace Ocelot.Configuration.Repository
             }
 
             _changeTokenSource.Activate();
-            _cache.AddAndDelete(CacheKey, fileConfiguration, TimeSpan.FromMinutes(5), region: CacheKey);
+            _cache.AddAndDelete(CacheKey, fileConfiguration, TimeSpan.FromSeconds(CacheTtlSeconds), region: CacheKey);
             return Task.FromResult<Response>(new OkResponse());
         }
     }

--- a/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Memory;
+using Ocelot.Authentication.Middleware;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
 using Ocelot.Logging;

--- a/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Authentication/AuthenticationMiddlewareTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
@@ -49,7 +50,7 @@ namespace Ocelot.UnitTests.Authentication
                 isNextCalled = true;
                 return Task.CompletedTask;
             };
-            _middleware = new AuthenticationMiddleware(_next, _factory.Object);
+            _middleware = new AuthenticationMiddleware(_next, _factory.Object, new MemoryCache(new MemoryCacheOptions()));
             var expected = _middleware.GetType().Name;
 
             // Act
@@ -259,7 +260,7 @@ namespace Ocelot.UnitTests.Authentication
                 _httpContext.Response.Body = stream;
                 return Task.CompletedTask;
             };
-            _middleware = new AuthenticationMiddleware(_next, _factory.Object);
+            _middleware = new AuthenticationMiddleware(_next, _factory.Object, new MemoryCache(new MemoryCacheOptions()));
             await _middleware.Invoke(_httpContext);
         }
     }

--- a/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
+using Ocelot.Cache;
 using Ocelot.Configuration.ChangeTracking;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Repository;

--- a/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
@@ -14,22 +14,25 @@ namespace Ocelot.UnitTests.Configuration
     {
         private readonly Mock<IWebHostEnvironment> _hostingEnvironment;
         private readonly Mock<IOcelotConfigurationChangeTokenSource> _changeTokenSource;
+        private readonly Mock<IOcelotCache<FileConfiguration>> _cache;
         private IFileConfigurationRepository _repo;
         private FileConfiguration _result;
 
         public DiskFileConfigurationRepositoryTests()
         {
-            _hostingEnvironment = new Mock<IWebHostEnvironment>();
-            _changeTokenSource = new Mock<IOcelotConfigurationChangeTokenSource>(MockBehavior.Strict);
+            _hostingEnvironment = new();
+            _changeTokenSource = new();
+            _cache = new();
             _changeTokenSource.Setup(m => m.Activate());
-            var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
-            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
+
+            // TODO Add integration tests: var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, /*aspMemoryCache*/_cache.Object);
         }
 
         private void Arrange([CallerMemberName] string testName = null)
         {
             _hostingEnvironment.Setup(he => he.EnvironmentName).Returns(testName);
-            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, TestID);
+            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, _cache.Object, TestID);
         }
 
         [Fact]
@@ -125,8 +128,8 @@ namespace Ocelot.UnitTests.Configuration
         private void GivenTheEnvironmentNameIsUnavailable()
         {
             _hostingEnvironment.Setup(he => he.EnvironmentName).Returns(string.Empty);
-            var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
-            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
+            // TODO Add integration tests: var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            //_repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
         }
 
         private async Task WhenISetTheConfiguration(FileConfiguration fileConfiguration)

--- a/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
@@ -22,7 +22,7 @@ namespace Ocelot.UnitTests.Configuration
             _hostingEnvironment = new Mock<IWebHostEnvironment>();
             _changeTokenSource = new Mock<IOcelotConfigurationChangeTokenSource>(MockBehavior.Strict);
             _changeTokenSource.Setup(m => m.Activate());
-            var aspMemoryCache = new AspMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
             _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
         }
 
@@ -124,9 +124,8 @@ namespace Ocelot.UnitTests.Configuration
 
         private void GivenTheEnvironmentNameIsUnavailable()
         {
-            _environmentName = null;
-            _hostingEnvironment.Setup(he => he.EnvironmentName).Returns(_environmentName);
-            var aspMemoryCache = new AspMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            _hostingEnvironment.Setup(he => he.EnvironmentName).Returns(string.Empty);
+            var aspMemoryCache = new DefaultMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
             _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
         }
 

--- a/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
@@ -20,6 +20,8 @@ namespace Ocelot.UnitTests.Configuration
             _hostingEnvironment = new Mock<IWebHostEnvironment>();
             _changeTokenSource = new Mock<IOcelotConfigurationChangeTokenSource>(MockBehavior.Strict);
             _changeTokenSource.Setup(m => m.Activate());
+            var aspMemoryCache = new AspMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
         }
 
         private void Arrange([CallerMemberName] string testName = null)
@@ -120,7 +122,10 @@ namespace Ocelot.UnitTests.Configuration
 
         private void GivenTheEnvironmentNameIsUnavailable()
         {
-            _hostingEnvironment.Setup(he => he.EnvironmentName).Returns((string)null);
+            _environmentName = null;
+            _hostingEnvironment.Setup(he => he.EnvironmentName).Returns(_environmentName);
+            var aspMemoryCache = new AspMemoryCache<FileConfiguration>(new MemoryCache(new MemoryCacheOptions()));
+            _repo = new DiskFileConfigurationRepository(_hostingEnvironment.Object, _changeTokenSource.Object, aspMemoryCache);
         }
 
         private async Task WhenISetTheConfiguration(FileConfiguration fileConfiguration)


### PR DESCRIPTION
## New Feature
Cache response access token

## Motivation for New Feature
- Improve performance for cache identity response.
- Improve performance for cache disk file repository.
- In large projects and with many simultaneous requests, this cache is required.
