### PR TITLE
fix OcelotBasic sample to make it work correctly

### DIFF
--- a/samples/OcelotBasic/OcelotBasic.csproj
+++ b/samples/OcelotBasic/OcelotBasic.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <PackageReference Include="ocelot" Version="14.0.9" />
+    <ProjectReference Include="..\..\src\Ocelot\Ocelot.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Fixes
The OcelotBasic sample do not work because the `Routes` was `ReRoutes` in the previous version. Upgrading to use the latest version make it works.