### PR TITLE
#893 Problems to cancel a request (CancellationToken)

### DIFF
--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -1,10 +1,8 @@
 using Microsoft.AspNetCore.Http;
-
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Logging;
 using Ocelot.Middleware;
-
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -184,6 +184,7 @@ namespace Ocelot.Multiplexer
             target.Request.RouteValues = source.Request.RouteValues;
             target.Connection.RemoteIpAddress = source.Connection.RemoteIpAddress;
             target.RequestServices = source.RequestServices;
+            target.RequestAborted = source.RequestAborted;
             return target;
         }
 

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
+
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Logging;
 using Ocelot.Middleware;
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -1,0 +1,133 @@
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using TestStack.BDDfy;
+using Xunit;
+
+namespace Ocelot.AcceptanceTests
+{
+    public class CancelRequestTests : IDisposable
+    {
+        private const int SERVICE_WORK_TIME = 5_000;
+        private const int MAX_WAITING_TIME = 60_000;
+        private readonly Steps _steps;
+        private readonly ServiceHandler _serviceHandler;
+        private Notifier _serviceWorkStartedNotifier;
+        private Notifier _serviceWorkStoppedNotifier;
+        private bool _cancelExceptionThrown;
+
+        public CancelRequestTests()
+        {
+            _serviceHandler = new ServiceHandler();
+            _steps = new Steps();
+            _serviceWorkStartedNotifier = new Notifier("service work started notifier");
+            _serviceWorkStoppedNotifier = new Notifier("service work finished notifier");
+        }
+
+        [Fact]
+        public void should_abort_service_work_when_cancelling_the_request()
+        {
+            var port = RandomPortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                    {
+                        new FileRoute
+                        {
+                            DownstreamPathTemplate = "/",
+                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new FileHostAndPort
+                                {
+                                    Host = "localhost",
+                                    Port = port,
+                                },
+                            },
+                            DownstreamScheme = "http",
+                            UpstreamPathTemplate = "/",
+                            UpstreamHttpMethod = new List<string> { "Get" },
+                        },
+                    },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}"))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGatewayAndDontWait("/"))
+                .And(x => x.WhenIWaitForNotification(_serviceWorkStartedNotifier))
+                .And(x => _steps.WhenICancelTheRequest())
+                .And(x => x.WhenIWaitForNotification(_serviceWorkStoppedNotifier))
+                .Then(x => x.ThenServiceWorkIsNotFinished())
+                .BDDfy();
+        }
+
+        private void GivenThereIsAServiceRunningOn(string baseUrl)
+        {
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, async context =>
+            {
+                try
+                {
+                    var response = string.Empty;
+
+                    _serviceWorkStartedNotifier.NotificationSent = true;
+                    await Task.Delay(SERVICE_WORK_TIME, context.RequestAborted);
+
+                    context.Response.StatusCode = (int)HttpStatusCode.OK;
+                    await context.Response.WriteAsync(response);
+                }
+                catch (TaskCanceledException)
+                {
+                    _cancelExceptionThrown = true;
+                }
+                finally
+                {
+                    _serviceWorkStoppedNotifier.NotificationSent = true;
+                }
+            });
+        }
+
+        private async Task WhenIWaitForNotification(Notifier notifier)
+        {
+            int waitingTime = 0;
+            while (!notifier.NotificationSent)
+            {
+                var waitingInterval = 50;
+                await Task.Delay(waitingInterval);
+                waitingTime += waitingInterval;
+
+                if (waitingTime > MAX_WAITING_TIME)
+                {
+                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME}s.");
+                }
+            }
+        }
+
+        private void ThenServiceWorkIsNotFinished()
+        {
+            _cancelExceptionThrown.ShouldBeTrue();
+        }
+
+        public void Dispose()
+        {
+            _serviceHandler?.Dispose();
+            _steps.Dispose();
+        }
+
+        class Notifier
+        {
+            public Notifier(string name)
+            {
+                Name = name;
+            }
+
+            public bool NotificationSent { get; set; }
+
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
 
                 if (waitingTime > MAX_WAITING_TIME)
                 {
-                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME}s.");
+                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000}s.");
                 }
             }
         }

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
 
                 if (waitingTime > MAX_WAITING_TIME)
                 {
-                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000}s.");
+                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000} s.");
                 }
             }
         }

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -102,7 +102,7 @@ namespace Ocelot.AcceptanceTests
 
                 if (waitingTime > MAX_WAITING_TIME)
                 {
-                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000} s.");
+                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME}s.");
                 }
             }
         }

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration.File;
 using Shouldly;
-
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-
 using TestStack.BDDfy;
 using Xunit;
 

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -14,16 +14,18 @@ public class CancelRequestTests : IDisposable
 {
     private const int SERVICE_WORK_TIME = 5_000;
     private const int MAX_WAITING_TIME = 60_000;
+
     private readonly Steps _steps;
     private readonly ServiceHandler _serviceHandler;
     private readonly Notifier _serviceWorkStartedNotifier;
     private readonly Notifier _serviceWorkStoppedNotifier;
+
     private bool _cancelExceptionThrown;
 
     public CancelRequestTests()
     {
-        _serviceHandler = new ServiceHandler();
         _steps = new Steps();
+        _serviceHandler = new ServiceHandler();
         _serviceWorkStartedNotifier = new Notifier("service work started notifier");
         _serviceWorkStoppedNotifier = new Notifier("service work finished notifier");
     }
@@ -36,23 +38,23 @@ public class CancelRequestTests : IDisposable
         var configuration = new FileConfiguration
         {
             Routes = new List<FileRoute>
+            {
+                new()
                 {
-                    new FileRoute
+                    DownstreamPathTemplate = "/",
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
                     {
-                        DownstreamPathTemplate = "/",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        new()
                         {
-                            new FileHostAndPort
-                            {
-                                Host = "localhost",
-                                Port = port,
-                            },
+                            Host = "localhost",
+                            Port = port,
                         },
-                        DownstreamScheme = "http",
-                        UpstreamPathTemplate = "/",
-                        UpstreamHttpMethod = new List<string> { "Get" },
                     },
+                    DownstreamScheme = "http",
+                    UpstreamPathTemplate = "/",
+                    UpstreamHttpMethod = new List<string> { "Get" },
                 },
+            },
         };
 
         this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}"))
@@ -124,13 +126,9 @@ public class CancelRequestTests : IDisposable
 
     class Notifier
     {
-        public Notifier(string name)
-        {
-            Name = name;
-        }
+        public Notifier(string name) => Name = name;
 
         public bool NotificationSent { get; set; }
-
         public string Name { get; set; }
     }
 }

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -62,7 +62,7 @@ namespace Ocelot.AcceptanceTests
                 .And(x => x.WhenIWaitForNotification(_serviceWorkStartedNotifier))
                 .And(x => _steps.WhenICancelTheRequest())
                 .And(x => x.WhenIWaitForNotification(_serviceWorkStoppedNotifier))
-                .Then(x => x.ThenServiceWorkIsNotFinished())
+                .Then(x => x.ThenOcelotClientRequestIsCanceled())
                 .BDDfy();
         }
 
@@ -102,13 +102,16 @@ namespace Ocelot.AcceptanceTests
 
                 if (waitingTime > MAX_WAITING_TIME)
                 {
-                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000} s.");
+                    throw new TimeoutException(notifier.Name + $" did not sent notification within {MAX_WAITING_TIME / 1000} second(s).");
                 }
             }
         }
 
-        private void ThenServiceWorkIsNotFinished()
+        private void ThenOcelotClientRequestIsCanceled()
         {
+            _serviceWorkStartedNotifier.NotificationSent.ShouldBeTrue();
+            _serviceWorkStoppedNotifier.NotificationSent.ShouldBeTrue();
+
             _cancelExceptionThrown.ShouldBeTrue();
         }
 

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -29,7 +29,7 @@ public class CancelRequestTests : IDisposable
     }
 
     [Fact]
-    public void should_abort_service_work_when_cancelling_the_request()
+    public void Should_abort_service_work_when_cancelling_the_request()
     {
         var port = RandomPortFinder.GetRandomPort();
 
@@ -59,9 +59,9 @@ public class CancelRequestTests : IDisposable
             .And(x => _steps.GivenThereIsAConfiguration(configuration))
             .And(x => _steps.GivenOcelotIsRunning())
             .When(x => _steps.WhenIGetUrlOnTheApiGatewayAndDontWait("/"))
-            .And(x => x.WhenIWaitForNotification(_serviceWorkStartedNotifier))
+            .And(x => WhenIWaitForNotification(_serviceWorkStartedNotifier))
             .And(x => _steps.WhenICancelTheRequest())
-            .And(x => x.WhenIWaitForNotification(_serviceWorkStoppedNotifier))
+            .And(x => WhenIWaitForNotification(_serviceWorkStoppedNotifier))
             .Then(x => x.ThenOcelotClientRequestIsCanceled())
             .BDDfy();
     }
@@ -91,7 +91,7 @@ public class CancelRequestTests : IDisposable
         });
     }
 
-    private async Task WhenIWaitForNotification(Notifier notifier)
+    private static async Task WhenIWaitForNotification(Notifier notifier)
     {
         int waitingTime = 0;
         while (!notifier.NotificationSent)
@@ -119,6 +119,7 @@ public class CancelRequestTests : IDisposable
     {
         _serviceHandler?.Dispose();
         _steps.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     class Notifier

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration.File;
 using Shouldly;
+
 using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+
 using TestStack.BDDfy;
 using Xunit;
 

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -16,8 +16,8 @@ public class CancelRequestTests : IDisposable
     private const int MAX_WAITING_TIME = 60_000;
     private readonly Steps _steps;
     private readonly ServiceHandler _serviceHandler;
-    private Notifier _serviceWorkStartedNotifier;
-    private Notifier _serviceWorkStoppedNotifier;
+    private readonly Notifier _serviceWorkStartedNotifier;
+    private readonly Notifier _serviceWorkStoppedNotifier;
     private bool _cancelExceptionThrown;
 
     public CancelRequestTests()

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -966,6 +966,16 @@ namespace Ocelot.AcceptanceTests
             _response = _ocelotClient.GetAsync(url).Result;
         }
 
+        public void WhenIGetUrlOnTheApiGatewayAndDontWait(string url)
+        {
+            _ocelotClient.GetAsync(url);
+        }
+
+        public void WhenICancelTheRequest()
+        {
+            _ocelotClient.CancelPendingRequests();
+        }
+
         public void WhenIGetUrlOnTheApiGateway(string url, HttpContent content)
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, url) { Content = content };

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -1,4 +1,33 @@
-﻿using Ocelot.Configuration.ChangeTracking;
+﻿using CacheManager.Core;
+using IdentityServer4.AccessTokenValidation;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Ocelot.AcceptanceTests.Caching;
+using Ocelot.Cache.CacheManager;
+using Ocelot.Configuration;
+using Ocelot.Configuration.ChangeTracking;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration.File;
+using Ocelot.Configuration.Repository;
+using Ocelot.DependencyInjection;
+using Ocelot.LoadBalancer.LoadBalancers;
+using Ocelot.Logging;
+using Ocelot.Middleware;
+using Ocelot.Multiplexer;
+using Ocelot.Provider.Consul;
+using Ocelot.Provider.Eureka;
+using Ocelot.Provider.Polly;
+using Ocelot.Requester;
+using Ocelot.ServiceDiscovery.Providers;
+using Ocelot.Tracing.Butterfly;
+using Ocelot.Tracing.OpenTracing;
+using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,54 +40,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-using CacheManager.Core;
-
-using Ocelot.AcceptanceTests.Caching;
-
-using Ocelot.Configuration;
-using Ocelot.Configuration.Creator;
-using Ocelot.Configuration.File;
-using Ocelot.Configuration.Repository;
-
-using Ocelot.DependencyInjection;
-
-using IdentityServer4.AccessTokenValidation;
-
-using Ocelot.LoadBalancer.LoadBalancers;
-
-using Ocelot.Logging;
-
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-
-using Ocelot.Middleware;
-
-using Moq;
-
-using Ocelot.Multiplexer;
-
-using Newtonsoft.Json;
-
-using Ocelot.Cache.CacheManager;
-using Ocelot.Provider.Consul;
-using Ocelot.Provider.Polly;
-using Ocelot.Tracing.Butterfly;
-using Ocelot.Tracing.OpenTracing;
-
-using Ocelot.Provider.Eureka;
-
-using Ocelot.Requester;
-
-using Ocelot.ServiceDiscovery.Providers;
-
-using Shouldly;
-
 using static Ocelot.AcceptanceTests.HttpDelegatingHandlersTests;
-
 using ConfigurationBuilder = Microsoft.Extensions.Configuration.ConfigurationBuilder;
 using CookieHeaderValue = Microsoft.Net.Http.Headers.CookieHeaderValue;
 using MediaTypeHeaderValue = System.Net.Http.Headers.MediaTypeHeaderValue;

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -1,33 +1,4 @@
-﻿using CacheManager.Core;
-using IdentityServer4.AccessTokenValidation;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Moq;
-using Newtonsoft.Json;
-using Ocelot.AcceptanceTests.Caching;
-using Ocelot.Cache.CacheManager;
-using Ocelot.Configuration;
-using Ocelot.Configuration.ChangeTracking;
-using Ocelot.Configuration.Creator;
-using Ocelot.Configuration.File;
-using Ocelot.Configuration.Repository;
-using Ocelot.DependencyInjection;
-using Ocelot.LoadBalancer.LoadBalancers;
-using Ocelot.Logging;
-using Ocelot.Middleware;
-using Ocelot.Multiplexer;
-using Ocelot.Provider.Consul;
-using Ocelot.Provider.Eureka;
-using Ocelot.Provider.Polly;
-using Ocelot.Requester;
-using Ocelot.ServiceDiscovery.Providers;
-using Ocelot.Tracing.Butterfly;
-using Ocelot.Tracing.OpenTracing;
-using Shouldly;
+﻿using Ocelot.Configuration.ChangeTracking;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -40,7 +11,54 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using CacheManager.Core;
+
+using Ocelot.AcceptanceTests.Caching;
+
+using Ocelot.Configuration;
+using Ocelot.Configuration.Creator;
+using Ocelot.Configuration.File;
+using Ocelot.Configuration.Repository;
+
+using Ocelot.DependencyInjection;
+
+using IdentityServer4.AccessTokenValidation;
+
+using Ocelot.LoadBalancer.LoadBalancers;
+
+using Ocelot.Logging;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Ocelot.Middleware;
+
+using Moq;
+
+using Ocelot.Multiplexer;
+
+using Newtonsoft.Json;
+
+using Ocelot.Cache.CacheManager;
+using Ocelot.Provider.Consul;
+using Ocelot.Provider.Polly;
+using Ocelot.Tracing.Butterfly;
+using Ocelot.Tracing.OpenTracing;
+
+using Ocelot.Provider.Eureka;
+
+using Ocelot.Requester;
+
+using Ocelot.ServiceDiscovery.Providers;
+
+using Shouldly;
+
 using static Ocelot.AcceptanceTests.HttpDelegatingHandlersTests;
+
 using ConfigurationBuilder = Microsoft.Extensions.Configuration.ConfigurationBuilder;
 using CookieHeaderValue = Microsoft.Net.Http.Headers.CookieHeaderValue;
 using MediaTypeHeaderValue = System.Net.Http.Headers.MediaTypeHeaderValue;


### PR DESCRIPTION
## Fixes #893 
- #893 


## Proposed Changes

  - One more problem related to `HttpContext`: cancellation token was not copied to the new `HttpContext`. 

