### PR TITLE
PollConsul timer is changed to start and it starts to pull from Consul

### DIFF
--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -18,6 +18,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
 
     public PollConsul(int pollingInterval, IOcelotLoggerFactory factory, IServiceDiscoveryProvider consulServiceDiscoveryProvider)
     {
+        const int startImmediately = 0;
         _logger = factory.CreateLogger<PollConsul>();
         _provider = consulServiceDiscoveryProvider;
         _services = new List<Service>();
@@ -32,7 +33,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
             _polling = true;
             await Poll();
             _polling = false;
-        }, null, 0, pollingInterval); // the dueTime parameter is 0 (zero) to start timer callback (task) immediately
+        }, null, startImmediately, pollingInterval); // the dueTime parameter is 0 (zero) to start timer callback (task) immediately
     }
 
     public void Dispose()

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -32,7 +32,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
             _polling = true;
             await Poll();
             _polling = false;
-        }, null, 0, pollingInterval);
+        }, null, 0, pollingInterval); // the dueTime parameter is 0 (zero) to start timer callback (task) immediately
     }
 
     public void Dispose()

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -32,7 +32,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
             _polling = true;
             await Poll();
             _polling = false;
-        }, null, pollingInterval, pollingInterval);
+        }, null, 0, pollingInterval);
     }
 
     public void Dispose()

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -41,7 +41,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
     public void Dispose()
     {
         _timer.Dispose();
-        _timer = null;
+        GC.SuppressFinalize(this);
     }
 
     public Task<List<Service>> Get()

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -12,13 +12,15 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
 {
     private readonly IOcelotLogger _logger;
     private readonly IServiceDiscoveryProvider _provider;
+
     private Timer _timer;
+    private const int StartImmediately = 0;
+
     private bool _polling;
     private List<Service> _services;
 
     public PollConsul(int pollingInterval, IOcelotLoggerFactory factory, IServiceDiscoveryProvider consulServiceDiscoveryProvider)
     {
-        const int startImmediately = 0;
         _logger = factory.CreateLogger<PollConsul>();
         _provider = consulServiceDiscoveryProvider;
         _services = new List<Service>();
@@ -33,7 +35,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
             _polling = true;
             await Poll();
             _polling = false;
-        }, null, startImmediately, pollingInterval); // the dueTime parameter is 0 (zero) to start timer callback (task) immediately
+        }, null, StartImmediately, pollingInterval); // the dueTime parameter is 0 (zero) to start timer callback (task) immediately
     }
 
     public void Dispose()

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -13,7 +13,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
     private readonly IOcelotLogger _logger;
     private readonly IServiceDiscoveryProvider _provider;
 
-    private Timer _timer;
+    private readonly Timer _timer;
     private const int StartImmediately = 0;
 
     private bool _polling;
@@ -40,7 +40,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
 
     public void Dispose()
     {
-        _timer?.Dispose();
+        _timer.Dispose();
         _timer = null;
     }
 

--- a/src/Ocelot.Provider.Consul/PollConsul.cs
+++ b/src/Ocelot.Provider.Consul/PollConsul.cs
@@ -11,7 +11,7 @@ namespace Ocelot.Provider.Consul;
 public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
 {
     private readonly IOcelotLogger _logger;
-    private readonly IServiceDiscoveryProvider _consulServiceDiscoveryProvider;
+    private readonly IServiceDiscoveryProvider _provider;
     private Timer _timer;
     private bool _polling;
     private List<Service> _services;
@@ -19,7 +19,7 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
     public PollConsul(int pollingInterval, IOcelotLoggerFactory factory, IServiceDiscoveryProvider consulServiceDiscoveryProvider)
     {
         _logger = factory.CreateLogger<PollConsul>();
-        _consulServiceDiscoveryProvider = consulServiceDiscoveryProvider;
+        _provider = consulServiceDiscoveryProvider;
         _services = new List<Service>();
 
         _timer = new Timer(async x =>
@@ -48,6 +48,6 @@ public sealed class PollConsul : IServiceDiscoveryProvider, IDisposable
 
     private async Task Poll()
     {
-        _services = await _consulServiceDiscoveryProvider.Get();
+        _services = await _provider.Get();
     }
 }


### PR DESCRIPTION
## Fixes
Current timer callback waits for `pollingInterval` milliseconds to run the timer callback, poll the services from Consul.
But before first triggering of task, in period of time **[0, pollingInterval]**, the services collection is empty.

## Proposed Changes
The `dueTime` parameter is **0** (zero) to start timer callback (task) immediately.
