### PR TITLE
#1400 Manage multiple patterns for allowed/blocked IPs via Security Options config section

### DIFF
--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -69,7 +69,7 @@ Here is an example Route configuration, You don't need to set all of these thing
             },
             "DangerousAcceptAnyServerCertificateValidator": false,
             "SecurityOptions": {
-                "IPAllowedList": [ ],
+                "IPAllowedList": [],
                 "IPBlockedList": [],
                 "ExcludeAllowedFromBlocked": false
             }

--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -67,7 +67,12 @@ Here is an example Route configuration, You don't need to set all of these thing
                 "UseTracing": true,
                 "MaxConnectionsPerServer": 100
             },
-            "DangerousAcceptAnyServerCertificateValidator": false
+            "DangerousAcceptAnyServerCertificateValidator": false,
+            "SecurityOptions": {
+                "IPAllowedList": [ ],
+                "IPBlockedList": [],
+                "ExcludeAllowedFromBlocked": false
+            }
         }
 
 More information on how to use these options is below.

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -237,3 +237,54 @@ Ocelot will also allow you to put query string parameters in the UpstreamPathTem
 
 In this example Ocelot will only match requests that have a matching url path and the query string starts with unitId=something. You can have other queries after this
 but you must start with the matching parameter. Also Ocelot will swap the {unitId} parameter from the query string and use it in the downstream request path. 
+
+Security Options
+^^^^^^^^^^^^^^^^
+
+Ocelot allows you to manage multiple pattern for allowed/blocked IP via `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_
+
+This feature is designed to allow greater IP management in order to include or exclude a wide IP range via CIDR notation or IP range.
+The current patterns managed are the following:
+
+* single IP: "192.168.1.1"
+* IP Range: "192.168.1.1-192.168.1.250"
+* IP Short Range: "192.168.1.1-250"
+* IP Range with subnet: "192.168.1.0/255.255.255.0"
+* CIDR: "192.168.1.0/24"
+* CIDR for IPv6: "fe80::/10"
+* The allowed and block list are evaluated on configuration loaded.
+* The *ExcludeAllowedFromBlocked* is meant to give the possibility to specify a wide range of blocked IP and allow a sub range of IPs
+* Default value: false
+* Missing property in SecurityOptions allowed, it assume default value.
+
+.. code-block:: json
+
+    {
+        "Routes": [
+            {
+                "DownstreamPathTemplate": "/api/service/{Id}",
+                "UpstreamPathTemplate": "/api/internal-service/{Id}/full",
+                "UpstreamHttpMethod": [
+                    "Get"
+                ],
+                "DownstreamScheme": "http",
+                "DownstreamHostAndPorts": [
+                    {
+                        "Host": "localhost",
+                        "Port": 50110
+                    }
+                ],
+                "SecurityOptions": { 
+                    "IPBlockedList": [ "192.168.0.0/23" ], 
+                    "IPAllowedList: [ "192.168.0.15", "192.168.1.15"], 
+                    "ExcludeAllowedFromBlocked": true 
+                }
+            }
+        ],
+        "GlobalConfiguration": {
+        }
+
+    }
+
+
+This feature was requested in `issue 1400 <https://github.com/ThreeMammals/Ocelot/issues/1400>`_.

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -241,7 +241,7 @@ but you must start with the matching parameter. Also Ocelot will swap the {unitI
 Security Options
 ^^^^^^^^^^^^^^^^
 
-Ocelot allows you to manage multiple patterns for allowed/blocked IPs using the `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_ package.
+Ocelot allows you to manage multiple patterns for allowed/blocked IPs using the `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_ package with `MPL-2.0 License <https://github.com/jsakamoto/ipaddressrange/blob/master/LICENSE>`_.
 
 This feature is designed to allow greater IP management in order to include or exclude a wide IP range via CIDR notation or IP range.
 The current patterns managed are the following:

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -241,21 +241,21 @@ but you must start with the matching parameter. Also Ocelot will swap the {unitI
 Security Options
 ^^^^^^^^^^^^^^^^
 
-Ocelot allows you to manage multiple pattern for allowed/blocked IP via `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_
+Ocelot allows you to manage multiple patterns for allowed/blocked IPs using the `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_ package.
 
 This feature is designed to allow greater IP management in order to include or exclude a wide IP range via CIDR notation or IP range.
 The current patterns managed are the following:
 
-* single IP: "192.168.1.1"
-* IP Range: "192.168.1.1-192.168.1.250"
-* IP Short Range: "192.168.1.1-250"
-* IP Range with subnet: "192.168.1.0/255.255.255.0"
-* CIDR: "192.168.1.0/24"
-* CIDR for IPv6: "fe80::/10"
-* The allowed and block list are evaluated on configuration loaded.
-* The *ExcludeAllowedFromBlocked* is meant to give the possibility to specify a wide range of blocked IP and allow a sub range of IPs
-* Default value: false
-* Missing property in SecurityOptions allowed, it assume default value.
+* Single IP: :code:`192.168.1.1`
+* IP Range: :code:`192.168.1.1-192.168.1.250`
+* IP Short Range: :code:`192.168.1.1-250`
+* IP Range with subnet: :code:`192.168.1.0/255.255.255.0`
+* CIDR: :code:`192.168.1.0/24`
+* CIDR for IPv6: :code:`fe80::/10`
+* The allowed/blocked lists are evaluated during configuration loading
+* The *ExcludeAllowedFromBlocked* property is intended to provide the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
+  Default value: :code:`false`
+* The absence of a property in **SecurityOptions** is allowed, it takes the default value.
 
 .. code-block:: json
 
@@ -276,15 +276,12 @@ The current patterns managed are the following:
                 ],
                 "SecurityOptions": { 
                     "IPBlockedList": [ "192.168.0.0/23" ], 
-                    "IPAllowedList: [ "192.168.0.15", "192.168.1.15"], 
+                    "IPAllowedList": ["192.168.0.15", "192.168.1.15"], 
                     "ExcludeAllowedFromBlocked": true 
-                }
-            }
+                },
+            },
         ],
-        "GlobalConfiguration": {
-        }
-
+        "GlobalConfiguration": { }
     }
 
-
-This feature was requested in `issue 1400 <https://github.com/ThreeMammals/Ocelot/issues/1400>`_.
+This feature was requested in the `issue 1400 <https://github.com/ThreeMammals/Ocelot/issues/1400>`_.

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -6,7 +6,7 @@ namespace Ocelot.Configuration.Creator
     {
         public SecurityOptions Create(FileSecurityOptions securityOptions)
         {
-            return new SecurityOptions(securityOptions.IPAllowedList, securityOptions.IPBlockedList);
+            return new SecurityOptions(securityOptions.IPAllowedList, securityOptions.IPBlockedList, securityOptions.ExcludeAllowedFromBlocked);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -17,7 +17,7 @@ namespace Ocelot.Configuration.Creator
             {
                 if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
                 {
-                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    var allowedIps = allowedIpAddressRange.Select(x => x.ToString()).ToArray();
                     ipAllowedList.AddRange(allowedIps);
                 }
             }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -1,41 +1,42 @@
 ﻿using Ocelot.Configuration.File;
-using System.Linq;
+
 using System.Collections.Generic;
+using System.Linq;
+
 using IPAddressRange = NetTools;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public class SecurityOptionsCreator : ISecurityOptionsCreator
 {
-    public class SecurityOptionsCreator : ISecurityOptionsCreator
+    public SecurityOptions Create(FileSecurityOptions securityOptions)
     {
-        public SecurityOptions Create(FileSecurityOptions securityOptions)
+        var IPAllowedList = new List<string>();
+        var IPBlockedList = new List<string>();
+
+        foreach (var allowed in securityOptions.IPAllowedList)
         {
-            var IPAllowedList = new List<string>();
-            var IPBlockedList = new List<string>();
-
-            foreach (var allowed in securityOptions.IPAllowedList)
+            if (IPAddressRange.IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
             {
-                if (IPAddressRange.IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
-                {
-                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                    IPAllowedList.AddRange(allowedIps);
-                }
+                var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                IPAllowedList.AddRange(allowedIps);
             }
-
-            foreach (var blocked in securityOptions.IPBlockedList)
-            {
-                if (IPAddressRange.IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
-                {
-                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                    IPBlockedList.AddRange(blockedIps);
-                }
-            }
-
-            if (securityOptions.ExcludeAllowedFromBlocked)
-            {
-                IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
-            }
-
-            return new SecurityOptions(IPAllowedList, IPBlockedList);
         }
+
+        foreach (var blocked in securityOptions.IPBlockedList)
+        {
+            if (IPAddressRange.IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+            {
+                var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                IPBlockedList.AddRange(blockedIps);
+            }
+        }
+
+        if (securityOptions.ExcludeAllowedFromBlocked)
+        {
+            IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
+        }
+
+        return new SecurityOptions(IPAllowedList, IPBlockedList);
     }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -1,10 +1,6 @@
 ﻿using NetTools; // <PackageReference Include="IPAddressRange" Version="6.0.0" />
 using Ocelot.Configuration.File;
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-
 namespace Ocelot.Configuration.Creator
 {
     public class SecurityOptionsCreator : ISecurityOptionsCreator

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -3,6 +3,7 @@ using Ocelot.Configuration.File;
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 
 namespace Ocelot.Configuration.Creator
 {
@@ -17,7 +18,7 @@ namespace Ocelot.Configuration.Creator
             {
                 if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
                 {
-                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    var allowedIps = allowedIpAddressRange.Select<IPAddress, string>(x => x.ToString());
                     ipAllowedList.AddRange(allowedIps);
                 }
             }
@@ -26,7 +27,7 @@ namespace Ocelot.Configuration.Creator
             {
                 if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
                 {
-                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    var blockedIps = blockedIpAddressRange.Select<IPAddress, string>(x => x.ToString());
                     ipBlockedList.AddRange(blockedIps);
                 }
             }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -1,4 +1,7 @@
 ﻿using Ocelot.Configuration.File;
+using System.Linq;
+using System.Collections.Generic;
+using IPAddressRange = NetTools;
 
 namespace Ocelot.Configuration.Creator
 {
@@ -6,7 +9,33 @@ namespace Ocelot.Configuration.Creator
     {
         public SecurityOptions Create(FileSecurityOptions securityOptions)
         {
-            return new SecurityOptions(securityOptions.IPAllowedList, securityOptions.IPBlockedList, securityOptions.ExcludeAllowedFromBlocked);
+            var IPAllowedList = new List<string>();
+            var IPBlockedList = new List<string>();
+
+            foreach (var allowed in securityOptions.IPAllowedList)
+            {
+                if (IPAddressRange.IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
+                {
+                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    IPAllowedList.AddRange(allowedIps);
+                }
+            }
+
+            foreach (var blocked in securityOptions.IPBlockedList)
+            {
+                if (IPAddressRange.IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+                {
+                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    IPBlockedList.AddRange(blockedIps);
+                }
+            }
+
+            if (securityOptions.ExcludeAllowedFromBlocked)
+            {
+                IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
+            }
+
+            return new SecurityOptions(IPAllowedList, IPBlockedList);
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -4,38 +4,39 @@ using Ocelot.Configuration.File;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Ocelot.Configuration.Creator;
-
-public class SecurityOptionsCreator : ISecurityOptionsCreator
+namespace Ocelot.Configuration.Creator
 {
-    public SecurityOptions Create(FileSecurityOptions securityOptions)
+    public class SecurityOptionsCreator : ISecurityOptionsCreator
     {
-        var ipAllowedList = new List<string>();
-        var ipBlockedList = new List<string>();
-
-        foreach (var allowed in securityOptions.IPAllowedList)
+        public SecurityOptions Create(FileSecurityOptions securityOptions)
         {
-            if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
+            var ipAllowedList = new List<string>();
+            var ipBlockedList = new List<string>();
+
+            foreach (var allowed in securityOptions.IPAllowedList)
             {
-                var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                ipAllowedList.AddRange(allowedIps);
+                if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
+                {
+                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    ipAllowedList.AddRange(allowedIps);
+                }
             }
-        }
 
-        foreach (var blocked in securityOptions.IPBlockedList)
-        {
-            if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+            foreach (var blocked in securityOptions.IPBlockedList)
             {
-                var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                ipBlockedList.AddRange(blockedIps);
+                if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+                {
+                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+                    ipBlockedList.AddRange(blockedIps);
+                }
             }
-        }
 
-        if (securityOptions.ExcludeAllowedFromBlocked)
-        {
-            ipBlockedList = ipBlockedList.Except(ipAllowedList).ToList();
-        }
+            if (securityOptions.ExcludeAllowedFromBlocked)
+            {
+                ipBlockedList = ipBlockedList.Except(ipAllowedList).ToList();
+            }
 
-        return new SecurityOptions(ipAllowedList, ipBlockedList);
+            return new SecurityOptions(ipAllowedList, ipBlockedList);
+        }
     }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -1,9 +1,8 @@
-﻿using Ocelot.Configuration.File;
+﻿using NetTools; // <PackageReference Include="IPAddressRange" Version="5.0.0" />
+using Ocelot.Configuration.File;
 
 using System.Collections.Generic;
 using System.Linq;
-
-using IPAddressRange = NetTools;
 
 namespace Ocelot.Configuration.Creator;
 
@@ -16,7 +15,7 @@ public class SecurityOptionsCreator : ISecurityOptionsCreator
 
         foreach (var allowed in securityOptions.IPAllowedList)
         {
-            if (IPAddressRange.IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
+            if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
             {
                 var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
                 ipAllowedList.AddRange(allowedIps);
@@ -25,7 +24,7 @@ public class SecurityOptionsCreator : ISecurityOptionsCreator
 
         foreach (var blocked in securityOptions.IPBlockedList)
         {
-            if (IPAddressRange.IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+            if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
             {
                 var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
                 ipBlockedList.AddRange(blockedIps);

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -1,4 +1,4 @@
-﻿using NetTools; // <PackageReference Include="IPAddressRange" Version="5.0.0" />
+﻿using NetTools; // <PackageReference Include="IPAddressRange" Version="6.0.0" />
 using Ocelot.Configuration.File;
 
 using System.Collections.Generic;

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -17,7 +17,7 @@ namespace Ocelot.Configuration.Creator
             {
                 if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
                 {
-                    var allowedIps = allowedIpAddressRange.Select(x => x.ToString()).ToArray();
+                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
                     ipAllowedList.AddRange(allowedIps);
                 }
             }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -11,15 +11,15 @@ public class SecurityOptionsCreator : ISecurityOptionsCreator
 {
     public SecurityOptions Create(FileSecurityOptions securityOptions)
     {
-        var IPAllowedList = new List<string>();
-        var IPBlockedList = new List<string>();
+        var ipAllowedList = new List<string>();
+        var ipBlockedList = new List<string>();
 
         foreach (var allowed in securityOptions.IPAllowedList)
         {
             if (IPAddressRange.IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
             {
                 var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                IPAllowedList.AddRange(allowedIps);
+                ipAllowedList.AddRange(allowedIps);
             }
         }
 
@@ -28,15 +28,15 @@ public class SecurityOptionsCreator : ISecurityOptionsCreator
             if (IPAddressRange.IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
             {
                 var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                IPBlockedList.AddRange(blockedIps);
+                ipBlockedList.AddRange(blockedIps);
             }
         }
 
         if (securityOptions.ExcludeAllowedFromBlocked)
         {
-            IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
+            ipBlockedList = ipBlockedList.Except(ipAllowedList).ToList();
         }
 
-        return new SecurityOptions(IPAllowedList, IPBlockedList);
+        return new SecurityOptions(ipAllowedList, ipBlockedList);
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -9,38 +9,39 @@ namespace Ocelot.Configuration.File
             ExcludeAllowedFromBlocked = false;
         }
 
-    public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
-        : this()
-    {
-        if (!string.IsNullOrEmpty(allowedIPs))
+        public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+            : this()
         {
-            IPAllowedList.Add(allowedIPs);
+            if (!string.IsNullOrEmpty(allowedIPs))
+            {
+                IPAllowedList.Add(allowedIPs);
+            }
+
+            if (!string.IsNullOrEmpty(blockedIPs))
+            {
+                IPBlockedList.Add(blockedIPs);
+            }
+
+            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
         }
 
-        if (!string.IsNullOrEmpty(blockedIPs))
+        public FileSecurityOptions(IEnumerable<string> allowedIPs = null, IEnumerable<string> blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+            : this()
         {
-            IPBlockedList.Add(blockedIPs);
+            IPAllowedList.AddRange(allowedIPs ?? Enumerable.Empty<string>());
+            IPBlockedList.AddRange(blockedIPs ?? Enumerable.Empty<string>());
+            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
         }
 
-        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
+        public List<string> IPAllowedList { get; set; }
+        public List<string> IPBlockedList { get; set; }
+
+        /// <summary>
+        /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
+        /// </summary>
+        /// <value>
+        /// Default value: false.
+        /// </value>        
+        public bool ExcludeAllowedFromBlocked { get; set; }
     }
-
-    public FileSecurityOptions(IEnumerable<string> allowedIPs = null, IEnumerable<string> blockedIPs = null, bool? excludeAllowedFromBlocked = null)
-        : this()
-    {
-        IPAllowedList.AddRange(allowedIPs ?? Enumerable.Empty<string>());
-        IPBlockedList.AddRange(blockedIPs ?? Enumerable.Empty<string>());
-        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
-    }
-
-    public List<string> IPAllowedList { get; set; }
-    public List<string> IPBlockedList { get; set; }
-
-    /// <summary>
-    /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
-    /// </summary>
-    /// <value>
-    /// Default value: false.
-    /// </value>        
-    public bool ExcludeAllowedFromBlocked { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -11,5 +11,7 @@
         public List<string> IPAllowedList { get; set; }
 
         public List<string> IPBlockedList { get; set; }
+
+        public bool ExcludeAllowedFromBlocked { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -9,15 +9,14 @@ namespace Ocelot.Configuration.File
             ExcludeAllowedFromBlocked = false;
         }
 
-        public List<string> IPAllowedList { get; set; }
-        public List<string> IPBlockedList { get; set; }
+    public List<string> IPAllowedList { get; set; }
+    public List<string> IPBlockedList { get; set; }
 
-        /// <summary>
-        /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
-        /// </summary>
-        /// <value>
-        /// Default value: false.
-        /// </value>        
-        public bool ExcludeAllowedFromBlocked { get; set; }
-    }
+    /// <summary>
+    /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
+    /// </summary>
+    /// <value>
+    /// Default value: false.
+    /// </value>        
+    public bool ExcludeAllowedFromBlocked { get; set; }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace Ocelot.Configuration.File
+namespace Ocelot.Configuration.File
 {
     public class FileSecurityOptions
     {
@@ -6,12 +6,11 @@
         {
             IPAllowedList = new List<string>();
             IPBlockedList = new List<string>();
+            ExcludeAllowedFromBlocked = false;
         }
 
         public List<string> IPAllowedList { get; set; }
-
         public List<string> IPBlockedList { get; set; }
-
         public bool ExcludeAllowedFromBlocked { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -9,6 +9,30 @@ namespace Ocelot.Configuration.File
             ExcludeAllowedFromBlocked = false;
         }
 
+    public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+        : this()
+    {
+        if (!string.IsNullOrEmpty(allowedIPs))
+        {
+            IPAllowedList.Add(allowedIPs);
+        }
+
+        if (!string.IsNullOrEmpty(blockedIPs))
+        {
+            IPBlockedList.Add(blockedIPs);
+        }
+
+        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
+    }
+
+    public FileSecurityOptions(IEnumerable<string> allowedIPs = null, IEnumerable<string> blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+        : this()
+    {
+        IPAllowedList.AddRange(allowedIPs ?? Enumerable.Empty<string>());
+        IPBlockedList.AddRange(blockedIPs ?? Enumerable.Empty<string>());
+        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
+    }
+
     public List<string> IPAllowedList { get; set; }
     public List<string> IPBlockedList { get; set; }
 

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -11,11 +11,13 @@ namespace Ocelot.Configuration.File
 
         public List<string> IPAllowedList { get; set; }
         public List<string> IPBlockedList { get; set; }
-        
+
         /// <summary>
         /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
+        /// </summary>
+        /// <value>
         /// Default value: false.
-        /// </summary>        
+        /// </value>        
         public bool ExcludeAllowedFromBlocked { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -11,6 +11,11 @@ namespace Ocelot.Configuration.File
 
         public List<string> IPAllowedList { get; set; }
         public List<string> IPBlockedList { get; set; }
+        
+        /// <summary>
+        /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
+        /// Default value: false.
+        /// </summary>        
         public bool ExcludeAllowedFromBlocked { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -1,36 +1,37 @@
 ﻿using NetTools;
 using System.Collections.Generic;
 
-namespace Ocelot.Configuration;
-
-public class SecurityOptions
+namespace Ocelot.Configuration
 {
-    public SecurityOptions()
+    public class SecurityOptions
     {
-        IPAllowedList = new();
-        IPBlockedList = new();
-    }
-
-    public SecurityOptions(string allowed = null, string blocked = null)
-        : this()
-    {
-        if (!string.IsNullOrEmpty(allowed))
+        public SecurityOptions()
         {
-            IPAllowedList.Add(allowed);
+            IPAllowedList = new();
+            IPBlockedList = new();
         }
 
-        if (!string.IsNullOrEmpty(blocked))
+        public SecurityOptions(string allowed = null, string blocked = null)
+            : this()
         {
-            IPBlockedList.Add(blocked);
+            if (!string.IsNullOrEmpty(allowed))
+            {
+                IPAllowedList.Add(allowed);
+            }
+
+            if (!string.IsNullOrEmpty(blocked))
+            {
+                IPBlockedList.Add(blocked);
+            }
         }
-    }
 
-    public SecurityOptions(List<string> allowedList = null, List<string> blockedList = null)
-    {
-        IPAllowedList = allowedList ?? new();
-        IPBlockedList = blockedList ?? new();
-    }
+        public SecurityOptions(List<string> allowedList = null, List<string> blockedList = null)
+        {
+            IPAllowedList = allowedList ?? new();
+            IPBlockedList = blockedList ?? new();
+        }
 
-    public List<string> IPAllowedList { get; }
-    public List<string> IPBlockedList { get; }
+        public List<string> IPAllowedList { get; }
+        public List<string> IPBlockedList { get; }
+    }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -1,18 +1,16 @@
 ﻿using NetTools;
 using System.Collections.Generic;
 
-namespace Ocelot.Configuration
+namespace Ocelot.Configuration;
+
+public class SecurityOptions
 {
-    public class SecurityOptions
+    public SecurityOptions(List<string> allowedList, List<string> blockedList)
     {
-        public SecurityOptions(List<string> allowedList, List<string> blockedList)
-        {
-            IPAllowedList = allowedList;
-            IPBlockedList = blockedList;
-        }
-
-        public List<string> IPAllowedList { get; }
-
-        public List<string> IPBlockedList { get; }
+        IPAllowedList = allowedList ?? new();
+        IPBlockedList = blockedList ?? new();
     }
+
+    public List<string> IPAllowedList { get; } = new();
+    public List<string> IPBlockedList { get; } = new();
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -1,41 +1,18 @@
 ﻿using NetTools;
+using System.Collections.Generic;
 
 namespace Ocelot.Configuration
 {
     public class SecurityOptions
     {
-        public SecurityOptions(List<string> allowedList, List<string> blockedList, bool excludeAllowedFromBlocked = false)
+        public SecurityOptions(List<string> allowedList, List<string> blockedList)
         {
-            IPAllowedList = new List<string>();
-            IPBlockedList = new List<string>();
-            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked;
-
-            foreach (var allowed in allowedList)
-            {
-                if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
-                {
-                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                    IPAllowedList.AddRange(allowedIps);
-                }
-            }
-
-            foreach (var blocked in blockedList)
-            {
-                if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
-                {
-                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-                    IPBlockedList.AddRange(blockedIps);
-                }
-            }
-
-            if (ExcludeAllowedFromBlocked)
-            {
-                IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
-            }
+            IPAllowedList = allowedList;
+            IPBlockedList = blockedList;
         }
 
         public List<string> IPAllowedList { get; }
+
         public List<string> IPBlockedList { get; }
-        public bool ExcludeAllowedFromBlocked { get; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -6,17 +6,16 @@ namespace Ocelot.Configuration
     {
         public SecurityOptions(List<string> allowedList, List<string> blockedList, bool excludeAllowedFromBlocked)
         {
-            this.IPAllowedList = new List<string>();
-            this.IPBlockedList = new List<string>();
-            this.ExcludeAllowedFromBlocked = excludeAllowedFromBlocked;
+            IPAllowedList = new List<string>();
+            IPBlockedList = new List<string>();
+            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked;
 
             foreach (var allowed in allowedList)
             {
                 if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
                 {
                     var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-
-                    this.IPAllowedList.AddRange(allowedIps);
+                    IPAllowedList.AddRange(allowedIps);
                 }
             }
 
@@ -25,21 +24,18 @@ namespace Ocelot.Configuration
                 if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
                 {
                     var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
-
-                    this.IPBlockedList.AddRange(blockedIps);
+                    IPBlockedList.AddRange(blockedIps);
                 }
             }
 
-            if (this.ExcludeAllowedFromBlocked)
+            if (ExcludeAllowedFromBlocked)
             {
-                this.IPBlockedList = this.IPBlockedList.Except(this.IPAllowedList).ToList();
+                IPBlockedList = IPBlockedList.Except(IPAllowedList).ToList();
             }
         }
 
         public List<string> IPAllowedList { get; }
-
         public List<string> IPBlockedList { get; }
-
-        public bool ExcludeAllowedFromBlocked { get; private set; }
+        public bool ExcludeAllowedFromBlocked { get; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -4,7 +4,7 @@ namespace Ocelot.Configuration
 {
     public class SecurityOptions
     {
-        public SecurityOptions(List<string> allowedList, List<string> blockedList, bool excludeAllowedFromBlocked)
+        public SecurityOptions(List<string> allowedList, List<string> blockedList, bool excludeAllowedFromBlocked = false)
         {
             IPAllowedList = new List<string>();
             IPBlockedList = new List<string>();

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -1,15 +1,45 @@
-﻿namespace Ocelot.Configuration
+﻿using NetTools;
+
+namespace Ocelot.Configuration
 {
     public class SecurityOptions
     {
-        public SecurityOptions(List<string> allowedList, List<string> blockedList)
+        public SecurityOptions(List<string> allowedList, List<string> blockedList, bool excludeAllowedFromBlocked)
         {
-            IPAllowedList = allowedList;
-            IPBlockedList = blockedList;
+            this.IPAllowedList = new List<string>();
+            this.IPBlockedList = new List<string>();
+            this.ExcludeAllowedFromBlocked = excludeAllowedFromBlocked;
+
+            foreach (var allowed in allowedList)
+            {
+                if (IPAddressRange.TryParse(allowed, out var allowedIpAddressRange))
+                {
+                    var allowedIps = allowedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+
+                    this.IPAllowedList.AddRange(allowedIps);
+                }
+            }
+
+            foreach (var blocked in blockedList)
+            {
+                if (IPAddressRange.TryParse(blocked, out var blockedIpAddressRange))
+                {
+                    var blockedIps = blockedIpAddressRange.AsEnumerable().Select(x => x.ToString());
+
+                    this.IPBlockedList.AddRange(blockedIps);
+                }
+            }
+
+            if (this.ExcludeAllowedFromBlocked)
+            {
+                this.IPBlockedList = this.IPBlockedList.Except(this.IPAllowedList).ToList();
+            }
         }
 
         public List<string> IPAllowedList { get; }
 
         public List<string> IPBlockedList { get; }
+
+        public bool ExcludeAllowedFromBlocked { get; private set; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -5,12 +5,32 @@ namespace Ocelot.Configuration;
 
 public class SecurityOptions
 {
-    public SecurityOptions(List<string> allowedList, List<string> blockedList)
+    public SecurityOptions()
+    {
+        IPAllowedList = new();
+        IPBlockedList = new();
+    }
+
+    public SecurityOptions(string allowed = null, string blocked = null)
+        : this()
+    {
+        if (!string.IsNullOrEmpty(allowed))
+        {
+            IPAllowedList.Add(allowed);
+        }
+
+        if (!string.IsNullOrEmpty(blocked))
+        {
+            IPBlockedList.Add(blocked);
+        }
+    }
+
+    public SecurityOptions(List<string> allowedList = null, List<string> blockedList = null)
     {
         IPAllowedList = allowedList ?? new();
         IPBlockedList = blockedList ?? new();
     }
 
-    public List<string> IPAllowedList { get; } = new();
-    public List<string> IPBlockedList { get; } = new();
+    public List<string> IPAllowedList { get; }
+    public List<string> IPBlockedList { get; }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -1,7 +1,4 @@
-﻿using NetTools;
-using System.Collections.Generic;
-
-namespace Ocelot.Configuration
+﻿namespace Ocelot.Configuration
 {
     public class SecurityOptions
     {

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.2" />
+    <PackageReference Include="IPAddressRange" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="7.0.5" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32">
       <NoWarn>NU1701</NoWarn>

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="11.5.2" />
-    <PackageReference Include="IPAddressRange" Version="5.0.0" />
+    <PackageReference Include="IPAddressRange" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="7.0.5" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32">
       <NoWarn>NU1701</NoWarn>

--- a/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
@@ -29,7 +29,7 @@ namespace Ocelot.UnitTests.Configuration
                 },
             };
 
-            var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
+            var expected = new SecurityOptions(ipAllowedList, ipBlockedList, false);
 
             this.Given(x => x.GivenThe(fileRoute))
               .When(x => x.WhenICreate())

--- a/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
@@ -29,7 +29,7 @@ namespace Ocelot.UnitTests.Configuration
                 },
             };
 
-            var expected = new SecurityOptions(ipAllowedList, ipBlockedList, false);
+            var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
 
             this.Given(x => x.GivenThe(fileRoute))
               .When(x => x.WhenICreate())

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -311,12 +311,12 @@ public class IPSecurityPolicyTests
 
     private void GivenSetAllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions("192.168.1.1"));
     }
 
     private void GivenSetBlockedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(blocked: "192.168.1.1"));
     }
 
     private void GivenSetDownstreamRoute()
@@ -326,125 +326,68 @@ public class IPSecurityPolicyTests
 
     private void GivenCidr24AllowedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.0/24" }, 
-                IPBlockedList = new List<string>()
-            };
-            
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.1.0/24");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenCidr29AllowedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.0/29" },
-                IPBlockedList = new List<string>()
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.1.0/29");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenCidr24BlockedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-                { 
-                    IPAllowedList = new List<string>(),
-                    IPBlockedList = new List<string> { "192.168.1.0/24" }
-                };
-            
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/24");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenRangeAllowedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" },
-                IPBlockedList = new List<string>()
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(GivenRangeAllowedIP);
+        var options = new FileSecurityOptions("192.168.1.0-192.168.1.10");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenRangeBlockedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string>(),
-                IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" }
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenShortRangeAllowedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.0-10" },
-                IPBlockedList = new List<string>()
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.1.0-10");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenShortRangeBlockedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string>(),
-                IPBlockedList = new List<string> { "192.168.1.0-10" }
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-10");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenIpSubnetAllowedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" },
-                IPBlockedList = new List<string>()
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.1.0/255.255.255.0");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenIpSubnetBlockedIP()
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string>(),
-                IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" }
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0");
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" },
-                IPBlockedList = new List<string> { "192.168.1.100-200" },
-                ExcludeAllowedFromBlocked = excludeAllowedInBlocked
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked);
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
     {
-            var fileSecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.10-20" },
-                IPBlockedList = new List<string> { "192.168.1.0/23" },
-                ExcludeAllowedFromBlocked = excludeAllowedInBlocked
-            };
-
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
+        var options = new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked);
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
     }
 
     private void WhenTheSecurityPolicy()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -8,403 +8,404 @@ using Ocelot.Request.Middleware;
 using Ocelot.Responses;
 using Ocelot.Security.IPSecurity;
 
-namespace Ocelot.UnitTests.Security;
-
-public class IPSecurityPolicyTests
+namespace Ocelot.UnitTests.Security
 {
-    private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
-    private readonly IPSecurityPolicy _ipSecurityPolicy;
-    private Response response;
-    private readonly HttpContext _httpContext;
-    private readonly SecurityOptionsCreator _securityOptionsCreator;
-
-    public IPSecurityPolicyTests()
+    public class IPSecurityPolicyTests
     {
-        _httpContext = new DefaultHttpContext();
-        _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-        _downstreamRouteBuilder = new DownstreamRouteBuilder();
-        _ipSecurityPolicy = new IPSecurityPolicy();
-        _securityOptionsCreator = new SecurityOptionsCreator();
-    }
+        private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
+        private readonly IPSecurityPolicy _ipSecurityPolicy;
+        private Response response;
+        private readonly HttpContext _httpContext;
+        private readonly SecurityOptionsCreator _securityOptionsCreator;
 
-    [Fact]
-    public void should_No_blocked_Ip_and_allowed_Ip()
-    {
-        this.Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        public IPSecurityPolicyTests()
+        {
+            _httpContext = new DefaultHttpContext();
+            _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+            _downstreamRouteBuilder = new DownstreamRouteBuilder();
+            _ipSecurityPolicy = new IPSecurityPolicy();
+            _securityOptionsCreator = new SecurityOptionsCreator();
+        }
 
-    [Fact]
-    public void should_blockedIp_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-        this.Given(x => x.GivenSetBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_No_blocked_Ip_and_allowed_Ip()
+        {
+            this.Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_blockedIp_clientIp_Not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-        this.Given(x => x.GivenSetBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_blockedIp_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+            this.Given(x => x.GivenSetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_allowedIp_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-        this.Given(x => x.GivenSetAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_blockedIp_clientIp_Not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+            this.Given(x => x.GivenSetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_allowedIp_clientIp_Not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-        this.Given(x => x.GivenSetAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_allowedIp_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+            this.Given(x => x.GivenSetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_cidrNotation_allowed24_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
-        this.Given(x => x.GivenCidr24AllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_allowedIp_clientIp_Not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+            this.Given(x => x.GivenSetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_cidrNotation_allowed24_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-        this.Given(x => x.GivenCidr24AllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_cidrNotation_allowed24_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
+            this.Given(x => x.GivenCidr24AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_cidrNotation_allowed29_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-        this.Given(x => x.GivenCidr29AllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_cidrNotation_allowed24_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenCidr24AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_cidrNotation_blocked24_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-        this.Given(x => x.GivenCidr24BlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_cidrNotation_allowed29_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenCidr29AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_cidrNotation_blocked24_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-        this.Given(x => x.GivenCidr24BlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_cidrNotation_blocked24_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+            this.Given(x => x.GivenCidr24BlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_range_allowed_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenRangeAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_cidrNotation_blocked24_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+            this.Given(x => x.GivenCidr24BlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_range_allowed_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-        this.Given(x => x.GivenRangeAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_range_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_range_blocked_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-        this.Given(x => x.GivenRangeBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_range_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+            this.Given(x => x.GivenRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_range_blocked_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenRangeBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_range_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_shortRange_allowed_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenShortRangeAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_range_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_shortRange_allowed_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-        this.Given(x => x.GivenShortRangeAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_shortRange_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenShortRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_shortRange_blocked_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-        this.Given(x => x.GivenShortRangeBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_shortRange_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+            this.Given(x => x.GivenShortRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_shortRange_blocked_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenShortRangeBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_shortRange_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenShortRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_ipSubnet_allowed_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
-        this.Given(x => x.GivenIpSubnetAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_shortRange_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenShortRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_ipSubnet_allowed_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenIpSubnetAllowedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_ipSubnet_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
+            this.Given(x => x.GivenIpSubnetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_ipSubnet_blocked_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-        this.Given(x => x.GivenIpSubnetBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_ipSubnet_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenIpSubnetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_ipSubnet_blocked_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-        this.Given(x => x.GivenIpSubnetBlockedIP())
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_ipSubnet_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenIpSubnetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-        this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_ipSubnet_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+            this.Given(x => x.GivenIpSubnetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-        this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+            this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-        this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenNotSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+            this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    [Fact]
-    public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
-    {
-        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-        this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
-            .Given(x => x.GivenSetDownstreamRoute())
-            .When(x => x.WhenTheSecurityPolicy())
-            .Then(x => x.ThenSecurityPassing())
-            .BDDfy();
-    }
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
 
-    private void GivenSetAllowedIP()
-    {
-        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions("192.168.1.1"));
-    }
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
 
-    private void GivenSetBlockedIP()
-    {
-        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(blocked: "192.168.1.1"));
-    }
+        private void GivenSetAllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions("192.168.1.1"));
+        }
 
-    private void GivenSetDownstreamRoute()
-    {
-        _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
-    }
+        private void GivenSetBlockedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(blocked: "192.168.1.1"));
+        }
 
-    private void GivenCidr24AllowedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/24"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenSetDownstreamRoute()
+        {
+            _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
+        }
 
-    private void GivenCidr29AllowedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/29"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenCidr24AllowedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/24"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenCidr24BlockedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/24"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenCidr29AllowedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/29"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenRangeAllowedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-192.168.1.10"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenCidr24BlockedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/24"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenRangeBlockedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenRangeAllowedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-192.168.1.10"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenShortRangeAllowedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-10"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenRangeBlockedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenShortRangeBlockedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-10"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenShortRangeAllowedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-10"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenIpSubnetAllowedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/255.255.255.0"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenShortRangeBlockedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-10"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenIpSubnetBlockedIP()
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0"));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenIpSubnetAllowedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/255.255.255.0"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenIpSubnetBlockedIP()
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0"));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
-    {
-        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked));
-        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-    }
+        private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void WhenTheSecurityPolicy()
-    {
-        response = _ipSecurityPolicy.Security(_httpContext.Items.DownstreamRoute(), _httpContext).GetAwaiter().GetResult();
-    }
+        private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
+        {
+            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked));
+            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+        }
 
-    private void ThenSecurityPassing()
-    {
-        Assert.False(response.IsError);
-    }
+        private void WhenTheSecurityPolicy()
+        {
+            response = _ipSecurityPolicy.Security(_httpContext.Items.DownstreamRoute(), _httpContext).GetAwaiter().GetResult();
+        }
 
-    private void ThenNotSecurityPassing()
-    {
-        Assert.True(response.IsError);
+        private void ThenSecurityPassing()
+        {
+            Assert.False(response.IsError);
+        }
+
+        private void ThenNotSecurityPassing()
+        {
+            Assert.True(response.IsError);
+        }
     }
 }

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
+using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
 using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
@@ -15,6 +16,7 @@ public class IPSecurityPolicyTests
     private readonly IPSecurityPolicy _ipSecurityPolicy;
     private Response response;
     private readonly HttpContext _httpContext;
+    private readonly SecurityOptionsCreator _securityOptionsCreator;
 
     public IPSecurityPolicyTests()
     {
@@ -23,6 +25,7 @@ public class IPSecurityPolicyTests
         _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
         _downstreamRouteBuilder = new DownstreamRouteBuilder();
         _ipSecurityPolicy = new IPSecurityPolicy();
+        _securityOptionsCreator = new SecurityOptionsCreator();
     }
 
     [Fact]
@@ -326,68 +329,68 @@ public class IPSecurityPolicyTests
 
     private void GivenCidr24AllowedIP()
     {
-        var options = new FileSecurityOptions("192.168.1.0/24");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/24"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenCidr29AllowedIP()
     {
-        var options = new FileSecurityOptions("192.168.1.0/29");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/29"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenCidr24BlockedIP()
     {
-        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/24");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/24"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenRangeAllowedIP()
     {
-        var options = new FileSecurityOptions("192.168.1.0-192.168.1.10");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-192.168.1.10"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenRangeBlockedIP()
     {
-        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenShortRangeAllowedIP()
     {
-        var options = new FileSecurityOptions("192.168.1.0-10");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-10"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenShortRangeBlockedIP()
     {
-        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-10");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-10"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenIpSubnetAllowedIP()
     {
-        var options = new FileSecurityOptions("192.168.1.0/255.255.255.0");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/255.255.255.0"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenIpSubnetBlockedIP()
     {
-        var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0");
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0"));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
     {
-        var options = new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked);
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
     {
-        var options = new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked);
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(options);
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked));
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
     }
 
     private void WhenTheSecurityPolicy()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -77,19 +77,305 @@ namespace Ocelot.UnitTests.Security
                 .BDDfy();
         }
 
+        [Fact]
+        public void should_cidrNotation_allowed24_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
+            this.Given(x => x.GivenCidr24AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_cidrNotation_allowed24_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenCidr24AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_cidrNotation_allowed29_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenCidr29AllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_cidrNotation_blocked24_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+            this.Given(x => x.GivenCidr24BlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_cidrNotation_blocked24_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+            this.Given(x => x.GivenCidr24BlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_range_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_range_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+            this.Given(x => x.GivenRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_range_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_range_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_shortRange_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenShortRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_shortRange_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+            this.Given(x => x.GivenShortRangeAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_shortRange_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+            this.Given(x => x.GivenShortRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_shortRange_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenShortRangeBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_ipSubnet_allowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
+            this.Given(x => x.GivenIpSubnetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_ipSubnet_allowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenIpSubnetAllowedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_ipSubnet_blocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+            this.Given(x => x.GivenIpSubnetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_ipSubnet_blocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+            this.Given(x => x.GivenIpSubnetBlockedIP())
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+            this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+            this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenNotSecurityPassing())
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+        {
+            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+            this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
+                .Given(x => x.GivenSetDownstreamRoute())
+                .When(x => x.WhenTheSecurityPolicy())
+                .Then(x => x.ThenSecurityPassing())
+                .BDDfy();
+        }
+
         private void GivenSetAllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>(), false));
         }
 
         private void GivenSetBlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }, false));
         }
 
         private void GivenSetDownstreamRoute()
         {
             _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
+        }
+
+        private void GivenCidr24AllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/24" }, new List<string>(), false));
+        }
+
+        private void GivenCidr29AllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/29" }, new List<string>(), false));
+        }
+
+        private void GivenCidr24BlockedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0/24" }, false));
+        }
+
+        private void GivenRangeAllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0-192.168.1.10" }, new List<string>(), false));
+        }
+
+        private void GivenRangeBlockedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0-192.168.1.10" }, false));
+        }
+
+        private void GivenShortRangeAllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0-10" }, new List<string>(), false));
+        }
+
+        private void GivenShortRangeBlockedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0-10" }, false));
+        }
+
+        private void GivenIpSubnetAllowedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/255.255.255.0" }, new List<string>(), false));
+        }
+
+        private void GivenIpSubnetBlockedIP()
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0/255.255.255.0" }, false));
+        }
+
+        private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.0.0/255.255.0.0" }, new List<string> { "192.168.1.100-200" }, excludeAllowedInBlocked));
+        }
+
+        private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
+        {
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.10-20" }, new List<string> { "192.168.1.0/23" }, excludeAllowedInBlocked));
         }
 
         private void WhenTheSecurityPolicy()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
+    using Ocelot.Configuration.File;
 using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
 using Ocelot.Responses;
@@ -308,14 +309,20 @@ namespace Ocelot.UnitTests.Security
                 .BDDfy();
         }
 
+        /// <summary>
+        /// NO
+        /// </summary>
         private void GivenSetAllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
         }
 
+        /// <summary>
+        /// NO
+        /// </summary>
         private void GivenSetBlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }, false));
+            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
         }
 
         private void GivenSetDownstreamRoute()
@@ -325,57 +332,57 @@ namespace Ocelot.UnitTests.Security
 
         private void GivenCidr24AllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/24" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/24" }, IPBlockedList = new List<string>() });
         }
 
         private void GivenCidr29AllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/29" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/29" }, IPBlockedList = new List<string>() });
         }
 
         private void GivenCidr24BlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0/24" }, false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/24" } });
         }
 
         private void GivenRangeAllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0-192.168.1.10" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" }, IPBlockedList = new List<string>() });
         }
 
         private void GivenRangeBlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0-192.168.1.10" }, false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" } });
         }
 
         private void GivenShortRangeAllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0-10" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-10" }, IPBlockedList = new List<string>() });
         }
 
         private void GivenShortRangeBlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0-10" }, false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-10" } });
         }
 
         private void GivenIpSubnetAllowedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.0/255.255.255.0" }, new List<string>(), false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" }, IPBlockedList = new List<string>() });
         }
 
         private void GivenIpSubnetBlockedIP()
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.0/255.255.255.0" }, false));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" } });
         }
 
         private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.0.0/255.255.0.0" }, new List<string> { "192.168.1.100-200" }, excludeAllowedInBlocked));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" }, IPBlockedList = new List<string> { "192.168.1.100-200" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
         }
 
         private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
         {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.10-20" }, new List<string> { "192.168.1.0/23" }, excludeAllowedInBlocked));
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.10-20" }, IPBlockedList = new List<string> { "192.168.1.0/23" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
         }
 
         private void WhenTheSecurityPolicy()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -309,17 +309,11 @@ public class IPSecurityPolicyTests
             .BDDfy();
     }
 
-    /// <summary>
-    /// NO
-    /// </summary>
     private void GivenSetAllowedIP()
     {
         _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
     }
 
-    /// <summary>
-    /// NO
-    /// </summary>
     private void GivenSetBlockedIP()
     {
         _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
@@ -332,57 +326,125 @@ public class IPSecurityPolicyTests
 
     private void GivenCidr24AllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/24" }, IPBlockedList = new List<string>() });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.0/24" }, 
+                IPBlockedList = new List<string>()
+            };
+            
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenCidr29AllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/29" }, IPBlockedList = new List<string>() });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.0/29" },
+                IPBlockedList = new List<string>()
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenCidr24BlockedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/24" } });
+            var fileSecurityOptions = new FileSecurityOptions
+                { 
+                    IPAllowedList = new List<string>(),
+                    IPBlockedList = new List<string> { "192.168.1.0/24" }
+                };
+            
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenRangeAllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" }, IPBlockedList = new List<string>() });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" },
+                IPBlockedList = new List<string>()
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(GivenRangeAllowedIP);
     }
 
     private void GivenRangeBlockedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" } });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string>(),
+                IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" }
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenShortRangeAllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-10" }, IPBlockedList = new List<string>() });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.0-10" },
+                IPBlockedList = new List<string>()
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenShortRangeBlockedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-10" } });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string>(),
+                IPBlockedList = new List<string> { "192.168.1.0-10" }
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenIpSubnetAllowedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" }, IPBlockedList = new List<string>() });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" },
+                IPBlockedList = new List<string>()
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenIpSubnetBlockedIP()
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" } });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string>(),
+                IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" }
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" }, IPBlockedList = new List<string> { "192.168.1.100-200" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" },
+                IPBlockedList = new List<string> { "192.168.1.100-200" },
+                ExcludeAllowedFromBlocked = excludeAllowedInBlocked
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
     {
-        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.10-20" }, IPBlockedList = new List<string> { "192.168.1.0/23" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
+            var fileSecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.10-20" },
+                IPBlockedList = new List<string> { "192.168.1.0/23" },
+                ExcludeAllowedFromBlocked = excludeAllowedInBlocked
+            };
+
+            _downstreamRouteBuilder.WithSecurityOptionsCreator(fileSecurityOptions);
     }
 
     private void WhenTheSecurityPolicy()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -1,403 +1,402 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
-    using Ocelot.Configuration.File;
+using Ocelot.Configuration.File;
 using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
 using Ocelot.Responses;
 using Ocelot.Security.IPSecurity;
 
-namespace Ocelot.UnitTests.Security
+namespace Ocelot.UnitTests.Security;
+
+public class IPSecurityPolicyTests
 {
-    public class IPSecurityPolicyTests
+    private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
+    private readonly IPSecurityPolicy _ipSecurityPolicy;
+    private Response response;
+    private readonly HttpContext _httpContext;
+
+    public IPSecurityPolicyTests()
     {
-        private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
-        private readonly IPSecurityPolicy _ipSecurityPolicy;
-        private Response response;
-        private readonly HttpContext _httpContext;
+        _httpContext = new DefaultHttpContext();
+        _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        _downstreamRouteBuilder = new DownstreamRouteBuilder();
+        _ipSecurityPolicy = new IPSecurityPolicy();
+    }
 
-        public IPSecurityPolicyTests()
-        {
-            _httpContext = new DefaultHttpContext();
-            _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            _downstreamRouteBuilder = new DownstreamRouteBuilder();
-            _ipSecurityPolicy = new IPSecurityPolicy();
-        }
+    [Fact]
+    public void should_No_blocked_Ip_and_allowed_Ip()
+    {
+        this.Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_No_blocked_Ip_and_allowed_Ip()
-        {
-            this.Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_blockedIp_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        this.Given(x => x.GivenSetBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_blockedIp_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenSetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_blockedIp_clientIp_Not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+        this.Given(x => x.GivenSetBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_blockedIp_clientIp_Not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-            this.Given(x => x.GivenSetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_allowedIp_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        this.Given(x => x.GivenSetAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_allowedIp_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenSetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_allowedIp_clientIp_Not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+        this.Given(x => x.GivenSetAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_allowedIp_clientIp_Not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-            this.Given(x => x.GivenSetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_cidrNotation_allowed24_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
+        this.Given(x => x.GivenCidr24AllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_cidrNotation_allowed24_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
-            this.Given(x => x.GivenCidr24AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_cidrNotation_allowed24_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        this.Given(x => x.GivenCidr24AllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_cidrNotation_allowed24_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenCidr24AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_cidrNotation_allowed29_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        this.Given(x => x.GivenCidr29AllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_cidrNotation_allowed29_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenCidr29AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_cidrNotation_blocked24_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        this.Given(x => x.GivenCidr24BlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_cidrNotation_blocked24_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenCidr24BlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_cidrNotation_blocked24_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+        this.Given(x => x.GivenCidr24BlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_cidrNotation_blocked24_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-            this.Given(x => x.GivenCidr24BlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_range_allowed_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenRangeAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_range_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_range_allowed_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+        this.Given(x => x.GivenRangeAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_range_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-            this.Given(x => x.GivenRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_range_blocked_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        this.Given(x => x.GivenRangeBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_range_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_range_blocked_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenRangeBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_range_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_shortRange_allowed_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenShortRangeAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_shortRange_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenShortRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_shortRange_allowed_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+        this.Given(x => x.GivenShortRangeAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_shortRange_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-            this.Given(x => x.GivenShortRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_shortRange_blocked_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        this.Given(x => x.GivenShortRangeBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_shortRange_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenShortRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_shortRange_blocked_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenShortRangeBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_shortRange_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenShortRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_ipSubnet_allowed_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
+        this.Given(x => x.GivenIpSubnetAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_ipSubnet_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
-            this.Given(x => x.GivenIpSubnetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_ipSubnet_allowed_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenIpSubnetAllowedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_ipSubnet_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenIpSubnetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_ipSubnet_blocked_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        this.Given(x => x.GivenIpSubnetBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_ipSubnet_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenIpSubnetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_ipSubnet_blocked_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+        this.Given(x => x.GivenIpSubnetBlockedIP())
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_ipSubnet_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-            this.Given(x => x.GivenIpSubnetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+        this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-            this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+        this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-            this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenNotSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
-        }
+    [Fact]
+    public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+    {
+        _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
+            .Given(x => x.GivenSetDownstreamRoute())
+            .When(x => x.WhenTheSecurityPolicy())
+            .Then(x => x.ThenSecurityPassing())
+            .BDDfy();
+    }
 
-        [Fact]
-        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
-        }
+    /// <summary>
+    /// NO
+    /// </summary>
+    private void GivenSetAllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
+    }
 
-        /// <summary>
-        /// NO
-        /// </summary>
-        private void GivenSetAllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string> { "192.168.1.1" }, new List<string>()));
-        }
+    /// <summary>
+    /// NO
+    /// </summary>
+    private void GivenSetBlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
+    }
 
-        /// <summary>
-        /// NO
-        /// </summary>
-        private void GivenSetBlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(new List<string>(), new List<string> { "192.168.1.1" }));
-        }
+    private void GivenSetDownstreamRoute()
+    {
+        _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
+    }
 
-        private void GivenSetDownstreamRoute()
-        {
-            _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
-        }
+    private void GivenCidr24AllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/24" }, IPBlockedList = new List<string>() });
+    }
 
-        private void GivenCidr24AllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/24" }, IPBlockedList = new List<string>() });
-        }
+    private void GivenCidr29AllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/29" }, IPBlockedList = new List<string>() });
+    }
 
-        private void GivenCidr29AllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/29" }, IPBlockedList = new List<string>() });
-        }
+    private void GivenCidr24BlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/24" } });
+    }
 
-        private void GivenCidr24BlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/24" } });
-        }
+    private void GivenRangeAllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" }, IPBlockedList = new List<string>() });
+    }
 
-        private void GivenRangeAllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-192.168.1.10" }, IPBlockedList = new List<string>() });
-        }
+    private void GivenRangeBlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" } });
+    }
 
-        private void GivenRangeBlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-192.168.1.10" } });
-        }
+    private void GivenShortRangeAllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-10" }, IPBlockedList = new List<string>() });
+    }
 
-        private void GivenShortRangeAllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0-10" }, IPBlockedList = new List<string>() });
-        }
+    private void GivenShortRangeBlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-10" } });
+    }
 
-        private void GivenShortRangeBlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0-10" } });
-        }
+    private void GivenIpSubnetAllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" }, IPBlockedList = new List<string>() });
+    }
 
-        private void GivenIpSubnetAllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.0/255.255.255.0" }, IPBlockedList = new List<string>() });
-        }
+    private void GivenIpSubnetBlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" } });
+    }
 
-        private void GivenIpSubnetBlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string>(), IPBlockedList = new List<string> { "192.168.1.0/255.255.255.0" } });
-        }
+    private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" }, IPBlockedList = new List<string> { "192.168.1.100-200" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
+    }
 
-        private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.0.0/255.255.0.0" }, IPBlockedList = new List<string> { "192.168.1.100-200" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
-        }
+    private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
+    {
+        _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.10-20" }, IPBlockedList = new List<string> { "192.168.1.0/23" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
+    }
 
-        private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
-        {
-            _downstreamRouteBuilder.WithSecurityOptionsCreator(new FileSecurityOptions { IPAllowedList = new List<string> { "192.168.1.10-20" }, IPBlockedList = new List<string> { "192.168.1.0/23" }, ExcludeAllowedFromBlocked = excludeAllowedInBlocked });
-        }
+    private void WhenTheSecurityPolicy()
+    {
+        response = _ipSecurityPolicy.Security(_httpContext.Items.DownstreamRoute(), _httpContext).GetAwaiter().GetResult();
+    }
 
-        private void WhenTheSecurityPolicy()
-        {
-            response = _ipSecurityPolicy.Security(_httpContext.Items.DownstreamRoute(), _httpContext).GetAwaiter().GetResult();
-        }
+    private void ThenSecurityPassing()
+    {
+        Assert.False(response.IsError);
+    }
 
-        private void ThenSecurityPassing()
-        {
-            Assert.False(response.IsError);
-        }
-
-        private void ThenNotSecurityPassing()
-        {
-            Assert.True(response.IsError);
-        }
+    private void ThenNotSecurityPassing()
+    {
+        Assert.True(response.IsError);
     }
 }


### PR DESCRIPTION
## Closes #1400 
- #1400 


## Proposed Changes

  - Added [IpAddressRange](https://github.com/jsakamoto/ipaddressrange) package ( [MPL-2.0 License](https://github.com/jsakamoto/ipaddressrange/blob/master/LICENSE) )
  - Manage multiple pattern in order to allow or block IP access (take a look to the [Example](https://github.com/jsakamoto/ipaddressrange#example) section of IpAddressRange)
  - Allow allowed Ips to be removed from blocked list via _ExcludeAllowedFromBlocked_ configuration propery in _SecurityOptions_ node
  - Backward compatibility with current _SecurityOptions_ configuration section
  - Added more unit tests about new feature 

### Description
This feature is designed to allow greater IP management in order to include or exclude a wide IP range via CIDR notation or IP range.
The current patterns managed are the following:
- single IP: "192.168.1.1"
- IP Range: "192.168.1.1-192.168.1.250"
- IP Short Range: "192.168.1.1-250"
- IP Range with subnet: "192.168.1.0/255.255.255.0"
- CIDR: "192.168.1.0/24"
- CIDR for IPv6: "fe80::/10"

The allowed and block list are evaluated on configuration loaded.
The _ExcludeAllowedFromBlocked_ is meant to give the possibility to specify a wide range of blocked IP and allow a sub range of IPs
Default value: _false_
Missing property in _SecurityOptions_ allowed, it assume default value.

e.g.
```json
"SecurityOptions": {
  "IPBlockedList": [ "192.168.0.0/23" ],
  "IPAllowedList": [ "192.168.0.15", "192.168.1.15" ],
  "ExcludeAllowedFromBlocked": true
}
```