### PR TITLE
ScopesAuthorizer refactoring

### DIFF
--- a/src/Ocelot/Authorization/ScopesAuthorizer.cs
+++ b/src/Ocelot/Authorization/ScopesAuthorizer.cs
@@ -1,21 +1,14 @@
-﻿using Ocelot.Responses;
+using Ocelot.Responses;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 
 namespace Ocelot.Authorization
 {
-    using Infrastructure.Claims.Parser;
-
     public class ScopesAuthorizer : IScopesAuthorizer
     {
-        private readonly IClaimsParser _claimsParser;
-        private readonly string _scope = "scope";
-
-        public ScopesAuthorizer(IClaimsParser claimsParser)
-        {
-            _claimsParser = claimsParser;
-        }
+        private const string ScopeClaimKey = "scope";
 
         public Response<bool> Authorize(ClaimsPrincipal claimsPrincipal, List<string> routeAllowedScopes)
         {
@@ -24,21 +17,32 @@ namespace Ocelot.Authorization
                 return new OkResponse<bool>(true);
             }
 
-            var values = _claimsParser.GetValuesByClaimType(claimsPrincipal.Claims, _scope);
+            var userScopes =
+                claimsPrincipal.Claims
+                    .Where(x => x.Type == ScopeClaimKey)
+                    .Select(x => x.Value)
+                    .ToArray();
 
-            if (values.IsError)
+            if (userScopes.Length == 1)
             {
-                return new ErrorResponse<bool>(values.Errors);
+                var userScope = userScopes[0];
+
+                var hasMultipleValues = userScope.Contains(" ");
+
+                if (hasMultipleValues)
+                {
+                    userScopes = userScope.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+                }
+                else
+                {
+                    userScopes = new[] { userScope };
+                }
             }
 
-            var userScopes = values.Data;
-
-            var matchesScopes = routeAllowedScopes.Intersect(userScopes).ToList();
-
-            if (matchesScopes.Count == 0)
+            if (routeAllowedScopes.Any(s => !userScopes.Contains(s)))
             {
                 return new ErrorResponse<bool>(
-                    new ScopeNotAuthorizedError($"no one user scope: '{string.Join(",", userScopes)}' match with some allowed scope: '{string.Join(",", routeAllowedScopes)}'"));
+                    new ScopeNotAuthorizedError($"User scopes: '{string.Join(",", userScopes)}' do not have all allowed scopes: '{string.Join(",", routeAllowedScopes)}'"));
             }
 
             return new OkResponse<bool>(true);


### PR DESCRIPTION
Scopes can be a space separated list in a single claim. Include this possibility on allowed scopes check.

Fixes #913, #1066

## Proposed Changes

  - Split user scope values with space character if scope claim is an single claim and its value has space character
  - User scopes must have all allowed scopes
