### PR TITLE
Missing scheme on downstream request

### DIFF
--- a/src/Ocelot/LoadBalancer/LoadBalancers/LeastConnection.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LeastConnection.cs
@@ -1,15 +1,13 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Responses;
+using Ocelot.Values;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Microsoft.AspNetCore.Http;
-
-using Ocelot.Middleware;
-using Ocelot.Responses;
-
-using Ocelot.Values;
-
+namespace Ocelot.LoadBalancer.LoadBalancers
+{
     public class LeastConnection : ILoadBalancer
     {
         private readonly Func<Task<List<Service>>> _services;


### PR DESCRIPTION
## Actual Behavior
On the **LeastConnection** balancer the downstream host **scheme** property is ignored and not return when **Lease** is called.

## Fixes
???

## Proposed Changes
- [LeastConnection](../blob/develop/src/Ocelot/LoadBalancer/LoadBalancers/LeastConnection.cs#L14) predicates (filters) take the `HostAndPort.Scheme` property into account