### PR TITLE
Fixs Issue 1233

### DIFF
--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -46,8 +46,9 @@
             }
 
             // Never change this to StreamContent again, I forgot it doesnt work in #464.
+            request.EnableBuffering();
             var content = new ByteArrayContent(await ToByteArray(request.Body));
-
+            request.Body.Position = 0;
             if (!string.IsNullOrEmpty(request.ContentType))
             {
                 content.Headers
@@ -106,13 +107,10 @@
 
         private async Task<byte[]> ToByteArray(Stream stream)
         {
-            using (stream)
+            using (var memStream = new MemoryStream())
             {
-                using (var memStream = new MemoryStream())
-                {
-                    await stream.CopyToAsync(memStream);
-                    return memStream.ToArray();
-                }
+                await stream.CopyToAsync(memStream);
+                return memStream.ToArray();
             }
         }
     }


### PR DESCRIPTION
Removed using stream as its only used in that location and its just disposing of the body before it can be used by the auth handler.

Fixes #1233

## Proposed Changes
  - Allow body to be used by custom authentication handlers and enables body to be re-read down the pipeline.
  - Removes disposal of the body via the using statement 
  - Enables re-reading of the body.  

