### PR TITLE
Second parameter of Substring is wrong in HeaderFindAndReplaceCreator

### DIFF
--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -71,7 +71,7 @@ namespace Ocelot.Configuration.Creator
 
         private Response<HeaderFindAndReplace> Map(KeyValuePair<string, string> input)
         {
-            var findAndReplace = input.Value.Split(",");
+            var findAndReplace = input.Value.Split(',');
 
             var replace = findAndReplace[1].TrimStart();
 

--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -78,7 +78,8 @@ namespace Ocelot.Configuration.Creator
             var startOfPlaceholder = replace.IndexOf('{', StringComparison.Ordinal);
             if (startOfPlaceholder > -1)
             {
-                var endOfPlaceholder = replace.IndexOf("}", startOfPlaceholder, StringComparison.Ordinal);
+                var endOfPlaceholder = replace.IndexOf('}', startOfPlaceholder, StringComparison.Ordinal);
+
 
                 var placeholder = replace.Substring(startOfPlaceholder, endOfPlaceholder + 1);
 

--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -2,8 +2,6 @@ using Ocelot.Configuration.File;
 using Ocelot.Infrastructure;
 using Ocelot.Logging;
 using Ocelot.Responses;
-using System;
-using System.Collections.Generic;
 
 namespace Ocelot.Configuration.Creator
 {
@@ -78,8 +76,7 @@ namespace Ocelot.Configuration.Creator
             var startOfPlaceholder = replace.IndexOf('{', StringComparison.Ordinal);
             if (startOfPlaceholder > -1)
             {
-                var endOfPlaceholder = replace.IndexOf('}', startOfPlaceholder, StringComparison.Ordinal);
-
+                var endOfPlaceholder = replace.IndexOf('}', startOfPlaceholder);
 
                 var placeholder = replace.Substring(startOfPlaceholder, endOfPlaceholder + 1);
 

--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -2,6 +2,8 @@ using Ocelot.Configuration.File;
 using Ocelot.Infrastructure;
 using Ocelot.Logging;
 using Ocelot.Responses;
+using System;
+using System.Collections.Generic;
 
 namespace Ocelot.Configuration.Creator
 {

--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -78,7 +78,7 @@ namespace Ocelot.Configuration.Creator
             {
                 var endOfPlaceholder = replace.IndexOf("}", startOfPlaceholder, StringComparison.Ordinal);
 
-                var placeholder = replace.Substring(startOfPlaceholder, startOfPlaceholder + (endOfPlaceholder + 1));
+                var placeholder = replace.Substring(startOfPlaceholder, endOfPlaceholder + 1);
 
                 var value = _placeholders.Get(placeholder);
 

--- a/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
+++ b/src/Ocelot/Configuration/Creator/HeaderFindAndReplaceCreator.cs
@@ -78,7 +78,7 @@ namespace Ocelot.Configuration.Creator
             {
                 var endOfPlaceholder = replace.IndexOf('}', startOfPlaceholder);
 
-                var placeholder = replace.Substring(startOfPlaceholder, endOfPlaceholder + 1);
+                var placeholder = replace.Substring(startOfPlaceholder, endOfPlaceholder - startOfPlaceholder + 1);
 
                 var value = _placeholders.Get(placeholder);
 

--- a/test/Ocelot.UnitTests/Configuration/HeaderFindAndReplaceCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/HeaderFindAndReplaceCreatorTests.cs
@@ -101,7 +101,7 @@ namespace Ocelot.UnitTests.Configuration
             };
 
             this.Given(x => GivenTheRoute(route))
-                .And(x => GivenTheBaseUrlIs("http://ocelot.com/"))
+                .And(x => GivenThePlaceholderIs("http://ocelot.com/"))
                 .When(x => WhenICreate())
                 .Then(x => ThenTheFollowingDownstreamIsReturned(downstream))
                 .BDDfy();
@@ -156,9 +156,32 @@ namespace Ocelot.UnitTests.Configuration
             };
 
             this.Given(x => GivenTheRoute(route))
-                .And(x => GivenTheBaseUrlIs("http://ocelot.com/"))
+                .And(x => GivenThePlaceholderIs("http://ocelot.com/"))
                 .When(x => WhenICreate())
                 .Then(x => ThenTheFollowingDownstreamIsReturned(downstream))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_map_with_partial_placeholder_in_the_middle()
+        {
+            var route = new FileRoute
+            {
+                DownstreamHeaderTransform = new Dictionary<string, string>
+                {
+                    {"Host-Next", "www.bbc.co.uk, subdomain.{Host}/path"},
+                },
+            };
+
+            var expected = new List<HeaderFindAndReplace>
+            {
+                new("Host-Next", "www.bbc.co.uk", "subdomain.ocelot.next/path", 0),
+            };
+
+            this.Given(x => GivenTheRoute(route))
+                .And(x => GivenThePlaceholderIs("ocelot.next"))
+                .When(x => WhenICreate())
+                .Then(x => ThenTheFollowingDownstreamIsReturned(expected))
                 .BDDfy();
         }
 
@@ -176,7 +199,7 @@ namespace Ocelot.UnitTests.Configuration
             var expected = new AddHeader("Trace-Id", "{TraceId}");
 
             this.Given(x => GivenTheRoute(route))
-                .And(x => GivenTheBaseUrlIs("http://ocelot.com/"))
+                .And(x => GivenThePlaceholderIs("http://ocelot.com/"))
                 .When(x => WhenICreate())
                 .Then(x => ThenTheFollowingAddHeaderToDownstreamIsReturned(expected))
                 .BDDfy();
@@ -220,9 +243,9 @@ namespace Ocelot.UnitTests.Configuration
                 .BDDfy();
         }
 
-        private void GivenTheBaseUrlIs(string baseUrl)
+        private void GivenThePlaceholderIs(string placeholderValue)
         {
-            _placeholders.Setup(x => x.Get(It.IsAny<string>())).Returns(new OkResponse<string>(baseUrl));
+            _placeholders.Setup(x => x.Get(It.IsAny<string>())).Returns(new OkResponse<string>(placeholderValue));
         }
 
         private void GivenTheBaseUrlErrors()


### PR DESCRIPTION
Second parameter of `Substring` was wrong: calculation of value for the `int length` parameter was wrong.
Existing implementation works only for replacements at the beginning of a string `startOfPlaceholder = 0`.

## Proposed Changes

  - Allow replacements inside a header, not only at the beginning
  - **Update 1** (Sep 30, 2023). Allow replacements inside of placeholder pattern, not only at the beginning
  - Add unit test to check this fix
