### PR TITLE
#1288 Query string char missing

### DIFF
--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -1,24 +1,16 @@
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration;
+using Ocelot.DownstreamRouteFinder.UrlMatcher;
+using Ocelot.DownstreamUrlCreator.UrlTemplateReplacer;
+using Ocelot.Logging;
+using Ocelot.Middleware;
+using Ocelot.Request.Middleware;
+using Ocelot.Responses;
+using Ocelot.Values;
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-
-using Ocelot.Configuration;
-
-using Ocelot.DownstreamRouteFinder.UrlMatcher;
-
-using Ocelot.Logging;
-
-using Microsoft.AspNetCore.Http;
-
-using Ocelot.Middleware;
-using Ocelot.Request.Middleware;
-
-using Ocelot.Responses;
-
-using Ocelot.DownstreamUrlCreator.UrlTemplateReplacer;
-
-using Ocelot.Values;
 
 namespace Ocelot.DownstreamUrlCreator.Middleware
 {

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -108,13 +108,12 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
             {
                 var name = nAndV.Name.Replace("{", string.Empty).Replace("}", string.Empty);
 
-                if (downstreamRequest.Query.Contains(name) &&
-                    downstreamRequest.Query.Contains(nAndV.Value))
+                var rgx = new Regex($@"\b{name}={nAndV.Value}\b");
+
+                if (rgx.IsMatch(downstreamRequest.Query))
                 {
                     var questionMarkOrAmpersand = downstreamRequest.Query.IndexOf(name, StringComparison.Ordinal);
                     downstreamRequest.Query = downstreamRequest.Query.Remove(questionMarkOrAmpersand - 1, 1);
-
-                    var rgx = new Regex($@"\b{name}={nAndV.Value}\b");
                     downstreamRequest.Query = rgx.Replace(downstreamRequest.Query, string.Empty);
 
                     if (!string.IsNullOrEmpty(downstreamRequest.Query))

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -58,11 +58,11 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
             if (ServiceFabricRequest(internalConfiguration, downstreamRoute))
             {
-                var pathAndQuery = CreateServiceFabricUri(downstreamRequest, downstreamRoute, templatePlaceholderNameAndValues, response);
+                var (path, query) = CreateServiceFabricUri(downstreamRequest, downstreamRoute, templatePlaceholderNameAndValues, response);
 
                 //todo check this works again hope there is a test..
-                downstreamRequest.AbsolutePath = pathAndQuery.Path;
-                downstreamRequest.Query = pathAndQuery.Query;
+                downstreamRequest.AbsolutePath = path;
+                downstreamRequest.Query = query;
             }
             else
             {

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -112,9 +112,9 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
                 if (rgx.IsMatch(downstreamRequest.Query))
                 {
-                    var questionMarkOrAmpersand = downstreamRequest.Query.IndexOf(name, StringComparison.Ordinal);
-                    downstreamRequest.Query = downstreamRequest.Query.Remove(questionMarkOrAmpersand - 1, 1);
+                    var questionMarkOrAmpersand = downstreamRequest.Query.IndexOf(name, StringComparison.Ordinal);                    
                     downstreamRequest.Query = rgx.Replace(downstreamRequest.Query, string.Empty);
+                    downstreamRequest.Query = downstreamRequest.Query.Remove(questionMarkOrAmpersand - 1, 1);
 
                     if (!string.IsNullOrEmpty(downstreamRequest.Query))
                     {

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -110,7 +110,7 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
                     if (!string.IsNullOrEmpty(downstreamRequest.Query))
                     {
-                        downstreamRequest.Query = '?' + downstreamRequest.Query.Substring(1);
+                        downstreamRequest.Query = string.Concat("?", downstreamRequest.Query.AsSpan(1));
                     }
                 }
             }

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -124,7 +124,8 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
         private static string GetQueryString(DownstreamPath dsPath)
         {
-            return dsPath.Value.Substring(dsPath.Value.IndexOf('?', StringComparison.Ordinal));
+            int startIndex = dsPath.Value.IndexOf('?', StringComparison.Ordinal);
+            return dsPath.Value[startIndex..];
         }
 
         private static bool ContainsQueryString(DownstreamPath dsPath)

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -118,7 +118,8 @@ namespace Ocelot.DownstreamUrlCreator.Middleware
 
         private static string GetPath(DownstreamPath dsPath)
         {
-            return dsPath.Value.Substring(0, dsPath.Value.IndexOf('?', StringComparison.Ordinal));
+            int length = dsPath.Value.IndexOf('?', StringComparison.Ordinal);
+            return dsPath.Value[..length];
         }
 
         private static string GetQueryString(DownstreamPath dsPath)

--- a/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
@@ -1,13 +1,9 @@
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
 using System;
 using System.Collections.Generic;
 using System.Net;
-
-using Ocelot.Configuration.File;
-
-using Microsoft.AspNetCore.Http;
-
 using TestStack.BDDfy;
-
 using Xunit;
 
 namespace Ocelot.AcceptanceTests

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -1,12 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
-
-using Microsoft.AspNetCore.Http;
-
+﻿using Microsoft.AspNetCore.Http;
 using Moq;
-
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
 using Ocelot.DownstreamRouteFinder;
@@ -17,15 +10,14 @@ using Ocelot.Infrastructure.RequestData;
 using Ocelot.Logging;
 using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
-
 using Ocelot.Responses;
-
-using Shouldly;
-
-using TestStack.BDDfy;
-
 using Ocelot.Values;
-
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using TestStack.BDDfy;
 using Xunit;
 
 namespace Ocelot.UnitTests.DownstreamUrlCreator
@@ -163,7 +155,7 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator
                         new List<PlaceholderNameAndValue>
                         {
                             new PlaceholderNameAndValue("{subscriptionId}", "1"),
-                            new PlaceholderNameAndValue("{unitId}", "2")
+                            new PlaceholderNameAndValue("{unitId}", "2"),
                         },
                         new RouteBuilder()
                             .WithDownstreamRoute(downstreamRoute)

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -137,7 +137,39 @@ namespace Ocelot.UnitTests.DownstreamUrlCreator
                             .WithDownstreamRoute(downstreamRoute)
                             .WithUpstreamHttpMethod(new List<string> { "Get" })
                             .Build())))
-                .And(x => x.GivenTheDownstreamRequestUriIs("http://localhost:5000/api/subscriptions/1/updates?unitId=2&productId=2"))
+                .And(x => x.GivenTheDownstreamRequestUriIs("http://localhost:5000/api/subscriptions/1/updates?unitId=2&productId=2")) // unitId is the first
+                .And(x => GivenTheServiceProviderConfigIs(config))
+                .And(x => x.GivenTheUrlReplacerWillReturn("api/units/1/2/updates"))
+                .When(x => x.WhenICallTheMiddleware())
+                .Then(x => x.ThenTheDownstreamRequestUriIs("https://localhost:5000/api/units/1/2/updates?productId=2"))
+                .And(x => ThenTheQueryStringIs("?productId=2"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_replace_query_string_but_leave_non_placeholder_queries_2()
+        {
+            var downstreamRoute = new DownstreamRouteBuilder()
+                .WithDownstreamPathTemplate("/api/units/{subscriptionId}/{unitId}/updates")
+                .WithUpstreamHttpMethod(new List<string> { "Get" })
+                .WithDownstreamScheme("https")
+                .Build();
+
+            var config = new ServiceProviderConfigurationBuilder()
+                .Build();
+
+            this.Given(x => x.GivenTheDownStreamRouteIs(
+                    new DownstreamRouteHolder(
+                        new List<PlaceholderNameAndValue>
+                        {
+                            new PlaceholderNameAndValue("{subscriptionId}", "1"),
+                            new PlaceholderNameAndValue("{unitId}", "2")
+                        },
+                        new RouteBuilder()
+                            .WithDownstreamRoute(downstreamRoute)
+                            .WithUpstreamHttpMethod(new List<string> { "Get" })
+                            .Build())))
+                .And(x => x.GivenTheDownstreamRequestUriIs("http://localhost:5000/api/subscriptions/1/updates?productId=2&unitId=2")) // unitId is the second
                 .And(x => GivenTheServiceProviderConfigIs(config))
                 .And(x => x.GivenTheUrlReplacerWillReturn("api/units/1/2/updates"))
                 .When(x => x.WhenICallTheMiddleware())


### PR DESCRIPTION
## Fixes #1288

## Proposed Changes
- the regex that is used to replace placeholder name and value should be used also in the `if` condition before
- The last commit fixed one more problem: when a query param was not the first one, it hadn't been removed.
