### PR TITLE
Remove unnecessary dictionary get value call after TryGetValue

### DIFF
--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -25,8 +25,6 @@ namespace Ocelot.LoadBalancer.LoadBalancers
 
                 if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
                 {
-                    loadBalancer = _loadBalancers[route.LoadBalancerKey];
-
                     if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
                     {
                         result = _factory.Get(route, config);


### PR DESCRIPTION
`ConcurrentDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value)` already set parameter value if the given key exists.
So extra call to get value from dictionary is unnecessary here.

## Proposed Changes

  - No breaking changes but a small fix
