### PR TITLE
#653 Adding null check for downstreamResponse

### DIFF
--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -3,9 +3,6 @@ using Ocelot.Errors;
 using Ocelot.Infrastructure.Extensions;
 using Ocelot.Logging;
 using Ocelot.Middleware;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Ocelot.Responder.Middleware
 {

--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -3,6 +3,9 @@ using Ocelot.Errors;
 using Ocelot.Infrastructure.Extensions;
 using Ocelot.Logging;
 using Ocelot.Middleware;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Ocelot.Responder.Middleware
 {

--- a/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
+++ b/src/Ocelot/Responder/Middleware/ResponderMiddleware.cs
@@ -32,6 +32,7 @@ namespace Ocelot.Responder.Middleware
             await _next.Invoke(httpContext);
 
             var errors = httpContext.Items.Errors();
+            var downstreamResponse = httpContext.Items.DownstreamResponse();
 
             // todo check errors is ok
             if (errors.Count > 0)
@@ -40,11 +41,13 @@ namespace Ocelot.Responder.Middleware
 
                 SetErrorResponse(httpContext, errors);
             }
+            else if (downstreamResponse == null)
+            {
+                Logger.LogDebug($"Pipeline was terminated early in {MiddlewareName}");
+            }
             else
             {
                 Logger.LogDebug("no pipeline errors, setting and returning completed response");
-
-                var downstreamResponse = httpContext.Items.DownstreamResponse();
 
                 await _responder.SetResponseOnHttpContext(httpContext, downstreamResponse);
             }

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -306,12 +306,12 @@ namespace Ocelot.AcceptanceTests
             {
                 Routes = new List<FileRoute>
                     {
-                        new FileRoute
+                        new()
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamHostAndPorts = new List<FileHostAndPort>
                             {
-                                new FileHostAndPort
+                                new()
                                 {
                                     Host = "localhost",
                                     Port = port,

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -288,6 +288,51 @@ namespace Ocelot.AcceptanceTests
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_not_throw_when_pipeline_terminates_early()
+        {
+            var configuration = new OcelotPipelineConfiguration
+            {
+                PreQueryStringBuilderMiddleware = async (context, next) =>
+                {
+                    _counter++;
+                    return; // do not invoke the rest of the pipeline
+                },
+            };
+
+            var port = RandomPortFinder.GetRandomPort();
+
+            var fileConfiguration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                    {
+                        new FileRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = port,
+                                },
+                            },
+                            DownstreamScheme = "http",
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                        },
+                    },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, ""))
+                .And(x => _steps.GivenThereIsAConfiguration(fileConfiguration, _configurationPath))
+                .And(x => _steps.GivenOcelotIsRunning(configuration))
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => x.ThenTheCounterIs(1))
+                .BDDfy();
+        }
+
         [Fact(Skip = "This is just an example to show how you could hook into Ocelot pipeline with your own middleware. At the moment you must use Response.OnCompleted callback and cannot change the response :( I will see if this can be changed one day!")]
         public void should_fix_issue_237()
         {

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -293,11 +293,12 @@ namespace Ocelot.AcceptanceTests
         {
             var configuration = new OcelotPipelineConfiguration
             {
-                PreQueryStringBuilderMiddleware = async (context, next) =>
-                {
-                    _counter++;
-                    return; // do not invoke the rest of the pipeline
-                },
+                PreQueryStringBuilderMiddleware = (context, next) =>
+                    Task.Run(() =>
+                    {
+                        _counter++;
+                        return; // do not invoke the rest of the pipeline
+                    }),
             };
 
             var port = RandomPortFinder.GetRandomPort();
@@ -325,7 +326,7 @@ namespace Ocelot.AcceptanceTests
             };
 
             this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, ""))
-                .And(x => _steps.GivenThereIsAConfiguration(fileConfiguration, _configurationPath))
+                .And(x => _steps.GivenThereIsAConfiguration(fileConfiguration))
                 .And(x => _steps.GivenOcelotIsRunning(configuration))
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
                 .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))

--- a/test/Ocelot.UnitTests/Responder/ResponderMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ResponderMiddlewareTests.cs
@@ -49,6 +49,17 @@ namespace Ocelot.UnitTests.Responder
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_not_call_responder_when_null_downstream_response()
+        {
+            this._responder.Reset();
+            this.Given(x => x.GivenTheHttpResponseMessageIs(null))
+                .When(x => x.WhenICallTheMiddleware())
+                .Then(x => x.ThenThereAreNoErrors())
+                .Then(x => x._responder.VerifyNoOtherCalls())
+                .BDDfy();
+        }
+
         private void WhenICallTheMiddleware()
         {
             _middleware.Invoke(_httpContext).GetAwaiter().GetResult();


### PR DESCRIPTION
## Fixes #653 
Null reference when pipeline terminates early

## Proposed Changes
  - In **ResponderMiddleware.cs** added a check for null `downstreamResponse` to avoid getting a null ref exception by passing it to `SetResponseOnHttpContext`
  - Added a unit test to make sure `SetResponseOnHttpContext` does not get called in that case
  - Added an acceptance test to make sure that when the pipeline terminates early nothing blows up
