### PR TITLE
Documentation: Updated text about AllowedScopes from "all of " to "at least one of"

### DIFF
--- a/docs/features/authentication.rst
+++ b/docs/features/authentication.rst
@@ -172,6 +172,6 @@ NOTE: In order to get Ocelot to view the scope claim from Okta properly, you hav
 Allowed Scopes
 ^^^^^^^^^^^^^
 
-If you add scopes to AllowedScopes Ocelot will get all the user claims (from the token) of the type scope and make sure that the user has all of the scopes in the list.
+If you add scopes to AllowedScopes Ocelot will get all the user claims (from the token) of the type scope and make sure that the user has at least one of the scopes in the list.
 
 This is a way to restrict access to a Route on a per scope basis.


### PR DESCRIPTION
In the docs it is said that if you configure AllowedScopes for a Route, the caller needs to have all scopes. 
Current code, unless I am completely mistaken, tests that you have at least one of the configured scopes.
Which anyway imho makes more sense.

``` AuthorizationMiddleware.cs
            var matchesScopes = routeAllowedScopes.Intersect(userScopes).ToList();

            if (matchesScopes.Count == 0)
            {
                return new ErrorResponse<bool>(
                    new ScopeNotAuthorizedError($"no one user scope: '{string.Join(",", userScopes)}' match with some allowed scope: '{string.Join(",", routeAllowedScopes)}'"));
            }
```


