### PR TITLE
Add 'multipart/form-data' support for file uploads

### DIFF
--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -219,6 +219,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
                 Body = bodyStream,
                 ContentLength = from.ContentLength,
                 ContentType = from.ContentType,
+                Form = from.Form,
                 Host = from.Host,
                 Method = from.Method,
                 Path = from.Path,

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -27,7 +27,7 @@ public class RequestMapper : IRequestMapper
 
         private static bool IsMultipartContentType(string contentType)
             => !string.IsNullOrEmpty(contentType)
-                && contentType.IndexOf("multipart/form-data", StringComparison.OrdinalIgnoreCase) >= 0;
+                && contentType.Contains("multipart/form-data", StringComparison.OrdinalIgnoreCase);
 
     private static HttpContent MapContent(HttpRequest request)
     {

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -25,11 +25,9 @@ public class RequestMapper : IRequestMapper
         return requestMessage;
     }
 
-    private static bool IsMultipartContentType(string contentType)
-    {
-        return !string.IsNullOrEmpty(contentType)
-               && contentType.IndexOf("multipart/form-data", StringComparison.OrdinalIgnoreCase) >= 0;
-    }
+        private static bool IsMultipartContentType(string contentType)
+            => !string.IsNullOrEmpty(contentType)
+                && contentType.IndexOf("multipart/form-data", StringComparison.OrdinalIgnoreCase) >= 0;
 
     private static HttpContent MapContent(HttpRequest request)
     {


### PR DESCRIPTION
## Fixes #714 
- #714 

## Motivation
Introduce a support of file streaming (file uploads) via the gateway, without body content caching.
Current loading of entire body to a memory in Ocelot core is a source of errors, unstable responses because downstream services produce errors during long lasting operation of the request.

## Proposed Changes
- add `multipart/form-data` support for file uploads

## Related to
- #792 
- #714 
- #617 
- #1685 
