### PR TITLE
Pass all HttpContext properties on Copy

### DIFF
--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -160,7 +160,7 @@
             }
         }
 
-        private HttpContext Copy(HttpContext source)
+        private static HttpContext Copy(HttpContext source)
         {
             var target = new DefaultHttpContext();
 
@@ -182,7 +182,21 @@
             target.Request.Scheme = source.Request.Scheme;
             target.Request.IsHttps = source.Request.IsHttps;
             target.Request.RouteValues = source.Request.RouteValues;
+            target.Request.Cookies = source.Request.Cookies;
+            target.Request.Form = source.Request.Form;
+
+            target.Connection.ClientCertificate = source.Connection.ClientCertificate;
+            target.Connection.LocalIpAddress = source.Connection.LocalIpAddress;
+            target.Connection.LocalPort = source.Connection.LocalPort;
             target.Connection.RemoteIpAddress = source.Connection.RemoteIpAddress;
+            target.Connection.RemotePort = source.Connection.RemotePort;
+
+            target.Items = source.Items;
+
+            target.RequestAborted = source.RequestAborted;
+            target.TraceIdentifier = source.TraceIdentifier;
+            target.User = source.User;
+
             target.RequestServices = source.RequestServices;
             return target;
         }


### PR DESCRIPTION
Fixes #1326 - Client Certificate Authentication

## Proposed Changes

  - Fix Copy function of HttpContext from MultiplexingMiddleware
