### PR TITLE
When the downstream service is not found, Consul provider throws an exception

### DIFF
--- a/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
@@ -1,12 +1,9 @@
+using Microsoft.AspNetCore.Http;
+using Ocelot.Responses;
+using Ocelot.Values;
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
-using Microsoft.AspNetCore.Http;
-
-using Ocelot.Responses;
-
-using Ocelot.Values;
 
 namespace Ocelot.LoadBalancer.LoadBalancers
 {

--- a/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
@@ -26,8 +26,8 @@ namespace Ocelot.LoadBalancer.LoadBalancers
             {
                 if (services.Count < 1)
                 {
-                    //When the downstream service is not found, LeastConnection prompts Warn and RoundRobin throws an exception。eg:/favicon.ico
-                    return new ErrorResponse<ServiceHostAndPort>(new ServicesAreEmptyError($"services were empty for {httpContext.Request.Path}"));
+                    // When the downstream service is not found, LeastConnection prompts Warn and RoundRobin throws an exception, eg: /favicon.ico
+                    return new ErrorResponse<ServiceHostAndPort>(new ServicesAreEmptyError($"Services were empty for {httpContext.Request.Path}"));
                 }
 
                 if (_last >= services.Count)

--- a/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/RoundRobin.cs
@@ -27,6 +27,12 @@ namespace Ocelot.LoadBalancer.LoadBalancers
             var services = await _services();
             lock (_lock)
             {
+                if (services.Count < 1)
+                {
+                    //When the downstream service is not found, LeastConnection prompts Warn and RoundRobin throws an exception。eg:/favicon.ico
+                    return new ErrorResponse<ServiceHostAndPort>(new ServicesAreEmptyError($"services were empty for {httpContext.Request.Path}"));
+                }
+
                 if (_last >= services.Count)
                 {
                     _last = 0;


### PR DESCRIPTION
## Actual Behavior

### Case 1: favicon.ico request
`ResponderMiddleware` generates warning for the route `/favicon.ico`

### Case 2: empty route in service discovery setup by Consul provider
`ExceptionHandlerMiddleware` generates exception for the route `/` in Consul setup.

## Fixes
???

## Proposed Changes
???