### PR TITLE
Fixed logger message typos in the OutputCacheMiddleware class

### DIFF
--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -40,22 +40,21 @@ namespace Ocelot.Cache.Middleware
             }
 
             var downstreamRequest = httpContext.Items.DownstreamRequest();
-
             var downstreamUrlKey = $"{downstreamRequest.Method}-{downstreamRequest.OriginalString}";
             var downStreamRequestCacheKey = _cacheGenerator.GenerateRequestCacheKey(downstreamRequest);
 
-            Logger.LogDebug($"Started checking cache for {downstreamUrlKey}");
+            Logger.LogDebug($"Started checking cache for the '{downstreamUrlKey}' key.");
 
             var cached = _outputCache.Get(downStreamRequestCacheKey, downstreamRoute.CacheOptions.Region);
 
             if (cached != null)
             {
-                Logger.LogDebug($"cache entry exists for {downstreamUrlKey}");
+                Logger.LogDebug($"Cache entry exists for the '{downstreamUrlKey}' key.");
 
                 var response = CreateHttpResponseMessage(cached);
                 SetHttpResponseMessageThisRequest(httpContext, response);
 
-                Logger.LogDebug($"finished returned cached response for {downstreamUrlKey}");
+                Logger.LogDebug($"Finished returning of cached response for the '{downstreamUrlKey}' key.");
 
                 return;
             }
@@ -66,7 +65,7 @@ namespace Ocelot.Cache.Middleware
 
             if (httpContext.Items.Errors().Count > 0)
             {
-                Logger.LogDebug($"there was a pipeline error for {downstreamUrlKey}");
+                Logger.LogDebug($"There was a pipeline error for the '{downstreamUrlKey}' key.");
 
                 return;
             }
@@ -77,7 +76,7 @@ namespace Ocelot.Cache.Middleware
 
             _outputCache.Add(downStreamRequestCacheKey, cached, TimeSpan.FromSeconds(downstreamRoute.CacheOptions.TtlSeconds), downstreamRoute.CacheOptions.Region);
 
-            Logger.LogDebug($"finished response added to cache for {downstreamUrlKey}");
+            Logger.LogDebug($"Finished response added to cache for the '{downstreamUrlKey}' key.");
         }
 
         private static void SetHttpResponseMessageThisRequest(HttpContext context,

--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -60,7 +60,7 @@ namespace Ocelot.Cache.Middleware
                 return;
             }
 
-            Logger.LogDebug($"No response cached for '{downstreamUrlKey}' key.");
+            Logger.LogDebug($"No response cached for the '{downstreamUrlKey}' key.");
 
             await _next.Invoke(httpContext);
 

--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -60,7 +60,7 @@ namespace Ocelot.Cache.Middleware
                 return;
             }
 
-            Logger.LogDebug($"no response cached for {downstreamUrlKey}");
+            Logger.LogDebug($"No response cached for '{downstreamUrlKey}' key.");
 
             await _next.Invoke(httpContext);
 

--- a/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
+++ b/src/Ocelot/Cache/Middleware/OutputCacheMiddleware.cs
@@ -60,7 +60,7 @@ namespace Ocelot.Cache.Middleware
                 return;
             }
 
-            Logger.LogDebug($"no resonse cached for {downstreamUrlKey}");
+            Logger.LogDebug($"no response cached for {downstreamUrlKey}");
 
             await _next.Invoke(httpContext);
 


### PR DESCRIPTION
## Proposed Changes

Fixed typos in the log when caching:
- [fixed typo in log](https://github.com/ThreeMammals/Ocelot/pull/1315/commits/e74a568a21f8c3e7125ec04e2b7f07faf94992a3)
- [Fix typos and improve logger messages for OutputCacheMiddleware](https://github.com/ThreeMammals/Ocelot/pull/1315/commits/c7c11c935c4400e97e8fc5e1dc22f605bf954d7b)

