### PR TITLE
Ignore port when using UpstreamHost option

### DIFF
--- a/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
@@ -27,7 +27,10 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
             var upstreamQueryString = httpContext.Request.QueryString.ToString();
 
-            var upstreamHost = httpContext.Request.Headers["Host"].ToString().Split(":")[0];
+            var hostHeader = httpContext.Request.Headers["Host"].ToString();
+            var upstreamHost = hostHeader.Contains(':')
+                ? hostHeader.Split(':')[0]
+                : hostHeader;
 
             Logger.LogDebug($"Upstream url path is {upstreamUrlPath}");
 

--- a/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Middleware/DownstreamRouteFinderMiddleware.cs
@@ -27,7 +27,7 @@ namespace Ocelot.DownstreamRouteFinder.Middleware
 
             var upstreamQueryString = httpContext.Request.QueryString.ToString();
 
-            var upstreamHost = httpContext.Request.Headers["Host"];
+            var upstreamHost = httpContext.Request.Headers["Host"].ToString().Split(":")[0];
 
             Logger.LogDebug($"Upstream url path is {upstreamUrlPath}");
 


### PR DESCRIPTION
# Fixes
I wanted to use the `UpstreamHost` option and found out that Ocelot is handling the port as part of the hostname (when running on a different port than :80/:443). For my understanding this is not the expected behaviour since any other software like nginx or traefik ignore the port when talking about the hostname.