### PR TITLE
Changed search for provider name to be more permissive (doc change too)

### DIFF
--- a/docs/features/kubernetes.rst
+++ b/docs/features/kubernetes.rst
@@ -51,13 +51,14 @@ The following example shows how to set up a Route that will work in kubernetes. 
       "Port": 443,
       "Token": "txpc696iUhbVoudg164r93CxDTrKRVWG",
       "Namespace": "dev",
-      "Type": "kube"
+      "Type": "kubernetes"
     }
   }
 }
     
-Service deployment in Namespace Dev , ServiceDiscoveryProvider type is kube, you also can set pollkube ServiceDiscoveryProvider type.
-  Note: Host、 Port and Token are no longer in use。
+Service deployment in Namespace Dev, ServiceDiscoveryProvider type is kubernetes.
+
+You also can set pollkube ServiceDiscoveryProvider type. Note: Host, Port and Token are no longer in use。
 
 You use Ocelot to poll kubernetes for latest service information rather than per request. If you want to poll kubernetes for the latest services rather than per request (default behaviour) then you need to set the following configuration.
 

--- a/src/Ocelot/ServiceDiscovery/ServiceDiscoveryProviderFactory.cs
+++ b/src/Ocelot/ServiceDiscovery/ServiceDiscoveryProviderFactory.cs
@@ -54,13 +54,27 @@ namespace Ocelot.ServiceDiscovery
             {
                 var provider = _delegates?.Invoke(_provider, config, route);
 
-                if (provider.GetType().Name.ToLower() == config.Type.ToLower())
+                if (MatchProviderName(config, provider))
                 {
                     return new OkResponse<IServiceDiscoveryProvider>(provider);
                 }
             }
 
             return new ErrorResponse<IServiceDiscoveryProvider>(new UnableToFindServiceDiscoveryProviderError($"Unable to find service discovery provider for type: {config.Type}"));
+        }
+
+        private static bool MatchProviderName(ServiceProviderConfiguration config, IServiceDiscoveryProvider provider)
+        {
+            var configTypeName = config.Type.ToLowerInvariant();
+            var providerTypeName = provider.GetType().Name.ToLowerInvariant();
+
+            return providerTypeName == configTypeName ||
+                providerTypeName == string.Concat(configTypeName, "provider") ||
+                providerTypeName == string.Concat(configTypeName, "discoveryprovider") ||
+                providerTypeName == string.Concat(configTypeName, "servicediscoveryprovider");
+
+
+
         }
     }
 }


### PR DESCRIPTION
Fixes / New Feature #1346

## Proposed Changes

  - Change search to include provider name, provider name + "Provider", provider name + "DiscoveryProvider", and provider name + "ServiceDiscoveryProvider".
  - Added tests for this.
  - Changed docs for kubernetes to use the type of kubernetes since issue type of 'kube' never worked. 
