### PR TITLE
Docs typo - Update requestaggregation.rst

### DIFF
--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -5,7 +5,7 @@ Ocelot allows you to specify Aggregate Routes that compose multiple normal Route
 a client that is making multiple requests to a server where it could just be one. This feature allows you to start implementing back end for a front end type 
 architecture with Ocelot.
 
-This feature was requested as part of `Issue 79 <https://github.com/ThreeMammals/Ocelot/issues/79>`_ and further improvements were made as part of `PR 298 <https://github.com/ThreeMammals/Ocelot/pull/298>`_.
+This feature was requested as part of `Issue 79 <https://github.com/ThreeMammals/Ocelot/issues/79>`_ and further improvements were made as part of `Issue 298 <https://github.com/ThreeMammals/Ocelot/issues/298>`_.
 
 In order to set this up you must do something like the following in your ocelot.json. Here we have specified two normal Routes and each one has a Key property. 
 We then specify an Aggregate that composes the two Routes using their keys in the RouteKeys list and says then we have the UpstreamPathTemplate which works like a normal Route.

--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -5,7 +5,7 @@ Ocelot allows you to specify Aggregate Routes that compose multiple normal Route
 a client that is making multiple requests to a server where it could just be one. This feature allows you to start implementing back end for a front end type 
 architecture with Ocelot.
 
-This feature was requested as part of `Issue 79 <https://github.com/ThreeMammals/Ocelot/pull/79>`_ and further improvements were made as part of `Issue 298 <https://github.com/ThreeMammals/Ocelot/issue/298>`_.
+This feature was requested as part of `Issue 79 <https://github.com/ThreeMammals/Ocelot/issues/79>`_ and further improvements were made as part of `PR 298 <https://github.com/ThreeMammals/Ocelot/pull/298>`_.
 
 In order to set this up you must do something like the following in your ocelot.json. Here we have specified two normal Routes and each one has a Key property. 
 We then specify an Aggregate that composes the two Routes using their keys in the RouteKeys list and says then we have the UpstreamPathTemplate which works like a normal Route.


### PR DESCRIPTION
## Proposed Changes

  - Fix hyperlinks of page https://ocelot.readthedocs.io/en/latest/features/requestaggregation.html 
Github link *Issue 298* currently returns to 404 error page -> [Issue 298](https://github.com/ThreeMammals/Ocelot/issue/298), should be #298
![image](https://user-images.githubusercontent.com/46479127/146186383-ab39d834-ed12-4381-92ca-3c7301be6386.png)
![image](https://user-images.githubusercontent.com/46479127/146186425-b9be4c7f-306f-40a9-a137-6ae1274344b4.png)
