### PR TITLE
#692 Simplify downstream service config

### DIFF
--- a/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using Ocelot.Logging;
 
 using Ocelot.Configuration.File;
 
@@ -7,9 +8,38 @@ namespace Ocelot.Configuration.Creator
 {
     public class DownstreamAddressesCreator : IDownstreamAddressesCreator
     {
-        public List<DownstreamHostAndPort> Create(FileRoute route)
+        private readonly IOcelotLogger _logger;
+
+        public DownstreamAddressesCreator(IOcelotLoggerFactory loggerFactory)
         {
-            return route.DownstreamHostAndPorts.Select(hostAndPort => new DownstreamHostAndPort(hostAndPort.Host, hostAndPort.Port)).ToList();
+            _logger = loggerFactory.CreateLogger<DownstreamAddressesCreator>();
+        }
+
+        public List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration)
+        {
+            return EnumerateDownstreamHosts(route, globalConfiguration).ToList();
+        }
+
+        private IEnumerable<DownstreamHostAndPort> EnumerateDownstreamHosts(FileRoute route, FileGlobalConfiguration fileGlobalConfiguration)
+        {
+            foreach (var downstreamHost in route.DownstreamHostAndPorts)
+            {
+                if (string.IsNullOrWhiteSpace(downstreamHost.GlobalHostKey) == false)
+                {
+                    if (fileGlobalConfiguration.DownstreamHosts.TryGetValue(downstreamHost.GlobalHostKey, out var globalDownstreamHost))
+                    {
+                        yield return new DownstreamHostAndPort(globalDownstreamHost.Host, globalDownstreamHost.Port);
+                    }
+                    else
+                    {
+                        _logger.LogWarning($"Global configuration doesn't contain the definition of '{downstreamHost.GlobalHostKey}' downstream host");
+                    }
+                }
+                else
+                {
+                    yield return new DownstreamHostAndPort(downstreamHost.Host, downstreamHost.Port);
+                }
+            }
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
@@ -4,41 +4,40 @@ using Ocelot.Logging;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public class DownstreamAddressesCreator : IDownstreamAddressesCreator
 {
-    public class DownstreamAddressesCreator : IDownstreamAddressesCreator
+    private readonly IOcelotLogger _logger;
+
+    public DownstreamAddressesCreator(IOcelotLoggerFactory loggerFactory)
     {
-        private readonly IOcelotLogger _logger;
+        _logger = loggerFactory.CreateLogger<DownstreamAddressesCreator>();
+    }
 
-        public DownstreamAddressesCreator(IOcelotLoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<DownstreamAddressesCreator>();
-        }
+    public List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration)
+    {
+        return EnumerateDownstreamHosts(route, globalConfiguration).ToList();
+    }
 
-        public List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration)
+    private IEnumerable<DownstreamHostAndPort> EnumerateDownstreamHosts(FileRoute route, FileGlobalConfiguration fileGlobalConfiguration)
+    {
+        foreach (var downstreamHost in route.DownstreamHostAndPorts)
         {
-            return EnumerateDownstreamHosts(route, globalConfiguration).ToList();
-        }
-
-        private IEnumerable<DownstreamHostAndPort> EnumerateDownstreamHosts(FileRoute route, FileGlobalConfiguration fileGlobalConfiguration)
-        {
-            foreach (var downstreamHost in route.DownstreamHostAndPorts)
+            if (string.IsNullOrWhiteSpace(downstreamHost.GlobalHostKey) == false)
             {
-                if (string.IsNullOrWhiteSpace(downstreamHost.GlobalHostKey) == false)
+                if (fileGlobalConfiguration.DownstreamHosts.TryGetValue(downstreamHost.GlobalHostKey, out var globalDownstreamHost))
                 {
-                    if (fileGlobalConfiguration.DownstreamHosts.TryGetValue(downstreamHost.GlobalHostKey, out var globalDownstreamHost))
-                    {
-                        yield return new DownstreamHostAndPort(globalDownstreamHost.Host, globalDownstreamHost.Port);
-                    }
-                    else
-                    {
-                        _logger.LogWarning($"Global configuration doesn't contain the definition of '{downstreamHost.GlobalHostKey}' downstream host");
-                    }
+                    yield return new DownstreamHostAndPort(globalDownstreamHost.Host, globalDownstreamHost.Port);
                 }
                 else
                 {
-                    yield return new DownstreamHostAndPort(downstreamHost.Host, downstreamHost.Port);
+                    _logger.LogWarning($"Global configuration doesn't contain the definition of '{downstreamHost.GlobalHostKey}' downstream host");
                 }
+            }
+            else
+            {
+                yield return new DownstreamHostAndPort(downstreamHost.Host, downstreamHost.Port);
             }
         }
     }

--- a/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/DownstreamAddressesCreator.cs
@@ -4,40 +4,41 @@ using Ocelot.Logging;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator;
-
-public class DownstreamAddressesCreator : IDownstreamAddressesCreator
+namespace Ocelot.Configuration.Creator
 {
-    private readonly IOcelotLogger _logger;
-
-    public DownstreamAddressesCreator(IOcelotLoggerFactory loggerFactory)
+    public class DownstreamAddressesCreator : IDownstreamAddressesCreator
     {
-        _logger = loggerFactory.CreateLogger<DownstreamAddressesCreator>();
-    }
+        private readonly IOcelotLogger _logger;
 
-    public List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration)
-    {
-        return EnumerateDownstreamHosts(route, globalConfiguration).ToList();
-    }
-
-    private IEnumerable<DownstreamHostAndPort> EnumerateDownstreamHosts(FileRoute route, FileGlobalConfiguration fileGlobalConfiguration)
-    {
-        foreach (var downstreamHost in route.DownstreamHostAndPorts)
+        public DownstreamAddressesCreator(IOcelotLoggerFactory loggerFactory)
         {
-            if (string.IsNullOrWhiteSpace(downstreamHost.GlobalHostKey) == false)
+            _logger = loggerFactory.CreateLogger<DownstreamAddressesCreator>();
+        }
+
+        public List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration)
+        {
+            return EnumerateDownstreamHosts(route, globalConfiguration).ToList();
+        }
+
+        private IEnumerable<DownstreamHostAndPort> EnumerateDownstreamHosts(FileRoute route, FileGlobalConfiguration fileGlobalConfiguration)
+        {
+            foreach (var downstreamHost in route.DownstreamHostAndPorts)
             {
-                if (fileGlobalConfiguration.DownstreamHosts.TryGetValue(downstreamHost.GlobalHostKey, out var globalDownstreamHost))
+                if (string.IsNullOrWhiteSpace(downstreamHost.GlobalHostKey) == false)
                 {
-                    yield return new DownstreamHostAndPort(globalDownstreamHost.Host, globalDownstreamHost.Port);
+                    if (fileGlobalConfiguration.DownstreamHosts.TryGetValue(downstreamHost.GlobalHostKey, out var globalDownstreamHost))
+                    {
+                        yield return new DownstreamHostAndPort(globalDownstreamHost.Host, globalDownstreamHost.Port);
+                    }
+                    else
+                    {
+                        _logger.LogWarning($"Global configuration doesn't contain the definition of '{downstreamHost.GlobalHostKey}' downstream host");
+                    }
                 }
                 else
                 {
-                    _logger.LogWarning($"Global configuration doesn't contain the definition of '{downstreamHost.GlobalHostKey}' downstream host");
+                    yield return new DownstreamHostAndPort(downstreamHost.Host, downstreamHost.Port);
                 }
-            }
-            else
-            {
-                yield return new DownstreamHostAndPort(downstreamHost.Host, downstreamHost.Port);
             }
         }
     }

--- a/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
@@ -6,6 +6,6 @@ namespace Ocelot.Configuration.Creator
 {
     public interface IDownstreamAddressesCreator
     {
-        List<DownstreamHostAndPort> Create(FileRoute route);
+        List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration);
     }
 }

--- a/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
@@ -2,10 +2,9 @@ using System.Collections.Generic;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public interface IDownstreamAddressesCreator
 {
-    public interface IDownstreamAddressesCreator
-    {
-        List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration);
-    }
+    List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration);
 }

--- a/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/IDownstreamAddressesCreator.cs
@@ -2,9 +2,10 @@ using System.Collections.Generic;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator;
-
-public interface IDownstreamAddressesCreator
+namespace Ocelot.Configuration.Creator
 {
-    List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration);
+    public interface IDownstreamAddressesCreator
+    {
+        List<DownstreamHostAndPort> Create(FileRoute route, FileGlobalConfiguration globalConfiguration);
+    }
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -9,11 +9,18 @@ namespace Ocelot.Configuration.Creator
     {
         public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
             ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
-            : $"{fileRoute.UpstreamPathTemplate}|{string.Join(',', fileRoute.UpstreamHttpMethod)}|{string.Join(',', fileRoute.DownstreamHostAndPorts.Select(x => $"{x.Host}:{x.Port}"))}";
+            : $"{fileRoute.UpstreamPathTemplate}|{ToUpstreamHttpMethodPart(fileRoute)}|{ToDownstreamHostPart(fileRoute)}";
 
         private static bool IsStickySession(FileRoute fileRoute) =>
             !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
             && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
             && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
+
+        private static string ToDownstreamHostPart(FileRoute fileRoute)
+            => string.Join(",", fileRoute.DownstreamHostAndPorts
+                .Select(x => string.IsNullOrWhiteSpace(x.GlobalHostKey) ? $"{x.Host}:{x.Port}": x.GlobalHostKey));
+
+        private static string ToUpstreamHttpMethodPart(FileRoute fileRoute)
+            => string.Join(",", fileRoute.UpstreamHttpMethod);
     }
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -3,24 +3,23 @@ using System.Linq;
 using Ocelot.Configuration.File;
 using Ocelot.LoadBalancer.LoadBalancers;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public class RouteKeyCreator : IRouteKeyCreator
 {
-    public class RouteKeyCreator : IRouteKeyCreator
-    {
-        public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
-            ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
-            : $"{fileRoute.UpstreamPathTemplate}|{ToUpstreamHttpMethodPart(fileRoute)}|{ToDownstreamHostPart(fileRoute)}";
+    public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
+        ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
+        : $"{fileRoute.UpstreamPathTemplate}|{ToUpstreamHttpMethodPart(fileRoute)}|{ToDownstreamHostPart(fileRoute)}";
 
-        private static bool IsStickySession(FileRoute fileRoute) =>
-            !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
-            && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
-            && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
+    private static bool IsStickySession(FileRoute fileRoute) =>
+        !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
+        && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
+        && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
 
-        private static string ToDownstreamHostPart(FileRoute fileRoute)
-            => string.Join(",", fileRoute.DownstreamHostAndPorts
-                .Select(x => string.IsNullOrWhiteSpace(x.GlobalHostKey) ? $"{x.Host}:{x.Port}": x.GlobalHostKey));
+    private static string ToDownstreamHostPart(FileRoute fileRoute)
+        => string.Join(",", fileRoute.DownstreamHostAndPorts
+            .Select(x => string.IsNullOrWhiteSpace(x.GlobalHostKey) ? $"{x.Host}:{x.Port}": x.GlobalHostKey));
 
-        private static string ToUpstreamHttpMethodPart(FileRoute fileRoute)
-            => string.Join(",", fileRoute.UpstreamHttpMethod);
-    }
+    private static string ToUpstreamHttpMethodPart(FileRoute fileRoute)
+        => string.Join(",", fileRoute.UpstreamHttpMethod);
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -3,23 +3,24 @@ using System.Linq;
 using Ocelot.Configuration.File;
 using Ocelot.LoadBalancer.LoadBalancers;
 
-namespace Ocelot.Configuration.Creator;
-
-public class RouteKeyCreator : IRouteKeyCreator
+namespace Ocelot.Configuration.Creator
 {
-    public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
-        ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
-        : $"{fileRoute.UpstreamPathTemplate}|{ToUpstreamHttpMethodPart(fileRoute)}|{ToDownstreamHostPart(fileRoute)}";
+    public class RouteKeyCreator : IRouteKeyCreator
+    {
+        public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
+            ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
+            : $"{fileRoute.UpstreamPathTemplate}|{ToUpstreamHttpMethodPart(fileRoute)}|{ToDownstreamHostPart(fileRoute)}";
 
-    private static bool IsStickySession(FileRoute fileRoute) =>
-        !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
-        && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
-        && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
+        private static bool IsStickySession(FileRoute fileRoute) =>
+            !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
+            && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
+            && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
 
-    private static string ToDownstreamHostPart(FileRoute fileRoute)
-        => string.Join(",", fileRoute.DownstreamHostAndPorts
-            .Select(x => string.IsNullOrWhiteSpace(x.GlobalHostKey) ? $"{x.Host}:{x.Port}": x.GlobalHostKey));
+        private static string ToDownstreamHostPart(FileRoute fileRoute)
+            => string.Join(",", fileRoute.DownstreamHostAndPorts
+                .Select(x => string.IsNullOrWhiteSpace(x.GlobalHostKey) ? $"{x.Host}:{x.Port}": x.GlobalHostKey));
 
-    private static string ToUpstreamHttpMethodPart(FileRoute fileRoute)
-        => string.Join(",", fileRoute.UpstreamHttpMethod);
+        private static string ToUpstreamHttpMethodPart(FileRoute fileRoute)
+            => string.Join(",", fileRoute.UpstreamHttpMethod);
+    }
 }

--- a/src/Ocelot/Configuration/Creator/RoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RoutesCreator.cs
@@ -104,7 +104,7 @@ namespace Ocelot.Configuration.Creator
 
             var hAndRs = _headerFAndRCreator.Create(fileRoute);
 
-            var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute);
+            var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute, globalConfiguration);
 
             var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
 

--- a/src/Ocelot/Configuration/Creator/RoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RoutesCreator.cs
@@ -7,163 +7,164 @@ using Ocelot.Cache;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator;
-
-public class RoutesCreator : IRoutesCreator
+namespace Ocelot.Configuration.Creator
 {
-    private readonly ILoadBalancerOptionsCreator _loadBalancerOptionsCreator;
-    private readonly IClaimsToThingCreator _claimsToThingCreator;
-    private readonly IAuthenticationOptionsCreator _authOptionsCreator;
-    private readonly IUpstreamTemplatePatternCreator _upstreamTemplatePatternCreator;
-    private readonly IRequestIdKeyCreator _requestIdKeyCreator;
-    private readonly IQoSOptionsCreator _qosOptionsCreator;
-    private readonly IRouteOptionsCreator _fileRouteOptionsCreator;
-    private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
-    private readonly IRegionCreator _regionCreator;
-    private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
-    private readonly IHeaderFindAndReplaceCreator _headerFAndRCreator;
-    private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
-    private readonly IRouteKeyCreator _routeKeyCreator;
-    private readonly ISecurityOptionsCreator _securityOptionsCreator;
-    private readonly IVersionCreator _versionCreator;
-
-    public RoutesCreator(
-        IClaimsToThingCreator claimsToThingCreator,
-        IAuthenticationOptionsCreator authOptionsCreator,
-        IUpstreamTemplatePatternCreator upstreamTemplatePatternCreator,
-        IRequestIdKeyCreator requestIdKeyCreator,
-        IQoSOptionsCreator qosOptionsCreator,
-        IRouteOptionsCreator fileRouteOptionsCreator,
-        IRateLimitOptionsCreator rateLimitOptionsCreator,
-        IRegionCreator regionCreator,
-        IHttpHandlerOptionsCreator httpHandlerOptionsCreator,
-        IHeaderFindAndReplaceCreator headerFAndRCreator,
-        IDownstreamAddressesCreator downstreamAddressesCreator,
-        ILoadBalancerOptionsCreator loadBalancerOptionsCreator,
-        IRouteKeyCreator routeKeyCreator,
-        ISecurityOptionsCreator securityOptionsCreator,
-        IVersionCreator versionCreator
-        )
+    public class RoutesCreator : IRoutesCreator
     {
-        _routeKeyCreator = routeKeyCreator;
-        _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
-        _downstreamAddressesCreator = downstreamAddressesCreator;
-        _headerFAndRCreator = headerFAndRCreator;
-        _regionCreator = regionCreator;
-        _rateLimitOptionsCreator = rateLimitOptionsCreator;
-        _requestIdKeyCreator = requestIdKeyCreator;
-        _upstreamTemplatePatternCreator = upstreamTemplatePatternCreator;
-        _authOptionsCreator = authOptionsCreator;
-        _claimsToThingCreator = claimsToThingCreator;
-        _qosOptionsCreator = qosOptionsCreator;
-        _fileRouteOptionsCreator = fileRouteOptionsCreator;
-        _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
-        _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
-        _securityOptionsCreator = securityOptionsCreator;
-        _versionCreator = versionCreator;
-    }
+        private readonly ILoadBalancerOptionsCreator _loadBalancerOptionsCreator;
+        private readonly IClaimsToThingCreator _claimsToThingCreator;
+        private readonly IAuthenticationOptionsCreator _authOptionsCreator;
+        private readonly IUpstreamTemplatePatternCreator _upstreamTemplatePatternCreator;
+        private readonly IRequestIdKeyCreator _requestIdKeyCreator;
+        private readonly IQoSOptionsCreator _qosOptionsCreator;
+        private readonly IRouteOptionsCreator _fileRouteOptionsCreator;
+        private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
+        private readonly IRegionCreator _regionCreator;
+        private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
+        private readonly IHeaderFindAndReplaceCreator _headerFAndRCreator;
+        private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
+        private readonly IRouteKeyCreator _routeKeyCreator;
+        private readonly ISecurityOptionsCreator _securityOptionsCreator;
+        private readonly IVersionCreator _versionCreator;
 
-    public List<Route> Create(FileConfiguration fileConfiguration)
-    {
-        return fileConfiguration.Routes
-            .Select(route =>
-            {
-                var downstreamRoute = SetUpDownstreamRoute(route, fileConfiguration.GlobalConfiguration);
-                return SetUpRoute(route, downstreamRoute);
-            })
-            .ToList();
-    }
+        public RoutesCreator(
+            IClaimsToThingCreator claimsToThingCreator,
+            IAuthenticationOptionsCreator authOptionsCreator,
+            IUpstreamTemplatePatternCreator upstreamTemplatePatternCreator,
+            IRequestIdKeyCreator requestIdKeyCreator,
+            IQoSOptionsCreator qosOptionsCreator,
+            IRouteOptionsCreator fileRouteOptionsCreator,
+            IRateLimitOptionsCreator rateLimitOptionsCreator,
+            IRegionCreator regionCreator,
+            IHttpHandlerOptionsCreator httpHandlerOptionsCreator,
+            IHeaderFindAndReplaceCreator headerFAndRCreator,
+            IDownstreamAddressesCreator downstreamAddressesCreator,
+            ILoadBalancerOptionsCreator loadBalancerOptionsCreator,
+            IRouteKeyCreator routeKeyCreator,
+            ISecurityOptionsCreator securityOptionsCreator,
+            IVersionCreator versionCreator
+            )
+        {
+            _routeKeyCreator = routeKeyCreator;
+            _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
+            _downstreamAddressesCreator = downstreamAddressesCreator;
+            _headerFAndRCreator = headerFAndRCreator;
+            _regionCreator = regionCreator;
+            _rateLimitOptionsCreator = rateLimitOptionsCreator;
+            _requestIdKeyCreator = requestIdKeyCreator;
+            _upstreamTemplatePatternCreator = upstreamTemplatePatternCreator;
+            _authOptionsCreator = authOptionsCreator;
+            _claimsToThingCreator = claimsToThingCreator;
+            _qosOptionsCreator = qosOptionsCreator;
+            _fileRouteOptionsCreator = fileRouteOptionsCreator;
+            _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
+            _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
+            _securityOptionsCreator = securityOptionsCreator;
+            _versionCreator = versionCreator;
+        }
 
-    private DownstreamRoute SetUpDownstreamRoute(FileRoute fileRoute, FileGlobalConfiguration globalConfiguration)
-    {
-        var fileRouteOptions = _fileRouteOptionsCreator.Create(fileRoute);
+        public List<Route> Create(FileConfiguration fileConfiguration)
+        {
+            return fileConfiguration.Routes
+                .Select(route =>
+                {
+                    var downstreamRoute = SetUpDownstreamRoute(route, fileConfiguration.GlobalConfiguration);
+                    return SetUpRoute(route, downstreamRoute);
+                })
+                .ToList();
+        }
 
-        var requestIdKey = _requestIdKeyCreator.Create(fileRoute, globalConfiguration);
+        private DownstreamRoute SetUpDownstreamRoute(FileRoute fileRoute, FileGlobalConfiguration globalConfiguration)
+        {
+            var fileRouteOptions = _fileRouteOptionsCreator.Create(fileRoute);
 
-        var routeKey = _routeKeyCreator.Create(fileRoute);
+            var requestIdKey = _requestIdKeyCreator.Create(fileRoute, globalConfiguration);
 
-        var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
+            var routeKey = _routeKeyCreator.Create(fileRoute);
 
-        var authOptionsForRoute = _authOptionsCreator.Create(fileRoute);
+            var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
 
-        var claimsToHeaders = _claimsToThingCreator.Create(fileRoute.AddHeadersToRequest);
+            var authOptionsForRoute = _authOptionsCreator.Create(fileRoute);
 
-        var claimsToClaims = _claimsToThingCreator.Create(fileRoute.AddClaimsToRequest);
+            var claimsToHeaders = _claimsToThingCreator.Create(fileRoute.AddHeadersToRequest);
 
-        var claimsToQueries = _claimsToThingCreator.Create(fileRoute.AddQueriesToRequest);
+            var claimsToClaims = _claimsToThingCreator.Create(fileRoute.AddClaimsToRequest);
 
-        var claimsToDownstreamPath = _claimsToThingCreator.Create(fileRoute.ChangeDownstreamPathTemplate);
+            var claimsToQueries = _claimsToThingCreator.Create(fileRoute.AddQueriesToRequest);
 
-        var qosOptions = _qosOptionsCreator.Create(fileRoute.QoSOptions, fileRoute.UpstreamPathTemplate, fileRoute.UpstreamHttpMethod);
+            var claimsToDownstreamPath = _claimsToThingCreator.Create(fileRoute.ChangeDownstreamPathTemplate);
 
-        var rateLimitOption = _rateLimitOptionsCreator.Create(fileRoute.RateLimitOptions, globalConfiguration);
+            var qosOptions = _qosOptionsCreator.Create(fileRoute.QoSOptions, fileRoute.UpstreamPathTemplate, fileRoute.UpstreamHttpMethod);
 
-        var region = _regionCreator.Create(fileRoute);
+            var rateLimitOption = _rateLimitOptionsCreator.Create(fileRoute.RateLimitOptions, globalConfiguration);
 
-        var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileRoute.HttpHandlerOptions);
+            var region = _regionCreator.Create(fileRoute);
 
-        var hAndRs = _headerFAndRCreator.Create(fileRoute);
+            var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileRoute.HttpHandlerOptions);
 
-        var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute, globalConfiguration);
+            var hAndRs = _headerFAndRCreator.Create(fileRoute);
 
-        var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
+            var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute, globalConfiguration);
 
-        var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions);
+            var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
 
-        var downstreamHttpVersion = _versionCreator.Create(fileRoute.DownstreamHttpVersion);
+            var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions);
 
-        var route = new DownstreamRouteBuilder()
-            .WithKey(fileRoute.Key)
-            .WithDownstreamPathTemplate(fileRoute.DownstreamPathTemplate)
-            .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
-            .WithUpstreamPathTemplate(upstreamTemplatePattern)
-            .WithIsAuthenticated(fileRouteOptions.IsAuthenticated)
-            .WithAuthenticationOptions(authOptionsForRoute)
-            .WithClaimsToHeaders(claimsToHeaders)
-            .WithClaimsToClaims(claimsToClaims)
-            .WithRouteClaimsRequirement(fileRoute.RouteClaimsRequirement)
-            .WithIsAuthorized(fileRouteOptions.IsAuthorized)
-            .WithClaimsToQueries(claimsToQueries)
-            .WithClaimsToDownstreamPath(claimsToDownstreamPath)
-            .WithRequestIdKey(requestIdKey)
-            .WithIsCached(fileRouteOptions.IsCached)
-            .WithCacheOptions(new CacheOptions(fileRoute.FileCacheOptions.TtlSeconds, region))
-            .WithDownstreamScheme(fileRoute.DownstreamScheme)
-            .WithLoadBalancerOptions(lbOptions)
-            .WithDownstreamAddresses(downstreamAddresses)
-            .WithLoadBalancerKey(routeKey)
-            .WithQosOptions(qosOptions)
-            .WithEnableRateLimiting(fileRouteOptions.EnableRateLimiting)
-            .WithRateLimitOptions(rateLimitOption)
-            .WithHttpHandlerOptions(httpHandlerOptions)
-            .WithServiceName(fileRoute.ServiceName)
-            .WithServiceNamespace(fileRoute.ServiceNamespace)
-            .WithUseServiceDiscovery(fileRouteOptions.UseServiceDiscovery)
-            .WithUpstreamHeaderFindAndReplace(hAndRs.Upstream)
-            .WithDownstreamHeaderFindAndReplace(hAndRs.Downstream)
-            .WithDelegatingHandlers(fileRoute.DelegatingHandlers)
-            .WithAddHeadersToDownstream(hAndRs.AddHeadersToDownstream)
-            .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
-            .WithDangerousAcceptAnyServerCertificateValidator(fileRoute.DangerousAcceptAnyServerCertificateValidator)
-            .WithSecurityOptions(securityOptions)
-            .WithDownstreamHttpVersion(downstreamHttpVersion)
-            .WithDownStreamHttpMethod(fileRoute.DownstreamHttpMethod)
-            .Build();
+            var downstreamHttpVersion = _versionCreator.Create(fileRoute.DownstreamHttpVersion);
 
-        return route;
-    }
+            var route = new DownstreamRouteBuilder()
+                .WithKey(fileRoute.Key)
+                .WithDownstreamPathTemplate(fileRoute.DownstreamPathTemplate)
+                .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
+                .WithUpstreamPathTemplate(upstreamTemplatePattern)
+                .WithIsAuthenticated(fileRouteOptions.IsAuthenticated)
+                .WithAuthenticationOptions(authOptionsForRoute)
+                .WithClaimsToHeaders(claimsToHeaders)
+                .WithClaimsToClaims(claimsToClaims)
+                .WithRouteClaimsRequirement(fileRoute.RouteClaimsRequirement)
+                .WithIsAuthorized(fileRouteOptions.IsAuthorized)
+                .WithClaimsToQueries(claimsToQueries)
+                .WithClaimsToDownstreamPath(claimsToDownstreamPath)
+                .WithRequestIdKey(requestIdKey)
+                .WithIsCached(fileRouteOptions.IsCached)
+                .WithCacheOptions(new CacheOptions(fileRoute.FileCacheOptions.TtlSeconds, region))
+                .WithDownstreamScheme(fileRoute.DownstreamScheme)
+                .WithLoadBalancerOptions(lbOptions)
+                .WithDownstreamAddresses(downstreamAddresses)
+                .WithLoadBalancerKey(routeKey)
+                .WithQosOptions(qosOptions)
+                .WithEnableRateLimiting(fileRouteOptions.EnableRateLimiting)
+                .WithRateLimitOptions(rateLimitOption)
+                .WithHttpHandlerOptions(httpHandlerOptions)
+                .WithServiceName(fileRoute.ServiceName)
+                .WithServiceNamespace(fileRoute.ServiceNamespace)
+                .WithUseServiceDiscovery(fileRouteOptions.UseServiceDiscovery)
+                .WithUpstreamHeaderFindAndReplace(hAndRs.Upstream)
+                .WithDownstreamHeaderFindAndReplace(hAndRs.Downstream)
+                .WithDelegatingHandlers(fileRoute.DelegatingHandlers)
+                .WithAddHeadersToDownstream(hAndRs.AddHeadersToDownstream)
+                .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
+                .WithDangerousAcceptAnyServerCertificateValidator(fileRoute.DangerousAcceptAnyServerCertificateValidator)
+                .WithSecurityOptions(securityOptions)
+                .WithDownstreamHttpVersion(downstreamHttpVersion)
+                .WithDownStreamHttpMethod(fileRoute.DownstreamHttpMethod)
+                .Build();
 
-    private Route SetUpRoute(FileRoute fileRoute, DownstreamRoute downstreamRoutes)
-    {
-        var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
+            return route;
+        }
 
-        var route = new RouteBuilder()
-            .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
-            .WithUpstreamPathTemplate(upstreamTemplatePattern)
-            .WithDownstreamRoute(downstreamRoutes)
-            .WithUpstreamHost(fileRoute.UpstreamHost)
-            .Build();
+        private Route SetUpRoute(FileRoute fileRoute, DownstreamRoute downstreamRoutes)
+        {
+            var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
 
-        return route;
+            var route = new RouteBuilder()
+                .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
+                .WithUpstreamPathTemplate(upstreamTemplatePattern)
+                .WithDownstreamRoute(downstreamRoutes)
+                .WithUpstreamHost(fileRoute.UpstreamHost)
+                .Build();
+
+            return route;
+        }
     }
 }

--- a/src/Ocelot/Configuration/Creator/RoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RoutesCreator.cs
@@ -7,164 +7,163 @@ using Ocelot.Cache;
 
 using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public class RoutesCreator : IRoutesCreator
 {
-    public class RoutesCreator : IRoutesCreator
+    private readonly ILoadBalancerOptionsCreator _loadBalancerOptionsCreator;
+    private readonly IClaimsToThingCreator _claimsToThingCreator;
+    private readonly IAuthenticationOptionsCreator _authOptionsCreator;
+    private readonly IUpstreamTemplatePatternCreator _upstreamTemplatePatternCreator;
+    private readonly IRequestIdKeyCreator _requestIdKeyCreator;
+    private readonly IQoSOptionsCreator _qosOptionsCreator;
+    private readonly IRouteOptionsCreator _fileRouteOptionsCreator;
+    private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
+    private readonly IRegionCreator _regionCreator;
+    private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
+    private readonly IHeaderFindAndReplaceCreator _headerFAndRCreator;
+    private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
+    private readonly IRouteKeyCreator _routeKeyCreator;
+    private readonly ISecurityOptionsCreator _securityOptionsCreator;
+    private readonly IVersionCreator _versionCreator;
+
+    public RoutesCreator(
+        IClaimsToThingCreator claimsToThingCreator,
+        IAuthenticationOptionsCreator authOptionsCreator,
+        IUpstreamTemplatePatternCreator upstreamTemplatePatternCreator,
+        IRequestIdKeyCreator requestIdKeyCreator,
+        IQoSOptionsCreator qosOptionsCreator,
+        IRouteOptionsCreator fileRouteOptionsCreator,
+        IRateLimitOptionsCreator rateLimitOptionsCreator,
+        IRegionCreator regionCreator,
+        IHttpHandlerOptionsCreator httpHandlerOptionsCreator,
+        IHeaderFindAndReplaceCreator headerFAndRCreator,
+        IDownstreamAddressesCreator downstreamAddressesCreator,
+        ILoadBalancerOptionsCreator loadBalancerOptionsCreator,
+        IRouteKeyCreator routeKeyCreator,
+        ISecurityOptionsCreator securityOptionsCreator,
+        IVersionCreator versionCreator
+        )
     {
-        private readonly ILoadBalancerOptionsCreator _loadBalancerOptionsCreator;
-        private readonly IClaimsToThingCreator _claimsToThingCreator;
-        private readonly IAuthenticationOptionsCreator _authOptionsCreator;
-        private readonly IUpstreamTemplatePatternCreator _upstreamTemplatePatternCreator;
-        private readonly IRequestIdKeyCreator _requestIdKeyCreator;
-        private readonly IQoSOptionsCreator _qosOptionsCreator;
-        private readonly IRouteOptionsCreator _fileRouteOptionsCreator;
-        private readonly IRateLimitOptionsCreator _rateLimitOptionsCreator;
-        private readonly IRegionCreator _regionCreator;
-        private readonly IHttpHandlerOptionsCreator _httpHandlerOptionsCreator;
-        private readonly IHeaderFindAndReplaceCreator _headerFAndRCreator;
-        private readonly IDownstreamAddressesCreator _downstreamAddressesCreator;
-        private readonly IRouteKeyCreator _routeKeyCreator;
-        private readonly ISecurityOptionsCreator _securityOptionsCreator;
-        private readonly IVersionCreator _versionCreator;
+        _routeKeyCreator = routeKeyCreator;
+        _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
+        _downstreamAddressesCreator = downstreamAddressesCreator;
+        _headerFAndRCreator = headerFAndRCreator;
+        _regionCreator = regionCreator;
+        _rateLimitOptionsCreator = rateLimitOptionsCreator;
+        _requestIdKeyCreator = requestIdKeyCreator;
+        _upstreamTemplatePatternCreator = upstreamTemplatePatternCreator;
+        _authOptionsCreator = authOptionsCreator;
+        _claimsToThingCreator = claimsToThingCreator;
+        _qosOptionsCreator = qosOptionsCreator;
+        _fileRouteOptionsCreator = fileRouteOptionsCreator;
+        _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
+        _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
+        _securityOptionsCreator = securityOptionsCreator;
+        _versionCreator = versionCreator;
+    }
 
-        public RoutesCreator(
-            IClaimsToThingCreator claimsToThingCreator,
-            IAuthenticationOptionsCreator authOptionsCreator,
-            IUpstreamTemplatePatternCreator upstreamTemplatePatternCreator,
-            IRequestIdKeyCreator requestIdKeyCreator,
-            IQoSOptionsCreator qosOptionsCreator,
-            IRouteOptionsCreator fileRouteOptionsCreator,
-            IRateLimitOptionsCreator rateLimitOptionsCreator,
-            IRegionCreator regionCreator,
-            IHttpHandlerOptionsCreator httpHandlerOptionsCreator,
-            IHeaderFindAndReplaceCreator headerFAndRCreator,
-            IDownstreamAddressesCreator downstreamAddressesCreator,
-            ILoadBalancerOptionsCreator loadBalancerOptionsCreator,
-            IRouteKeyCreator routeKeyCreator,
-            ISecurityOptionsCreator securityOptionsCreator,
-            IVersionCreator versionCreator
-            )
-        {
-            _routeKeyCreator = routeKeyCreator;
-            _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
-            _downstreamAddressesCreator = downstreamAddressesCreator;
-            _headerFAndRCreator = headerFAndRCreator;
-            _regionCreator = regionCreator;
-            _rateLimitOptionsCreator = rateLimitOptionsCreator;
-            _requestIdKeyCreator = requestIdKeyCreator;
-            _upstreamTemplatePatternCreator = upstreamTemplatePatternCreator;
-            _authOptionsCreator = authOptionsCreator;
-            _claimsToThingCreator = claimsToThingCreator;
-            _qosOptionsCreator = qosOptionsCreator;
-            _fileRouteOptionsCreator = fileRouteOptionsCreator;
-            _httpHandlerOptionsCreator = httpHandlerOptionsCreator;
-            _loadBalancerOptionsCreator = loadBalancerOptionsCreator;
-            _securityOptionsCreator = securityOptionsCreator;
-            _versionCreator = versionCreator;
-        }
+    public List<Route> Create(FileConfiguration fileConfiguration)
+    {
+        return fileConfiguration.Routes
+            .Select(route =>
+            {
+                var downstreamRoute = SetUpDownstreamRoute(route, fileConfiguration.GlobalConfiguration);
+                return SetUpRoute(route, downstreamRoute);
+            })
+            .ToList();
+    }
 
-        public List<Route> Create(FileConfiguration fileConfiguration)
-        {
-            return fileConfiguration.Routes
-                .Select(route =>
-                {
-                    var downstreamRoute = SetUpDownstreamRoute(route, fileConfiguration.GlobalConfiguration);
-                    return SetUpRoute(route, downstreamRoute);
-                })
-                .ToList();
-        }
+    private DownstreamRoute SetUpDownstreamRoute(FileRoute fileRoute, FileGlobalConfiguration globalConfiguration)
+    {
+        var fileRouteOptions = _fileRouteOptionsCreator.Create(fileRoute);
 
-        private DownstreamRoute SetUpDownstreamRoute(FileRoute fileRoute, FileGlobalConfiguration globalConfiguration)
-        {
-            var fileRouteOptions = _fileRouteOptionsCreator.Create(fileRoute);
+        var requestIdKey = _requestIdKeyCreator.Create(fileRoute, globalConfiguration);
 
-            var requestIdKey = _requestIdKeyCreator.Create(fileRoute, globalConfiguration);
+        var routeKey = _routeKeyCreator.Create(fileRoute);
 
-            var routeKey = _routeKeyCreator.Create(fileRoute);
+        var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
 
-            var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
+        var authOptionsForRoute = _authOptionsCreator.Create(fileRoute);
 
-            var authOptionsForRoute = _authOptionsCreator.Create(fileRoute);
+        var claimsToHeaders = _claimsToThingCreator.Create(fileRoute.AddHeadersToRequest);
 
-            var claimsToHeaders = _claimsToThingCreator.Create(fileRoute.AddHeadersToRequest);
+        var claimsToClaims = _claimsToThingCreator.Create(fileRoute.AddClaimsToRequest);
 
-            var claimsToClaims = _claimsToThingCreator.Create(fileRoute.AddClaimsToRequest);
+        var claimsToQueries = _claimsToThingCreator.Create(fileRoute.AddQueriesToRequest);
 
-            var claimsToQueries = _claimsToThingCreator.Create(fileRoute.AddQueriesToRequest);
+        var claimsToDownstreamPath = _claimsToThingCreator.Create(fileRoute.ChangeDownstreamPathTemplate);
 
-            var claimsToDownstreamPath = _claimsToThingCreator.Create(fileRoute.ChangeDownstreamPathTemplate);
+        var qosOptions = _qosOptionsCreator.Create(fileRoute.QoSOptions, fileRoute.UpstreamPathTemplate, fileRoute.UpstreamHttpMethod);
 
-            var qosOptions = _qosOptionsCreator.Create(fileRoute.QoSOptions, fileRoute.UpstreamPathTemplate, fileRoute.UpstreamHttpMethod);
+        var rateLimitOption = _rateLimitOptionsCreator.Create(fileRoute.RateLimitOptions, globalConfiguration);
 
-            var rateLimitOption = _rateLimitOptionsCreator.Create(fileRoute.RateLimitOptions, globalConfiguration);
+        var region = _regionCreator.Create(fileRoute);
 
-            var region = _regionCreator.Create(fileRoute);
+        var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileRoute.HttpHandlerOptions);
 
-            var httpHandlerOptions = _httpHandlerOptionsCreator.Create(fileRoute.HttpHandlerOptions);
+        var hAndRs = _headerFAndRCreator.Create(fileRoute);
 
-            var hAndRs = _headerFAndRCreator.Create(fileRoute);
+        var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute, globalConfiguration);
 
-            var downstreamAddresses = _downstreamAddressesCreator.Create(fileRoute, globalConfiguration);
+        var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
 
-            var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
+        var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions);
 
-            var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions);
+        var downstreamHttpVersion = _versionCreator.Create(fileRoute.DownstreamHttpVersion);
 
-            var downstreamHttpVersion = _versionCreator.Create(fileRoute.DownstreamHttpVersion);
+        var route = new DownstreamRouteBuilder()
+            .WithKey(fileRoute.Key)
+            .WithDownstreamPathTemplate(fileRoute.DownstreamPathTemplate)
+            .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
+            .WithUpstreamPathTemplate(upstreamTemplatePattern)
+            .WithIsAuthenticated(fileRouteOptions.IsAuthenticated)
+            .WithAuthenticationOptions(authOptionsForRoute)
+            .WithClaimsToHeaders(claimsToHeaders)
+            .WithClaimsToClaims(claimsToClaims)
+            .WithRouteClaimsRequirement(fileRoute.RouteClaimsRequirement)
+            .WithIsAuthorized(fileRouteOptions.IsAuthorized)
+            .WithClaimsToQueries(claimsToQueries)
+            .WithClaimsToDownstreamPath(claimsToDownstreamPath)
+            .WithRequestIdKey(requestIdKey)
+            .WithIsCached(fileRouteOptions.IsCached)
+            .WithCacheOptions(new CacheOptions(fileRoute.FileCacheOptions.TtlSeconds, region))
+            .WithDownstreamScheme(fileRoute.DownstreamScheme)
+            .WithLoadBalancerOptions(lbOptions)
+            .WithDownstreamAddresses(downstreamAddresses)
+            .WithLoadBalancerKey(routeKey)
+            .WithQosOptions(qosOptions)
+            .WithEnableRateLimiting(fileRouteOptions.EnableRateLimiting)
+            .WithRateLimitOptions(rateLimitOption)
+            .WithHttpHandlerOptions(httpHandlerOptions)
+            .WithServiceName(fileRoute.ServiceName)
+            .WithServiceNamespace(fileRoute.ServiceNamespace)
+            .WithUseServiceDiscovery(fileRouteOptions.UseServiceDiscovery)
+            .WithUpstreamHeaderFindAndReplace(hAndRs.Upstream)
+            .WithDownstreamHeaderFindAndReplace(hAndRs.Downstream)
+            .WithDelegatingHandlers(fileRoute.DelegatingHandlers)
+            .WithAddHeadersToDownstream(hAndRs.AddHeadersToDownstream)
+            .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
+            .WithDangerousAcceptAnyServerCertificateValidator(fileRoute.DangerousAcceptAnyServerCertificateValidator)
+            .WithSecurityOptions(securityOptions)
+            .WithDownstreamHttpVersion(downstreamHttpVersion)
+            .WithDownStreamHttpMethod(fileRoute.DownstreamHttpMethod)
+            .Build();
 
-            var route = new DownstreamRouteBuilder()
-                .WithKey(fileRoute.Key)
-                .WithDownstreamPathTemplate(fileRoute.DownstreamPathTemplate)
-                .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
-                .WithUpstreamPathTemplate(upstreamTemplatePattern)
-                .WithIsAuthenticated(fileRouteOptions.IsAuthenticated)
-                .WithAuthenticationOptions(authOptionsForRoute)
-                .WithClaimsToHeaders(claimsToHeaders)
-                .WithClaimsToClaims(claimsToClaims)
-                .WithRouteClaimsRequirement(fileRoute.RouteClaimsRequirement)
-                .WithIsAuthorized(fileRouteOptions.IsAuthorized)
-                .WithClaimsToQueries(claimsToQueries)
-                .WithClaimsToDownstreamPath(claimsToDownstreamPath)
-                .WithRequestIdKey(requestIdKey)
-                .WithIsCached(fileRouteOptions.IsCached)
-                .WithCacheOptions(new CacheOptions(fileRoute.FileCacheOptions.TtlSeconds, region))
-                .WithDownstreamScheme(fileRoute.DownstreamScheme)
-                .WithLoadBalancerOptions(lbOptions)
-                .WithDownstreamAddresses(downstreamAddresses)
-                .WithLoadBalancerKey(routeKey)
-                .WithQosOptions(qosOptions)
-                .WithEnableRateLimiting(fileRouteOptions.EnableRateLimiting)
-                .WithRateLimitOptions(rateLimitOption)
-                .WithHttpHandlerOptions(httpHandlerOptions)
-                .WithServiceName(fileRoute.ServiceName)
-                .WithServiceNamespace(fileRoute.ServiceNamespace)
-                .WithUseServiceDiscovery(fileRouteOptions.UseServiceDiscovery)
-                .WithUpstreamHeaderFindAndReplace(hAndRs.Upstream)
-                .WithDownstreamHeaderFindAndReplace(hAndRs.Downstream)
-                .WithDelegatingHandlers(fileRoute.DelegatingHandlers)
-                .WithAddHeadersToDownstream(hAndRs.AddHeadersToDownstream)
-                .WithAddHeadersToUpstream(hAndRs.AddHeadersToUpstream)
-                .WithDangerousAcceptAnyServerCertificateValidator(fileRoute.DangerousAcceptAnyServerCertificateValidator)
-                .WithSecurityOptions(securityOptions)
-                .WithDownstreamHttpVersion(downstreamHttpVersion)
-                .WithDownStreamHttpMethod(fileRoute.DownstreamHttpMethod)
-                .Build();
+        return route;
+    }
 
-            return route;
-        }
+    private Route SetUpRoute(FileRoute fileRoute, DownstreamRoute downstreamRoutes)
+    {
+        var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
 
-        private Route SetUpRoute(FileRoute fileRoute, DownstreamRoute downstreamRoutes)
-        {
-            var upstreamTemplatePattern = _upstreamTemplatePatternCreator.Create(fileRoute);
+        var route = new RouteBuilder()
+            .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
+            .WithUpstreamPathTemplate(upstreamTemplatePattern)
+            .WithDownstreamRoute(downstreamRoutes)
+            .WithUpstreamHost(fileRoute.UpstreamHost)
+            .Build();
 
-            var route = new RouteBuilder()
-                .WithUpstreamHttpMethod(fileRoute.UpstreamHttpMethod)
-                .WithUpstreamPathTemplate(upstreamTemplatePattern)
-                .WithDownstreamRoute(downstreamRoutes)
-                .WithUpstreamHost(fileRoute.UpstreamHost)
-                .Build();
-
-            return route;
-        }
+        return route;
     }
 }

--- a/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
@@ -1,6 +1,6 @@
 namespace Ocelot.Configuration.File
 {
-    public class FileHostAndPort
+    public class FileDownstreamHostConfig
     {
         public string Host { get; set; }
         public int Port { get; set; }

--- a/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
@@ -2,6 +2,13 @@ namespace Ocelot.Configuration.File
 {
     public class FileDownstreamHostConfig
     {
+        /// <summary>
+        /// Key to reference downstream host config from global configuration.
+        /// </summary>
+        /// <value>
+        /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>
+        /// </value>
+        public string GlobalHostKey { get; set; }
         public string Host { get; set; }
         public int Port { get; set; }
     }

--- a/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
@@ -6,7 +6,7 @@ namespace Ocelot.Configuration.File
         /// Key to reference downstream host config from global configuration.
         /// </summary>
         /// <value>
-        /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>
+        /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>.
         /// </value>
         public string GlobalHostKey { get; set; }
         public string Host { get; set; }

--- a/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
@@ -1,14 +1,15 @@
-namespace Ocelot.Configuration.File;
-
-public class FileDownstreamHostConfig
+namespace Ocelot.Configuration.File
 {
-    /// <summary>
-    /// Key to reference downstream host config from global configuration.
-    /// </summary>
-    /// <value>
-    /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>.
-    /// </value>
-    public string GlobalHostKey { get; set; }
-    public string Host { get; set; }
-    public int Port { get; set; }
+    public class FileDownstreamHostConfig
+    {
+        /// <summary>
+        /// Key to reference downstream host config from global configuration.
+        /// </summary>
+        /// <value>
+        /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>.
+        /// </value>
+        public string GlobalHostKey { get; set; }
+        public string Host { get; set; }
+        public int Port { get; set; }
+    }
 }

--- a/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileDownstreamHostConfig.cs
@@ -1,15 +1,14 @@
-namespace Ocelot.Configuration.File
+namespace Ocelot.Configuration.File;
+
+public class FileDownstreamHostConfig
 {
-    public class FileDownstreamHostConfig
-    {
-        /// <summary>
-        /// Key to reference downstream host config from global configuration.
-        /// </summary>
-        /// <value>
-        /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>.
-        /// </value>
-        public string GlobalHostKey { get; set; }
-        public string Host { get; set; }
-        public int Port { get; set; }
-    }
+    /// <summary>
+    /// Key to reference downstream host config from global configuration.
+    /// </summary>
+    /// <value>
+    /// Key reference from <see cref="FileGlobalConfiguration.DownstreamHosts"/>.
+    /// </value>
+    public string GlobalHostKey { get; set; }
+    public string Host { get; set; }
+    public int Port { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
@@ -1,4 +1,6 @@
-﻿namespace Ocelot.Configuration.File
+﻿using System.Collections.Generic;
+
+namespace Ocelot.Configuration.File
 {
     public class FileGlobalConfiguration
     {
@@ -9,6 +11,7 @@
             LoadBalancerOptions = new FileLoadBalancerOptions();
             QoSOptions = new FileQoSOptions();
             HttpHandlerOptions = new FileHttpHandlerOptions();
+            DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>();
         }
 
         public string RequestIdKey { get; set; }
@@ -28,5 +31,6 @@
         public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
 
         public string DownstreamHttpVersion { get; set; }
+        public Dictionary<string, FileGlobalDownstreamHostConfig> DownstreamHosts { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
@@ -1,36 +1,36 @@
 ﻿using System.Collections.Generic;
 
-namespace Ocelot.Configuration.File
+namespace Ocelot.Configuration.File;
+
+public class FileGlobalConfiguration
 {
-    public class FileGlobalConfiguration
+    public FileGlobalConfiguration()
     {
-        public FileGlobalConfiguration()
-        {
-            ServiceDiscoveryProvider = new FileServiceDiscoveryProvider();
-            RateLimitOptions = new FileRateLimitOptions();
-            LoadBalancerOptions = new FileLoadBalancerOptions();
-            QoSOptions = new FileQoSOptions();
-            HttpHandlerOptions = new FileHttpHandlerOptions();
-            DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>();
-        }
-
-        public string RequestIdKey { get; set; }
-
-        public FileServiceDiscoveryProvider ServiceDiscoveryProvider { get; set; }
-
-        public FileRateLimitOptions RateLimitOptions { get; set; }
-
-        public FileQoSOptions QoSOptions { get; set; }
-
-        public string BaseUrl { get; set; }
-
-        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
-
-        public string DownstreamScheme { get; set; }
-
-        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-
-        public string DownstreamHttpVersion { get; set; }
-        public Dictionary<string, FileGlobalDownstreamHostConfig> DownstreamHosts { get; set; }
+        ServiceDiscoveryProvider = new FileServiceDiscoveryProvider();
+        RateLimitOptions = new FileRateLimitOptions();
+        LoadBalancerOptions = new FileLoadBalancerOptions();
+        QoSOptions = new FileQoSOptions();
+        HttpHandlerOptions = new FileHttpHandlerOptions();
+        DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>();
     }
+
+    public string RequestIdKey { get; set; }
+
+    public FileServiceDiscoveryProvider ServiceDiscoveryProvider { get; set; }
+
+    public FileRateLimitOptions RateLimitOptions { get; set; }
+
+    public FileQoSOptions QoSOptions { get; set; }
+
+    public string BaseUrl { get; set; }
+
+    public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
+
+    public string DownstreamScheme { get; set; }
+
+    public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
+
+    public string DownstreamHttpVersion { get; set; }
+
+    public Dictionary<string, FileGlobalDownstreamHostConfig> DownstreamHosts { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
@@ -1,36 +1,36 @@
 ﻿using System.Collections.Generic;
 
-namespace Ocelot.Configuration.File;
-
-public class FileGlobalConfiguration
+namespace Ocelot.Configuration.File
 {
-    public FileGlobalConfiguration()
+    public class FileGlobalConfiguration
     {
-        ServiceDiscoveryProvider = new FileServiceDiscoveryProvider();
-        RateLimitOptions = new FileRateLimitOptions();
-        LoadBalancerOptions = new FileLoadBalancerOptions();
-        QoSOptions = new FileQoSOptions();
-        HttpHandlerOptions = new FileHttpHandlerOptions();
-        DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>();
+        public FileGlobalConfiguration()
+        {
+            ServiceDiscoveryProvider = new FileServiceDiscoveryProvider();
+            RateLimitOptions = new FileRateLimitOptions();
+            LoadBalancerOptions = new FileLoadBalancerOptions();
+            QoSOptions = new FileQoSOptions();
+            HttpHandlerOptions = new FileHttpHandlerOptions();
+            DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>();
+        }
+
+        public string RequestIdKey { get; set; }
+
+        public FileServiceDiscoveryProvider ServiceDiscoveryProvider { get; set; }
+
+        public FileRateLimitOptions RateLimitOptions { get; set; }
+
+        public FileQoSOptions QoSOptions { get; set; }
+
+        public string BaseUrl { get; set; }
+
+        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
+
+        public string DownstreamScheme { get; set; }
+
+        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
+
+        public string DownstreamHttpVersion { get; set; }
+        public Dictionary<string, FileGlobalDownstreamHostConfig> DownstreamHosts { get; set; }
     }
-
-    public string RequestIdKey { get; set; }
-
-    public FileServiceDiscoveryProvider ServiceDiscoveryProvider { get; set; }
-
-    public FileRateLimitOptions RateLimitOptions { get; set; }
-
-    public FileQoSOptions QoSOptions { get; set; }
-
-    public string BaseUrl { get; set; }
-
-    public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
-
-    public string DownstreamScheme { get; set; }
-
-    public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-
-    public string DownstreamHttpVersion { get; set; }
-
-    public Dictionary<string, FileGlobalDownstreamHostConfig> DownstreamHosts { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace Ocelot.Configuration.File
+{
+    public class FileGlobalDownstreamHostConfig
+    {
+        public string Host { get; set; }
+        public int Port { get; set; }
+    }
+}

--- a/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
@@ -1,8 +1,7 @@
-﻿namespace Ocelot.Configuration.File
+﻿namespace Ocelot.Configuration.File;
+
+public class FileGlobalDownstreamHostConfig
 {
-    public class FileGlobalDownstreamHostConfig
-    {
-        public string Host { get; set; }
-        public int Port { get; set; }
-    }
+    public string Host { get; set; }
+    public int Port { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalDownstreamHostConfig.cs
@@ -1,7 +1,8 @@
-﻿namespace Ocelot.Configuration.File;
-
-public class FileGlobalDownstreamHostConfig
+﻿namespace Ocelot.Configuration.File
 {
-    public string Host { get; set; }
-    public int Port { get; set; }
+    public class FileGlobalDownstreamHostConfig
+    {
+        public string Host { get; set; }
+        public int Port { get; set; }
+    }
 }

--- a/src/Ocelot/Configuration/File/FileRoute.cs
+++ b/src/Ocelot/Configuration/File/FileRoute.cs
@@ -19,7 +19,7 @@ namespace Ocelot.Configuration.File
             AuthenticationOptions = new FileAuthenticationOptions();
             HttpHandlerOptions = new FileHttpHandlerOptions();
             UpstreamHeaderTransform = new Dictionary<string, string>();
-            DownstreamHostAndPorts = new List<FileHostAndPort>();
+            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>();
             DelegatingHandlers = new List<string>();
             LoadBalancerOptions = new FileLoadBalancerOptions();
             SecurityOptions = new FileSecurityOptions();
@@ -48,7 +48,7 @@ namespace Ocelot.Configuration.File
         public FileRateLimitRule RateLimitOptions { get; set; }
         public FileAuthenticationOptions AuthenticationOptions { get; set; }
         public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-        public List<FileHostAndPort> DownstreamHostAndPorts { get; set; }
+        public List<FileDownstreamHostConfig> DownstreamHostAndPorts { get; set; }
         public string UpstreamHost { get; set; }
         public string Key { get; set; }
         public List<string> DelegatingHandlers { get; set; }

--- a/src/Ocelot/Configuration/File/FileRoute.cs
+++ b/src/Ocelot/Configuration/File/FileRoute.cs
@@ -1,60 +1,61 @@
 ﻿using System.Collections.Generic;
 
-namespace Ocelot.Configuration.File;
-
-public class FileRoute : IRoute
+namespace Ocelot.Configuration.File
 {
-    public FileRoute()
+    public class FileRoute : IRoute
     {
-        UpstreamHttpMethod = new List<string>();
-        AddHeadersToRequest = new Dictionary<string, string>();
-        AddClaimsToRequest = new Dictionary<string, string>();
-        RouteClaimsRequirement = new Dictionary<string, string>();
-        AddQueriesToRequest = new Dictionary<string, string>();
-        ChangeDownstreamPathTemplate = new Dictionary<string, string>();
-        DownstreamHeaderTransform = new Dictionary<string, string>();
-        FileCacheOptions = new FileCacheOptions();
-        QoSOptions = new FileQoSOptions();
-        RateLimitOptions = new FileRateLimitRule();
-        AuthenticationOptions = new FileAuthenticationOptions();
-        HttpHandlerOptions = new FileHttpHandlerOptions();
-        UpstreamHeaderTransform = new Dictionary<string, string>();
-        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>();
-        DelegatingHandlers = new List<string>();
-        LoadBalancerOptions = new FileLoadBalancerOptions();
-        SecurityOptions = new FileSecurityOptions();
-        Priority = 1;
-    }
+        public FileRoute()
+        {
+            UpstreamHttpMethod = new List<string>();
+            AddHeadersToRequest = new Dictionary<string, string>();
+            AddClaimsToRequest = new Dictionary<string, string>();
+            RouteClaimsRequirement = new Dictionary<string, string>();
+            AddQueriesToRequest = new Dictionary<string, string>();
+            ChangeDownstreamPathTemplate = new Dictionary<string, string>();
+            DownstreamHeaderTransform = new Dictionary<string, string>();
+            FileCacheOptions = new FileCacheOptions();
+            QoSOptions = new FileQoSOptions();
+            RateLimitOptions = new FileRateLimitRule();
+            AuthenticationOptions = new FileAuthenticationOptions();
+            HttpHandlerOptions = new FileHttpHandlerOptions();
+            UpstreamHeaderTransform = new Dictionary<string, string>();
+            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>();
+            DelegatingHandlers = new List<string>();
+            LoadBalancerOptions = new FileLoadBalancerOptions();
+            SecurityOptions = new FileSecurityOptions();
+            Priority = 1;
+        }
 
-    public string DownstreamPathTemplate { get; set; }
-    public string UpstreamPathTemplate { get; set; }
-    public List<string> UpstreamHttpMethod { get; set; }
-    public string DownstreamHttpMethod { get; set; }
-    public Dictionary<string, string> AddHeadersToRequest { get; set; }
-    public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
-    public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
-    public Dictionary<string, string> AddClaimsToRequest { get; set; }
-    public Dictionary<string, string> RouteClaimsRequirement { get; set; }
-    public Dictionary<string, string> AddQueriesToRequest { get; set; }
-    public Dictionary<string, string> ChangeDownstreamPathTemplate { get; set; }
-    public string RequestIdKey { get; set; }
-    public FileCacheOptions FileCacheOptions { get; set; }
-    public bool RouteIsCaseSensitive { get; set; }
-    public string ServiceName { get; set; }
-    public string ServiceNamespace { get; set; }
-    public string DownstreamScheme { get; set; }
-    public FileQoSOptions QoSOptions { get; set; }
-    public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
-    public FileRateLimitRule RateLimitOptions { get; set; }
-    public FileAuthenticationOptions AuthenticationOptions { get; set; }
-    public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-    public List<FileDownstreamHostConfig> DownstreamHostAndPorts { get; set; }
-    public string UpstreamHost { get; set; }
-    public string Key { get; set; }
-    public List<string> DelegatingHandlers { get; set; }
-    public int Priority { get; set; }
-    public int Timeout { get; set; }
-    public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
-    public FileSecurityOptions SecurityOptions { get; set; }
-    public string DownstreamHttpVersion { get; set; }
+        public string DownstreamPathTemplate { get; set; }
+        public string UpstreamPathTemplate { get; set; }
+        public List<string> UpstreamHttpMethod { get; set; }
+        public string DownstreamHttpMethod { get; set; }
+        public Dictionary<string, string> AddHeadersToRequest { get; set; }
+        public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
+        public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
+        public Dictionary<string, string> AddClaimsToRequest { get; set; }
+        public Dictionary<string, string> RouteClaimsRequirement { get; set; }
+        public Dictionary<string, string> AddQueriesToRequest { get; set; }
+        public Dictionary<string, string> ChangeDownstreamPathTemplate { get; set; }
+        public string RequestIdKey { get; set; }
+        public FileCacheOptions FileCacheOptions { get; set; }
+        public bool RouteIsCaseSensitive { get; set; }
+        public string ServiceName { get; set; }
+        public string ServiceNamespace { get; set; }
+        public string DownstreamScheme { get; set; }
+        public FileQoSOptions QoSOptions { get; set; }
+        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
+        public FileRateLimitRule RateLimitOptions { get; set; }
+        public FileAuthenticationOptions AuthenticationOptions { get; set; }
+        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
+        public List<FileDownstreamHostConfig> DownstreamHostAndPorts { get; set; }
+        public string UpstreamHost { get; set; }
+        public string Key { get; set; }
+        public List<string> DelegatingHandlers { get; set; }
+        public int Priority { get; set; }
+        public int Timeout { get; set; }
+        public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
+        public FileSecurityOptions SecurityOptions { get; set; }
+        public string DownstreamHttpVersion { get; set; }
+    }
 }

--- a/src/Ocelot/Configuration/File/FileRoute.cs
+++ b/src/Ocelot/Configuration/File/FileRoute.cs
@@ -1,61 +1,60 @@
 ﻿using System.Collections.Generic;
 
-namespace Ocelot.Configuration.File
-{
-    public class FileRoute : IRoute
-    {
-        public FileRoute()
-        {
-            UpstreamHttpMethod = new List<string>();
-            AddHeadersToRequest = new Dictionary<string, string>();
-            AddClaimsToRequest = new Dictionary<string, string>();
-            RouteClaimsRequirement = new Dictionary<string, string>();
-            AddQueriesToRequest = new Dictionary<string, string>();
-            ChangeDownstreamPathTemplate = new Dictionary<string, string>();
-            DownstreamHeaderTransform = new Dictionary<string, string>();
-            FileCacheOptions = new FileCacheOptions();
-            QoSOptions = new FileQoSOptions();
-            RateLimitOptions = new FileRateLimitRule();
-            AuthenticationOptions = new FileAuthenticationOptions();
-            HttpHandlerOptions = new FileHttpHandlerOptions();
-            UpstreamHeaderTransform = new Dictionary<string, string>();
-            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>();
-            DelegatingHandlers = new List<string>();
-            LoadBalancerOptions = new FileLoadBalancerOptions();
-            SecurityOptions = new FileSecurityOptions();
-            Priority = 1;
-        }
+namespace Ocelot.Configuration.File;
 
-        public string DownstreamPathTemplate { get; set; }
-        public string UpstreamPathTemplate { get; set; }
-        public List<string> UpstreamHttpMethod { get; set; }
-        public string DownstreamHttpMethod { get; set; }
-        public Dictionary<string, string> AddHeadersToRequest { get; set; }
-        public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
-        public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
-        public Dictionary<string, string> AddClaimsToRequest { get; set; }
-        public Dictionary<string, string> RouteClaimsRequirement { get; set; }
-        public Dictionary<string, string> AddQueriesToRequest { get; set; }
-        public Dictionary<string, string> ChangeDownstreamPathTemplate { get; set; }
-        public string RequestIdKey { get; set; }
-        public FileCacheOptions FileCacheOptions { get; set; }
-        public bool RouteIsCaseSensitive { get; set; }
-        public string ServiceName { get; set; }
-        public string ServiceNamespace { get; set; }
-        public string DownstreamScheme { get; set; }
-        public FileQoSOptions QoSOptions { get; set; }
-        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
-        public FileRateLimitRule RateLimitOptions { get; set; }
-        public FileAuthenticationOptions AuthenticationOptions { get; set; }
-        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-        public List<FileDownstreamHostConfig> DownstreamHostAndPorts { get; set; }
-        public string UpstreamHost { get; set; }
-        public string Key { get; set; }
-        public List<string> DelegatingHandlers { get; set; }
-        public int Priority { get; set; }
-        public int Timeout { get; set; }
-        public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
-        public FileSecurityOptions SecurityOptions { get; set; }
-        public string DownstreamHttpVersion { get; set; }
+public class FileRoute : IRoute
+{
+    public FileRoute()
+    {
+        UpstreamHttpMethod = new List<string>();
+        AddHeadersToRequest = new Dictionary<string, string>();
+        AddClaimsToRequest = new Dictionary<string, string>();
+        RouteClaimsRequirement = new Dictionary<string, string>();
+        AddQueriesToRequest = new Dictionary<string, string>();
+        ChangeDownstreamPathTemplate = new Dictionary<string, string>();
+        DownstreamHeaderTransform = new Dictionary<string, string>();
+        FileCacheOptions = new FileCacheOptions();
+        QoSOptions = new FileQoSOptions();
+        RateLimitOptions = new FileRateLimitRule();
+        AuthenticationOptions = new FileAuthenticationOptions();
+        HttpHandlerOptions = new FileHttpHandlerOptions();
+        UpstreamHeaderTransform = new Dictionary<string, string>();
+        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>();
+        DelegatingHandlers = new List<string>();
+        LoadBalancerOptions = new FileLoadBalancerOptions();
+        SecurityOptions = new FileSecurityOptions();
+        Priority = 1;
     }
+
+    public string DownstreamPathTemplate { get; set; }
+    public string UpstreamPathTemplate { get; set; }
+    public List<string> UpstreamHttpMethod { get; set; }
+    public string DownstreamHttpMethod { get; set; }
+    public Dictionary<string, string> AddHeadersToRequest { get; set; }
+    public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
+    public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
+    public Dictionary<string, string> AddClaimsToRequest { get; set; }
+    public Dictionary<string, string> RouteClaimsRequirement { get; set; }
+    public Dictionary<string, string> AddQueriesToRequest { get; set; }
+    public Dictionary<string, string> ChangeDownstreamPathTemplate { get; set; }
+    public string RequestIdKey { get; set; }
+    public FileCacheOptions FileCacheOptions { get; set; }
+    public bool RouteIsCaseSensitive { get; set; }
+    public string ServiceName { get; set; }
+    public string ServiceNamespace { get; set; }
+    public string DownstreamScheme { get; set; }
+    public FileQoSOptions QoSOptions { get; set; }
+    public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
+    public FileRateLimitRule RateLimitOptions { get; set; }
+    public FileAuthenticationOptions AuthenticationOptions { get; set; }
+    public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
+    public List<FileDownstreamHostConfig> DownstreamHostAndPorts { get; set; }
+    public string UpstreamHost { get; set; }
+    public string Key { get; set; }
+    public List<string> DelegatingHandlers { get; set; }
+    public int Priority { get; set; }
+    public int Timeout { get; set; }
+    public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
+    public FileSecurityOptions SecurityOptions { get; set; }
+    public string DownstreamHttpVersion { get; set; }
 }

--- a/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
+++ b/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
@@ -4,7 +4,7 @@ using FluentValidation;
 
 namespace Ocelot.Configuration.Validator
 {
-    public class HostAndPortValidator : AbstractValidator<FileHostAndPort>
+    public class HostAndPortValidator : AbstractValidator<FileDownstreamHostConfig>
     {
         public HostAndPortValidator()
         {

--- a/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
+++ b/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
@@ -2,15 +2,14 @@ using Ocelot.Configuration.File;
 
 using FluentValidation;
 
-namespace Ocelot.Configuration.Validator
+namespace Ocelot.Configuration.Validator;
+
+public class HostAndPortValidator : AbstractValidator<FileDownstreamHostConfig>
 {
-    public class HostAndPortValidator : AbstractValidator<FileDownstreamHostConfig>
+    public HostAndPortValidator()
     {
-        public HostAndPortValidator()
-        {
-            RuleFor(r => r.Host)
-                .NotEmpty()
-                .WithMessage("When not using service discovery Host must be set on DownstreamHostAndPorts if you are not using Route.Host or Ocelot cannot find your service!");
-        }
+        RuleFor(r => r.Host)
+            .NotEmpty()
+            .WithMessage("When not using service discovery Host must be set on DownstreamHostAndPorts if you are not using Route.Host or Ocelot cannot find your service!");
     }
 }

--- a/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
+++ b/src/Ocelot/Configuration/Validator/HostAndPortValidator.cs
@@ -2,14 +2,15 @@ using Ocelot.Configuration.File;
 
 using FluentValidation;
 
-namespace Ocelot.Configuration.Validator;
-
-public class HostAndPortValidator : AbstractValidator<FileDownstreamHostConfig>
+namespace Ocelot.Configuration.Validator
 {
-    public HostAndPortValidator()
+    public class HostAndPortValidator : AbstractValidator<FileDownstreamHostConfig>
     {
-        RuleFor(r => r.Host)
-            .NotEmpty()
-            .WithMessage("When not using service discovery Host must be set on DownstreamHostAndPorts if you are not using Route.Host or Ocelot cannot find your service!");
+        public HostAndPortValidator()
+        {
+            RuleFor(r => r.Host)
+                .NotEmpty()
+                .WithMessage("When not using service discovery Host must be set on DownstreamHostAndPorts if you are not using Route.Host or Ocelot cannot find your service!");
+        }
     }
 }

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -46,7 +46,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/key1data/{userid}",
                         UpstreamHttpMethod = new List<string> {"Get"},
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -62,7 +62,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/key2data/{userid}",
                         UpstreamHttpMethod = new List<string> {"Get"},
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -78,7 +78,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/key3data/{userid}",
                         UpstreamHttpMethod = new List<string> {"Get"},
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -94,7 +94,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/key4data/{userid}",
                         UpstreamHttpMethod = new List<string> {"Get"},
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -157,7 +157,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -173,7 +173,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/users/{userId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -189,7 +189,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/posts/{postId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -253,7 +253,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -269,7 +269,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -324,7 +324,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -340,7 +340,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -394,7 +394,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -410,7 +410,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -464,7 +464,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -480,7 +480,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -534,7 +534,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -550,7 +550,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthenticationTests.cs
@@ -61,7 +61,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = _downstreamServicePath,
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = _downstreamServicePath,
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {
@@ -145,7 +145,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = _downstreamServicePath,
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {
@@ -187,7 +187,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = _downstreamServicePath,
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {
@@ -230,7 +230,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = _downstreamServicePath,
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {

--- a/test/Ocelot.AcceptanceTests/AuthorizationTests.cs
+++ b/test/Ocelot.AcceptanceTests/AuthorizationTests.cs
@@ -57,7 +57,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -117,7 +117,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -175,7 +175,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -218,7 +218,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -261,7 +261,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ButterflyTracingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ButterflyTracingTests.cs
@@ -50,7 +50,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/values",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -69,7 +69,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/values",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -122,7 +122,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/values",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/CachingTests.cs
+++ b/test/Ocelot.AcceptanceTests/CachingTests.cs
@@ -36,7 +36,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -81,7 +81,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -127,7 +127,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -171,7 +171,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/CannotStartOcelotTests.cs
+++ b/test/Ocelot.AcceptanceTests/CannotStartOcelotTests.cs
@@ -104,7 +104,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -153,7 +153,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/CaseSensitiveRoutingTests.cs
@@ -35,7 +35,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -70,7 +70,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -106,7 +106,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -142,7 +142,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -178,7 +178,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -214,7 +214,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/ClaimsToDownstreamPathTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToDownstreamPathTests.cs
@@ -64,7 +64,7 @@ namespace Ocelot.AcceptanceTests
                        new()
                        {
                            DownstreamPathTemplate = "/users/{userId}",
-                           DownstreamHostAndPorts = new List<FileHostAndPort>
+                           DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                            {
                                new()
                                {

--- a/test/Ocelot.AcceptanceTests/ClaimsToHeadersForwardingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToHeadersForwardingTests.cs
@@ -71,7 +71,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClaimsToQueryStringForwardingTests.cs
@@ -71,7 +71,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -137,7 +137,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
+++ b/test/Ocelot.AcceptanceTests/ClientRateLimitTests.cs
@@ -36,7 +36,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/api/ClientRateLimit",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -96,7 +96,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/api/ClientRateLimit",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -163,7 +163,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/api/ClientRateLimit",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConfigurationInConsulTests.cs
@@ -51,7 +51,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/ConsulConfigurationInConsulTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConsulConfigurationInConsulTests.cs
@@ -52,7 +52,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -116,7 +116,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/status",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -179,7 +179,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/status",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -210,7 +210,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/status",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ContentTests.cs
+++ b/test/Ocelot.AcceptanceTests/ContentTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -78,7 +78,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -119,7 +119,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
+++ b/test/Ocelot.AcceptanceTests/CustomMiddlewareTests.cs
@@ -54,7 +54,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -99,7 +99,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -144,7 +144,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/41879/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -189,7 +189,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -234,7 +234,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -279,7 +279,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -328,7 +328,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/west",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/GzipTests.cs
+++ b/test/Ocelot.AcceptanceTests/GzipTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/HeaderTests.cs
+++ b/test/Ocelot.AcceptanceTests/HeaderTests.cs
@@ -39,7 +39,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -80,7 +80,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -120,7 +120,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -164,7 +164,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -208,7 +208,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -256,7 +256,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/sso/{everything}",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -299,7 +299,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/sso/{everything}",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -342,7 +342,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -379,7 +379,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/HttpClientCachingTests.cs
+++ b/test/Ocelot.AcceptanceTests/HttpClientCachingTests.cs
@@ -36,7 +36,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -78,7 +78,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -93,7 +93,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/two",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/HttpDelegatingHandlersTests.cs
+++ b/test/Ocelot.AcceptanceTests/HttpDelegatingHandlersTests.cs
@@ -42,7 +42,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -84,7 +84,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -121,7 +121,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -174,7 +174,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/HttpTests.cs
+++ b/test/Ocelot.AcceptanceTests/HttpTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "http",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Get" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -78,7 +78,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/{url}",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -115,7 +115,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "https",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Get" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -157,7 +157,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "https",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Get" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -199,7 +199,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "http",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Get" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/LoadBalancerTests.cs
+++ b/test/Ocelot.AcceptanceTests/LoadBalancerTests.cs
@@ -57,7 +57,7 @@ namespace Ocelot.AcceptanceTests
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
                             LoadBalancerOptions = new FileLoadBalancerOptions { Type = nameof(LeastConnection) },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -104,7 +104,7 @@ namespace Ocelot.AcceptanceTests
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
                             LoadBalancerOptions = new FileLoadBalancerOptions { Type = nameof(RoundRobin) },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -151,7 +151,7 @@ namespace Ocelot.AcceptanceTests
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
                             LoadBalancerOptions = new FileLoadBalancerOptions { Type = nameof(CustomLoadBalancer) },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/MethodTests.cs
+++ b/test/Ocelot.AcceptanceTests/MethodTests.cs
@@ -40,7 +40,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/{url}",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -76,7 +76,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "http",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Get" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -116,7 +116,7 @@ namespace Ocelot.AcceptanceTests
                         DownstreamScheme = "http",
                         UpstreamPathTemplate = "/{url}",
                         UpstreamHttpMethod = new List<string> { "Post" },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/OpenTracingTests.cs
+++ b/test/Ocelot.AcceptanceTests/OpenTracingTests.cs
@@ -55,7 +55,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/values",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -74,7 +74,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/values",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -124,7 +124,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/values",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
@@ -38,7 +38,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -79,7 +79,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -121,7 +121,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -174,7 +174,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -195,7 +195,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/ReasonPhraseTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReasonPhraseTests.cs
@@ -36,7 +36,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/RequestIdTests.cs
+++ b/test/Ocelot.AcceptanceTests/RequestIdTests.cs
@@ -34,7 +34,7 @@ namespace Ocelot.AcceptanceTests
                     new()
                     {
                         DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -70,7 +70,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -107,7 +107,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -148,7 +148,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/ResponseCodeTests.cs
+++ b/test/Ocelot.AcceptanceTests/ResponseCodeTests.cs
@@ -32,7 +32,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{everything}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -33,7 +33,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPathTemplate = "/",
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -67,7 +67,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPathTemplate = "/",
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPathTemplate = "/",
                             UpstreamPathTemplate = "/",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingTests.cs
@@ -40,7 +40,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/api/v{apiVersion}/cards",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -86,7 +86,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/{url}",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -120,7 +120,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{url}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -135,7 +135,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -170,7 +170,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{url}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -185,7 +185,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -221,7 +221,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -236,7 +236,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{url}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -272,7 +272,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{url}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -308,7 +308,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -344,7 +344,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/v1/vacancy",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -360,7 +360,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/v1/vacancy/{vacancyId}",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -397,7 +397,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/products",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -433,7 +433,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/products",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -469,7 +469,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/products",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -505,7 +505,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/products",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -540,7 +540,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/products",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -575,7 +575,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -611,7 +611,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/{variantId}/products/{productId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -647,7 +647,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/products/{productId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -681,7 +681,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -719,7 +719,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamPathTemplate = "/newThing",
                             UpstreamPathTemplate = "/newThing",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -754,7 +754,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/{urlPath}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -789,7 +789,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -825,7 +825,7 @@ namespace Ocelot.AcceptanceTests
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -862,7 +862,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/v1/vacancy",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -878,7 +878,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/v1/vacancy/{vacancyId}",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -914,7 +914,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/{url}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -953,7 +953,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/goods/{url}",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -969,7 +969,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/goods/delete",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -1005,7 +1005,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/{everything}",
                             UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -1041,7 +1041,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/api/v1/{everything}",
                             UpstreamHttpMethod = new List<string> { "Get", "Put", "Post" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -1056,7 +1056,7 @@ namespace Ocelot.AcceptanceTests
                             DownstreamScheme = "http",
                             UpstreamPathTemplate = "/connect/token",
                             UpstreamHttpMethod = new List<string> { "Post" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
+++ b/test/Ocelot.AcceptanceTests/RoutingWithQueryStringTests.cs
@@ -38,7 +38,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/subscriptions/{subscriptionId}/updates?unitId={unitId}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -76,7 +76,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/{everything}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -114,7 +114,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/units/{subscriptionId}/{unitId}/updates",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -152,7 +152,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/units/{subscriptionId}/{unitId}/updates",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -189,7 +189,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/units/{subscriptionId}/{unitId}/updates",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -226,7 +226,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/api/units/{subscriptionId}/{unitId}/updates",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/SslTests.cs
+++ b/test/Ocelot.AcceptanceTests/SslTests.cs
@@ -37,7 +37,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "https",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -74,7 +74,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "https",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/StartupTests.cs
+++ b/test/Ocelot.AcceptanceTests/StartupTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/StickySessionsTests.cs
+++ b/test/Ocelot.AcceptanceTests/StickySessionsTests.cs
@@ -51,7 +51,7 @@ namespace Ocelot.AcceptanceTests
                                 Key = "sessionid",
                                 Expiry = 300000,
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
                                 Key = "sessionid",
                                 Expiry = 300000,
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -128,7 +128,7 @@ namespace Ocelot.AcceptanceTests
                                 Key = "bestid",
                                 Expiry = 300000,
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -180,7 +180,7 @@ namespace Ocelot.AcceptanceTests
                                 Key = "sessionid",
                                 Expiry = 300000,
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -206,7 +206,7 @@ namespace Ocelot.AcceptanceTests
                                 Key = "sessionid",
                                 Expiry = 300000,
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/TwoDownstreamServicesTests.cs
+++ b/test/Ocelot.AcceptanceTests/TwoDownstreamServicesTests.cs
@@ -49,7 +49,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/user/{user}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -64,7 +64,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/api/product/{product}",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.AcceptanceTests/UpstreamHostTests.cs
+++ b/test/Ocelot.AcceptanceTests/UpstreamHostTests.cs
@@ -37,7 +37,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -74,7 +74,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -90,7 +90,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -127,7 +127,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -143,7 +143,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -180,7 +180,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -195,7 +195,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -232,7 +232,7 @@ namespace Ocelot.AcceptanceTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.AcceptanceTests/WebSocketTests.cs
+++ b/test/Ocelot.AcceptanceTests/WebSocketTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/",
                         DownstreamPathTemplate = "/ws",
                         DownstreamScheme = "ws",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -78,7 +78,7 @@ namespace Ocelot.AcceptanceTests
                         UpstreamPathTemplate = "/",
                         DownstreamPathTemplate = "/ws",
                         DownstreamScheme = "ws",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.Benchmarks/AllTheThingsBenchmarks.cs
+++ b/test/Ocelot.Benchmarks/AllTheThingsBenchmarks.cs
@@ -48,7 +48,7 @@ namespace Ocelot.Benchmarks
                         new()
                         {
                             DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.IntegrationTests/AdministrationTests.cs
+++ b/test/Ocelot.IntegrationTests/AdministrationTests.cs
@@ -141,7 +141,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -161,7 +161,7 @@ namespace Ocelot.IntegrationTests
                     },
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -202,7 +202,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -217,7 +217,7 @@ namespace Ocelot.IntegrationTests
                     },
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -240,7 +240,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -255,7 +255,7 @@ namespace Ocelot.IntegrationTests
                     },
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -295,7 +295,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -355,7 +355,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -378,7 +378,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -425,7 +425,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -444,7 +444,7 @@ namespace Ocelot.IntegrationTests
                     },
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.IntegrationTests/CacheManagerTests.cs
+++ b/test/Ocelot.IntegrationTests/CacheManagerTests.cs
@@ -60,7 +60,7 @@ namespace Ocelot.IntegrationTests
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -79,7 +79,7 @@ namespace Ocelot.IntegrationTests
                     },
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.IntegrationTests/HeaderTests.cs
+++ b/test/Ocelot.IntegrationTests/HeaderTests.cs
@@ -55,7 +55,7 @@ namespace Ocelot.IntegrationTests
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
+++ b/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
@@ -54,7 +54,7 @@ namespace Ocelot.IntegrationTests
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {

--- a/test/Ocelot.ManualTest/ocelot.json
+++ b/test/Ocelot.ManualTest/ocelot.json
@@ -94,8 +94,7 @@
       "DownstreamScheme": "https",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 443
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts",
@@ -115,8 +114,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/{postId}",
@@ -139,8 +137,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/{postId}/comments",
@@ -161,8 +158,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/comments",
@@ -178,8 +174,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts",
@@ -195,8 +190,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/{postId}",
@@ -212,8 +206,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/{postId}",
@@ -229,8 +222,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/{postId}",
@@ -246,8 +238,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/products",
@@ -264,8 +255,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/products/{productId}",
@@ -277,8 +267,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/products",
@@ -294,8 +283,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/products/{productId}",
@@ -312,8 +300,7 @@
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [
         {
-          "Host": "jsonplaceholder.typicode.com",
-          "Port": 80
+          "GlobalHostKey": "JsonPlaceholderService"
         }
       ],
       "UpstreamPathTemplate": "/posts/",
@@ -340,6 +327,12 @@
   ],
 
   "GlobalConfiguration": {
-    "RequestIdKey": "ot-traceid"
+    "RequestIdKey": "ot-traceid",
+    "DownstreamHosts": {
+      "JsonPlaceholderService": {
+        "Host": "jsonplaceholder.typicode.com",
+        "Port": 80
+      }
+    } 
   }
 }

--- a/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DiskFileConfigurationRepositoryTests.cs
@@ -235,7 +235,7 @@ namespace Ocelot.UnitTests.Configuration
             {
                 new()
                 {
-                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                     {
                         new()
                         {
@@ -271,7 +271,7 @@ namespace Ocelot.UnitTests.Configuration
             {
                 new()
                 {
-                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                     {
                         new()
                         {

--- a/test/Ocelot.UnitTests/Configuration/DownstreamAddressesCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DownstreamAddressesCreatorTests.cs
@@ -41,7 +41,7 @@ namespace Ocelot.UnitTests.Configuration
         {
             var route = new FileRoute
             {
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {
@@ -67,7 +67,7 @@ namespace Ocelot.UnitTests.Configuration
         {
             var route = new FileRoute
             {
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {

--- a/test/Ocelot.UnitTests/Configuration/DownstreamAddressesCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/DownstreamAddressesCreatorTests.cs
@@ -1,8 +1,10 @@
+using Moq;
 using System.Collections.Generic;
 
 using Ocelot.Configuration;
 using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
+using Ocelot.Logging;
 
 using Shouldly;
 
@@ -14,13 +16,19 @@ namespace Ocelot.UnitTests.Configuration
 {
     public class DownstreamAddressesCreatorTests
     {
-        public DownstreamAddressesCreator _creator;
+        private DownstreamAddressesCreator _creator;
         private FileRoute _route;
         private List<DownstreamHostAndPort> _result;
+        private Mock<IOcelotLoggerFactory> _factory;
+        private Mock<IOcelotLogger> _logger;
+        private FileGlobalConfiguration _globalConfiguration;
 
         public DownstreamAddressesCreatorTests()
         {
-            _creator = new DownstreamAddressesCreator();
+            _logger = new Mock<IOcelotLogger>();
+            _factory = new Mock<IOcelotLoggerFactory>();
+            _factory.Setup(x => x.CreateLogger<DownstreamAddressesCreator>()).Returns(_logger.Object);
+            _creator = new DownstreamAddressesCreator(_factory.Object);
         }
 
         [Fact]
@@ -93,15 +101,58 @@ namespace Ocelot.UnitTests.Configuration
                 .Then(x => TheThenFollowingIsReturned(expected))
                 .BDDfy();
         }
+        
+        [Fact]
+        public void should_create_downstream_addresses_from_reference_to_global_downstream_host_configuration()
+        {
+            var route = new FileRoute
+            {
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
+                {
+                    new()
+                    {
+                        GlobalHostKey = "TestHost",
+                    },
+                },
+            };
+
+            var globalConfig = new FileGlobalConfiguration
+            {
+                DownstreamHosts = new Dictionary<string, FileGlobalDownstreamHostConfig>
+                {
+                    ["TestHost"] = new FileGlobalDownstreamHostConfig
+                    {
+                        Host = "some.service.test.com",
+                        Port = 9090,
+                    },
+                },
+            };
+
+            var expected = new List<DownstreamHostAndPort>
+            {
+                new("some.service.test.com", 9090),
+            };
+
+            this.Given(x => GivenTheFollowingRoute(route))
+                .Given(x => GivenTheFollowingGlobalConfiguration(globalConfig))
+                .When(x => WhenICreate())
+                .Then(x => TheThenFollowingIsReturned(expected))
+                .BDDfy();
+        }
 
         private void GivenTheFollowingRoute(FileRoute route)
         {
             _route = route;
         }
+        
+        private void GivenTheFollowingGlobalConfiguration(FileGlobalConfiguration globalConfiguration)
+        {
+            _globalConfiguration = globalConfiguration;
+        }
 
         private void WhenICreate()
         {
-            _result = _creator.Create(_route);
+            _result = _creator.Create(_route, _globalConfiguration ?? new FileGlobalConfiguration());
         }
 
         private void TheThenFollowingIsReturned(List<DownstreamHostAndPort> expecteds)

--- a/test/Ocelot.UnitTests/Configuration/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/FileConfigurationPollerTests.cs
@@ -61,7 +61,7 @@ namespace Ocelot.UnitTests.Configuration
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -87,7 +87,7 @@ namespace Ocelot.UnitTests.Configuration
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -113,7 +113,7 @@ namespace Ocelot.UnitTests.Configuration
                 {
                     new()
                     {
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -49,7 +49,7 @@ namespace Ocelot.UnitTests.Configuration
             {
                 UpstreamPathTemplate = "/api/product",
                 UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {

--- a/test/Ocelot.UnitTests/Configuration/RoutesCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RoutesCreatorTests.cs
@@ -185,7 +185,7 @@ namespace Ocelot.UnitTests.Configuration
             _rCreator.Setup(x => x.Create(It.IsAny<FileRoute>())).Returns(_region);
             _hhoCreator.Setup(x => x.Create(It.IsAny<FileHttpHandlerOptions>())).Returns(_hho);
             _hfarCreator.Setup(x => x.Create(It.IsAny<FileRoute>())).Returns(_ht);
-            _daCreator.Setup(x => x.Create(It.IsAny<FileRoute>())).Returns(_dhp);
+            _daCreator.Setup(x => x.Create(It.IsAny<FileRoute>(), It.IsAny<FileGlobalConfiguration>())).Returns(_dhp);
             _lboCreator.Setup(x => x.Create(It.IsAny<FileLoadBalancerOptions>())).Returns(_lbo);
             _versionCreator.Setup(x => x.Create(It.IsAny<string>())).Returns(_expectedVersion);
         }
@@ -274,7 +274,7 @@ namespace Ocelot.UnitTests.Configuration
             _rCreator.Verify(x => x.Create(fileRoute), Times.Once);
             _hhoCreator.Verify(x => x.Create(fileRoute.HttpHandlerOptions), Times.Once);
             _hfarCreator.Verify(x => x.Create(fileRoute), Times.Once);
-            _daCreator.Verify(x => x.Create(fileRoute), Times.Once);
+            _daCreator.Verify(x => x.Create(fileRoute, globalConfig), Times.Once);
             _lboCreator.Verify(x => x.Create(fileRoute.LoadBalancerOptions), Times.Once);
             _soCreator.Verify(x => x.Create(fileRoute.SecurityOptions), Times.Once);
         }

--- a/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
@@ -240,7 +240,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -278,7 +278,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -319,7 +319,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -358,7 +358,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -400,7 +400,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -416,7 +416,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -461,7 +461,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -477,7 +477,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -524,7 +524,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -540,7 +540,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -586,7 +586,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -602,7 +602,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -658,7 +658,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -704,7 +704,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -720,7 +720,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/",
                             DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -794,7 +794,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -860,7 +860,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "//api/prod/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -888,7 +888,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "//api/products/",
                         UpstreamPathTemplate = "/api/prod/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -916,7 +916,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -971,7 +971,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -983,7 +983,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1010,7 +1010,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/api/products/",
                             UpstreamPathTemplate = "/asdf/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -1023,7 +1023,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         {
                             DownstreamPathTemplate = "/www/test/",
                             UpstreamPathTemplate = "/asdf/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {
@@ -1050,7 +1050,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1063,7 +1063,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1092,7 +1092,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1105,7 +1105,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Post"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1131,7 +1131,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1145,7 +1145,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1174,7 +1174,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1188,7 +1188,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1216,7 +1216,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1230,7 +1230,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/www/test/",
                         UpstreamPathTemplate = "/asdf/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1258,7 +1258,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1291,7 +1291,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1356,7 +1356,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1384,7 +1384,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1411,7 +1411,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -1438,7 +1438,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                         },
                     },
@@ -1462,7 +1462,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                         DownstreamPathTemplate = "/api/products/",
                         UpstreamPathTemplate = "/asdf/",
                         UpstreamHttpMethod = new List<string> {"Get"},
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new(),
                         },
@@ -1486,7 +1486,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                     {
                         DownstreamPathTemplate = "/bar/{everything}",
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new() { Host = "a.b.cd" },
                         },

--- a/test/Ocelot.UnitTests/Configuration/Validation/HostAndPortValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/HostAndPortValidatorTests.cs
@@ -15,7 +15,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
     {
         private HostAndPortValidator _validator;
         private ValidationResult _result;
-        private FileHostAndPort _hostAndPort;
+        private FileDownstreamHostConfig _downstreamHostConfig;
 
         public HostAndPortValidatorTests()
         {
@@ -27,7 +27,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
         [InlineData("")]
         public void should_be_invalid_because_host_empty(string host)
         {
-            var fileHostAndPort = new FileHostAndPort
+            var fileHostAndPort = new FileDownstreamHostConfig
             {
                 Host = host,
             };
@@ -42,7 +42,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
         [Fact]
         public void should_be_valid_because_host_set()
         {
-            var fileHostAndPort = new FileHostAndPort
+            var fileHostAndPort = new FileDownstreamHostConfig
             {
                 Host = "test",
             };
@@ -53,14 +53,14 @@ namespace Ocelot.UnitTests.Configuration.Validation
                 .BDDfy();
         }
 
-        private void GivenThe(FileHostAndPort hostAndPort)
+        private void GivenThe(FileDownstreamHostConfig downstreamHostConfig)
         {
-            _hostAndPort = hostAndPort;
+            _downstreamHostConfig = downstreamHostConfig;
         }
 
         private void WhenIValidate()
         {
-            _result = _validator.Validate(_hostAndPort);
+            _result = _validator.Validate(_downstreamHostConfig);
         }
 
         private void ThenTheResultIsValid()

--- a/test/Ocelot.UnitTests/Configuration/Validation/RouteFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/RouteFluentValidatorTests.cs
@@ -258,7 +258,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
             {
                 DownstreamPathTemplate = "/test",
                 UpstreamPathTemplate = "/test",
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {
@@ -287,7 +287,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
                 {
                     AuthenticationProviderKey = key,
                 },
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {
@@ -321,7 +321,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
             {
                 DownstreamPathTemplate = "/test",
                 UpstreamPathTemplate = "/test",
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {
@@ -351,7 +351,7 @@ namespace Ocelot.UnitTests.Configuration.Validation
             {
                 DownstreamPathTemplate = "/test",
                 UpstreamPathTemplate = "/test",
-                DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                 {
                     new()
                     {

--- a/test/Ocelot.UnitTests/Consul/ConsulFileConfigurationRepositoryTests.cs
+++ b/test/Ocelot.UnitTests/Consul/ConsulFileConfigurationRepositoryTests.cs
@@ -230,7 +230,7 @@ namespace Ocelot.UnitTests.Consul
             {
                 new()
                 {
-                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                     {
                         new()
                         {

--- a/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
+++ b/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
@@ -129,7 +129,7 @@ namespace Ocelot.UnitTests.DependencyInjection
                         {
                             "UpstreamHttpMethod",
                         },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -155,7 +155,7 @@ namespace Ocelot.UnitTests.DependencyInjection
                         {
                             "UpstreamHttpMethodB",
                         },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -174,7 +174,7 @@ namespace Ocelot.UnitTests.DependencyInjection
                         {
                             "UpstreamHttpMethodBB",
                         },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                         {
                             new()
                             {
@@ -225,7 +225,7 @@ namespace Ocelot.UnitTests.DependencyInjection
                             {
                                 "UpstreamHttpMethodSpec",
                             },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            DownstreamHostAndPorts = new List<FileDownstreamHostConfig>
                             {
                                 new()
                                 {


### PR DESCRIPTION
## Closes #692
This allows to simplify downstream configuration by defining a given downstream service once in the global configuration and reuse it later by referencing with `GlobalHostKey`.

```json
{
  "Routes": [{
      "DownstreamPathTemplate": "/api/products/{productId}",
      "DownstreamScheme": "http",
      "DownstreamHostAndPorts": [
        {
          "GlobalHostKey": "JsonPlaceholderService"
        }
      ],
      "UpstreamPathTemplate": "/products/{productId}",
      "UpstreamHttpMethod": [ "Put" ],
      "QoSOptions": {
        "ExceptionsAllowedBeforeBreaking": 3,
        "DurationOfBreak": 10,
        "TimeoutValue": 5000
      },
      "FileCacheOptions": { "TtlSeconds": 15 }
    },
    {
      "DownstreamPathTemplate": "/posts",
      "DownstreamScheme": "http",
      "DownstreamHostAndPorts": [
        {
          "GlobalHostKey": "JsonPlaceholderService"
        }
      ],
      "UpstreamPathTemplate": "/posts/",
      "UpstreamHttpMethod": [ "Get" ],
      "QoSOptions": {
        "ExceptionsAllowedBeforeBreaking": 3,
        "DurationOfBreak": 10,
        "TimeoutValue": 5000
      },
      "FileCacheOptions": { "TtlSeconds": 15 }
    },
    {
      "DownstreamPathTemplate": "/",
      "DownstreamScheme": "http",
      "DownstreamHostAndPorts": [
        {
          "Host": "www.bbc.co.uk",
          "Port": 80
        }
      ],
      "UpstreamPathTemplate": "/bbc/",
      "UpstreamHttpMethod": [ "Get" ]
    }
  ],

  "GlobalConfiguration": {
    "RequestIdKey": "ot-traceid",
    "DownstreamHosts": {
      "JsonPlaceholderService": {
        "Host": "jsonplaceholder.typicode.com",
        "Port": 80
      }
    } 
  }
}
```

This also allows to very easily override downstream address per environment.

**Important**: I've changed a lot of files because I need to rename `FileHostAndPort` &rarr; `FileDownstreamHostConfig`.
All things related to rename are in a separated commit.
