### PR TITLE
removed unnecessary parameter from custom load balancer doc.

### DIFF
--- a/docs/features/loadbalancer.rst
+++ b/docs/features/loadbalancer.rst
@@ -147,7 +147,7 @@ Then you need to create a class that implements the ILoadBalancer interface. Bel
                 _services = services;
             }
 
-            public async Task<Response<ServiceHostAndPort>> Lease(DownstreamContext downstreamContext, HttpContext httpContext)
+            public async Task<Response<ServiceHostAndPort>> Lease(HttpContext httpContext)
             {
                 var services = await _services();
                 lock (_lock)


### PR DESCRIPTION
## Proposed Changes

    - Current Ocelot package doesn't contain two parameters in Lease method. I deleted unnecessary parameter from doc.

```csharp
namespace Ocelot.LoadBalancer.LoadBalancers
{
  public interface ILoadBalancer
  {
    Task<Response<ServiceHostAndPort>> Lease(HttpContext httpContext);

    void Release(ServiceHostAndPort hostAndPort);
  }
}
```

when we implement above interface

```csharp
public async Task<Response<ServiceHostAndPort>> Lease(HttpContext httpContext)
{
    var services = await _services();

    lock (_lock)
    {
        if (_last >= services.Count)
        {
            _last = 0;
        }

        var next = services[_last];

        _last++;

        return new OkResponse<ServiceHostAndPort>(next.HostAndPort);
    }
}
```
we are gonna expect this parameter