### PR TITLE
Ignore remote certificate validation errors if accept any configured

### DIFF
--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -95,6 +95,11 @@ namespace Ocelot.WebSockets.Middleware
             }
 
             var client = new ClientWebSocket();
+            if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
+            {
+                client.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+            }
+
             foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)
             {
                 client.Options.AddSubProtocol(protocol);

--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -124,11 +124,10 @@ namespace Ocelot.WebSockets.Middleware
 
             var destinationUri = new Uri(serverEndpoint);
             await client.ConnectAsync(destinationUri, context.RequestAborted);
-            using (var server = await context.WebSockets.AcceptWebSocketAsync(client.SubProtocol))
-            {
-                var bufferSize = DefaultWebSocketBufferSize;
-                await Task.WhenAll(PumpWebSocket(client, server, bufferSize, context.RequestAborted), PumpWebSocket(server, client, bufferSize, context.RequestAborted));
-            }
+
+            using var server = await context.WebSockets.AcceptWebSocketAsync(client.SubProtocol);
+            var bufferSize = DefaultWebSocketBufferSize;
+            await Task.WhenAll(PumpWebSocket(client, server, bufferSize, context.RequestAborted), PumpWebSocket(server, client, bufferSize, context.RequestAborted));
         }
     }
 }


### PR DESCRIPTION
## Fixes / New Feature

We can not use WebSocket SignalR protocol in Ocelot with self-signed certificate on downstream service side because `DownstreamRoute.DangerousAcceptAnyServerCertificateValidator` not used to skip `ClientWebSocket`'s remote certificate validation.

## Proposed Changes
  - Use fake validator and assign it to the `RemoteCertificateValidationCallback` property of the client to have successful validation result always
