### PR TITLE
#1228 #1235 #1247 Overloaded AddOcelot method for dynamic FileConfiguration construction

### DIFF
--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -74,12 +74,11 @@ namespace Ocelot.DependencyInjection
                 fileConfiguration.Routes.AddRange(config.Routes);
             }
 
-            return builder.AddOcelot(fileConfiguration, env);
+            return builder.AddOcelot(fileConfiguration);
         }
 
-
         public static IConfigurationBuilder AddOcelot(
-            this IConfigurationBuilder builder, FileConfiguration fileConfiguration, IWebHostEnvironment env)
+            this IConfigurationBuilder builder, FileConfiguration fileConfiguration)
         {
             var json = JsonConvert.SerializeObject(fileConfiguration);
 

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -11,6 +11,9 @@ using Newtonsoft.Json;
 
 namespace Ocelot.DependencyInjection
 {
+    /// <summary>
+    /// Defines extension-methods for the <see cref="IConfigurationBuilder"/> interface.
+    /// </summary>
     public static partial class ConfigurationBuilderExtensions
     {
         public const string PrimaryConfigFile = "ocelot.json";
@@ -76,6 +79,13 @@ namespace Ocelot.DependencyInjection
             return builder.AddOcelot(fileConfiguration);
         }
 
+        /// <summary>
+        /// Adds Ocelot configuration by ready configuration object and writes JSON to the primary configuration file.<br/>
+        /// Finally, adds JSON file as configuration provider.
+        /// </summary>
+        /// <param name="builder">Configuration builder to extend.</param>
+        /// <param name="fileConfiguration">File configuration to add as JSON provider.</param>
+        /// <returns>An <see cref="IConfigurationBuilder"/> object.</returns>
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, FileConfiguration fileConfiguration)
         {
             var json = JsonConvert.SerializeObject(fileConfiguration);

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -11,11 +11,13 @@ using Newtonsoft.Json;
 
 namespace Ocelot.DependencyInjection
 {
-    public static class ConfigurationBuilderExtensions
+    public static partial class ConfigurationBuilderExtensions
     {
         public const string PrimaryConfigFile = "ocelot.json";
         public const string GlobalConfigFile = "ocelot.global.json";
-        private const string SubConfigPattern = @"^ocelot\.(.*?)\.json$";
+
+        [GeneratedRegex("^ocelot\\.(.*?)\\.json$", RegexOptions.IgnoreCase | RegexOptions.Singleline, "en-US")]
+        private static partial Regex SubConfigRegex();
 
         [Obsolete("Please set BaseUrl in ocelot.json GlobalConfiguration.BaseUrl")]
         public static IConfigurationBuilder AddOcelotBaseUrl(this IConfigurationBuilder builder, string baseUrl)
@@ -42,11 +44,11 @@ namespace Ocelot.DependencyInjection
         {
             var excludeConfigName = env?.EnvironmentName != null ? $"ocelot.{env.EnvironmentName}.json" : string.Empty;
 
-            var reg = new Regex(SubConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var reg = SubConfigRegex();
 
             var files = new DirectoryInfo(folder)
                 .EnumerateFiles()
-                .Where(fi => reg.IsMatch(fi.Name) && (fi.Name != excludeConfigName))
+                .Where(fi => reg.IsMatch(fi.Name) && fi.Name != excludeConfigName)
                 .ToArray();
 
             var fileConfiguration = new FileConfiguration();
@@ -71,7 +73,7 @@ namespace Ocelot.DependencyInjection
                 fileConfiguration.Routes.AddRange(config.Routes);
             }
 
-            return AddOcelot(builder, fileConfiguration);
+            return builder.AddOcelot(fileConfiguration);
         }
 
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, FileConfiguration fileConfiguration)

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -38,11 +38,24 @@ namespace Ocelot.DependencyInjection
             return builder;
         }
 
+        /// <summary>
+        /// Adds Ocelot configuration by environment, reading the required files from the default path.
+        /// </summary>
+        /// <param name="builder">Configuration builder to extend.</param>
+        /// <param name="env">Web hosting environment object.</param>
+        /// <returns>An <see cref="IConfigurationBuilder"/> object.</returns>
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, IWebHostEnvironment env)
         {
             return builder.AddOcelot(".", env);
         }
 
+        /// <summary>
+        /// Adds Ocelot configuration by environment, reading the required files from the specified folder.
+        /// </summary>
+        /// <param name="builder">Configuration builder to extend.</param>
+        /// <param name="folder">Folder to read files from.</param>
+        /// <param name="env">Web hosting environment object.</param>
+        /// <returns>An <see cref="IConfigurationBuilder"/> object.</returns>
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, string folder, IWebHostEnvironment env)
         {
             var excludeConfigName = env?.EnvironmentName != null ? $"ocelot.{env.EnvironmentName}.json" : string.Empty;

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -84,5 +84,20 @@ namespace Ocelot.DependencyInjection
 
             return builder;
         }
+
+
+        public static IConfigurationBuilder AddOcelot(
+            this IConfigurationBuilder builder, FileConfiguration fileConfiguration, IWebHostEnvironment env)
+        {
+            const string primaryConfigFile = "ocelot.json";
+
+            var json = JsonConvert.SerializeObject(fileConfiguration);
+
+            File.WriteAllText(primaryConfigFile, json);
+
+            builder.AddJsonFile(primaryConfigFile, false, false);
+
+            return builder;
+        }
     }
 }

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -13,9 +13,9 @@ namespace Ocelot.DependencyInjection
 {
     public static class ConfigurationBuilderExtensions
     {
-        private const string PrimaryConfigFile = "ocelot.json";
-
-        private const string GlobalConfigFile = "ocelot.global.json";
+        public const string PrimaryConfigFile = "ocelot.json";
+        public const string GlobalConfigFile = "ocelot.global.json";
+        private const string SubConfigPattern = @"^ocelot\.(.*?)\.json$";
 
         [Obsolete("Please set BaseUrl in ocelot.json GlobalConfiguration.BaseUrl")]
         public static IConfigurationBuilder AddOcelotBaseUrl(this IConfigurationBuilder builder, string baseUrl)
@@ -40,12 +40,9 @@ namespace Ocelot.DependencyInjection
 
         public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, string folder, IWebHostEnvironment env)
         {
-            
-            const string subConfigPattern = @"^ocelot\.(.*?)\.json$";
-
             var excludeConfigName = env?.EnvironmentName != null ? $"ocelot.{env.EnvironmentName}.json" : string.Empty;
 
-            var reg = new Regex(subConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            var reg = new Regex(SubConfigPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
             var files = new DirectoryInfo(folder)
                 .EnumerateFiles()
@@ -74,19 +71,16 @@ namespace Ocelot.DependencyInjection
                 fileConfiguration.Routes.AddRange(config.Routes);
             }
 
-            return builder.AddOcelot(fileConfiguration);
+            return AddOcelot(builder, fileConfiguration);
         }
 
-        public static IConfigurationBuilder AddOcelot(
-            this IConfigurationBuilder builder, FileConfiguration fileConfiguration)
+        public static IConfigurationBuilder AddOcelot(this IConfigurationBuilder builder, FileConfiguration fileConfiguration)
         {
             var json = JsonConvert.SerializeObject(fileConfiguration);
 
             File.WriteAllText(PrimaryConfigFile, json);
 
-            builder.AddJsonFile(PrimaryConfigFile, false, false);
-
-            return builder;
+            return builder.AddJsonFile(PrimaryConfigFile, false, false);
         }
     }
 }

--- a/test/Ocelot.AcceptanceTests/ConfigurationReloadTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConfigurationReloadTests.cs
@@ -88,6 +88,7 @@ namespace Ocelot.AcceptanceTests
         public void Dispose()
         {
             _steps.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
+++ b/test/Ocelot.UnitTests/DependencyInjection/ConfigurationBuilderExtensionsTests.cs
@@ -1,13 +1,13 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Moq;
 using Newtonsoft.Json;
 using Ocelot.Configuration.File;
 using Ocelot.DependencyInjection;
 using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using TestStack.BDDfy;
 using Xunit;
 
@@ -40,7 +40,7 @@ namespace Ocelot.UnitTests.DependencyInjection
         }
 
         [Fact]
-        public void should_add_base_url_to_config()
+        public void Should_add_base_url_to_config()
         {
             this.Given(_ => GivenTheBaseUrl("test"))
                 .When(_ => WhenIGet("BaseUrl"))
@@ -49,7 +49,7 @@ namespace Ocelot.UnitTests.DependencyInjection
         }
 
         [Fact]
-        public void should_merge_files()
+        public void Should_merge_files()
         {
             this.Given(_ => GivenMultipleConfigurationFiles(string.Empty, false))
                 .And(_ => GivenTheEnvironmentIs(null))
@@ -59,7 +59,7 @@ namespace Ocelot.UnitTests.DependencyInjection
         }
 
         [Fact]
-        public void AddOcelot_WhenProvidedFileConfigurationObject_ShouldStoreGivenConfigurations()
+        public void Should_store_given_configurations_when_provided_file_configuration_object()
         {
             this.Given(_ => GivenCombinedFileConfigurationObject(string.Empty))
                 .And(_ => GivenTheEnvironmentIs(null))
@@ -69,7 +69,7 @@ namespace Ocelot.UnitTests.DependencyInjection
         }
 
         [Fact]
-        public void should_merge_files_except_env()
+        public void Should_merge_files_except_env()
         {
             this.Given(_ => GivenMultipleConfigurationFiles(string.Empty, true))
                 .And(_ => GivenTheEnvironmentIs("Env"))
@@ -80,7 +80,7 @@ namespace Ocelot.UnitTests.DependencyInjection
         }
 
         [Fact]
-        public void should_merge_files_in_specific_folder()
+        public void Should_merge_files_in_specific_folder()
         {
             var configFolder = "ConfigFiles";
             this.Given(_ => GivenMultipleConfigurationFiles(configFolder, false))
@@ -180,123 +180,123 @@ namespace Ocelot.UnitTests.DependencyInjection
         private static List<FileAggregateRoute> GetFileAggregatesRouteData()
         {
             return new List<FileAggregateRoute>
+            {
+                new()
                 {
-                    new()
+                    RouteKeys = new List<string>
                     {
-                        RouteKeys = new List<string>
-                        {
-                            "KeyB",
-                            "KeyBB",
-                        },
-                        UpstreamPathTemplate = "UpstreamPathTemplate",
+                        "KeyB",
+                        "KeyBB",
                     },
-                    new()
+                    UpstreamPathTemplate = "UpstreamPathTemplate",
+                },
+                new()
+                {
+                    RouteKeys = new List<string>
                     {
-                        RouteKeys = new List<string>
-                        {
-                            "KeyB",
-                            "KeyBB",
-                        },
-                        UpstreamPathTemplate = "UpstreamPathTemplate",
+                        "KeyB",
+                        "KeyBB",
                     },
-                };
+                    UpstreamPathTemplate = "UpstreamPathTemplate",
+                },
+            };
         }
 
         private static List<FileRoute> GetServiceARoutes()
         {
             return new List<FileRoute>
+            {
+                new()
                 {
-                    new()
+                    DownstreamScheme = "DownstreamScheme",
+                    DownstreamPathTemplate = "DownstreamPathTemplate",
+                    Key = "Key",
+                    UpstreamHost = "UpstreamHost",
+                    UpstreamHttpMethod = new List<string>
                     {
-                        DownstreamScheme = "DownstreamScheme",
-                        DownstreamPathTemplate = "DownstreamPathTemplate",
-                        Key = "Key",
-                        UpstreamHost = "UpstreamHost",
-                        UpstreamHttpMethod = new List<string>
+                        "UpstreamHttpMethod",
+                    },
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    {
+                        new()
                         {
-                            "UpstreamHttpMethod",
-                        },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "Host",
-                                Port = 80,
-                            },
+                            Host = "Host",
+                            Port = 80,
                         },
                     },
-                };
+                },
+            };
         }
 
         private static List<FileRoute> GetServiceBRoutes()
         {
             return new List<FileRoute>
+            {
+                new()
                 {
-                    new ()
+                    DownstreamScheme = "DownstreamSchemeB",
+                    DownstreamPathTemplate = "DownstreamPathTemplateB",
+                    Key = "KeyB",
+                    UpstreamHost = "UpstreamHostB",
+                    UpstreamHttpMethod = new List<string>
                     {
-                        DownstreamScheme = "DownstreamSchemeB",
-                        DownstreamPathTemplate = "DownstreamPathTemplateB",
-                        Key = "KeyB",
-                        UpstreamHost = "UpstreamHostB",
-                        UpstreamHttpMethod = new List<string>
+                        "UpstreamHttpMethodB",
+                    },
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    {
+                        new()
                         {
-                            "UpstreamHttpMethodB",
-                        },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new ()
-                            {
-                                Host = "HostB",
-                                Port = 80,
-                            },
+                            Host = "HostB",
+                            Port = 80,
                         },
                     },
-                    new()
+                },
+                new()
+                {
+                    DownstreamScheme = "DownstreamSchemeBB",
+                    DownstreamPathTemplate = "DownstreamPathTemplateBB",
+                    Key = "KeyBB",
+                    UpstreamHost = "UpstreamHostBB",
+                    UpstreamHttpMethod = new List<string>
                     {
-                        DownstreamScheme = "DownstreamSchemeBB",
-                        DownstreamPathTemplate = "DownstreamPathTemplateBB",
-                        Key = "KeyBB",
-                        UpstreamHost = "UpstreamHostBB",
-                        UpstreamHttpMethod = new List<string>
+                        "UpstreamHttpMethodBB",
+                    },
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                    {
+                        new()
                         {
-                            "UpstreamHttpMethodBB",
-                        },
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "HostBB",
-                                Port = 80,
-                            },
+                            Host = "HostBB",
+                            Port = 80,
                         },
                     },
-                };
+                },
+            };
         }
 
         private static List<FileRoute> GetEnvironmentSpecificRoutes()
         {
             return new List<FileRoute>
+            {
+                new()
+                {
+                    DownstreamScheme = "DownstreamSchemeSpec",
+                    DownstreamPathTemplate = "DownstreamPathTemplateSpec",
+                    Key = "KeySpec",
+                    UpstreamHost = "UpstreamHostSpec",
+                    UpstreamHttpMethod = new List<string>
+                    {
+                        "UpstreamHttpMethodSpec",
+                    },
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
                     {
                         new()
                         {
-                            DownstreamScheme = "DownstreamSchemeSpec",
-                            DownstreamPathTemplate = "DownstreamPathTemplateSpec",
-                            Key = "KeySpec",
-                            UpstreamHost = "UpstreamHostSpec",
-                            UpstreamHttpMethod = new List<string>
-                            {
-                                "UpstreamHttpMethodSpec",
-                            },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "HostSpec",
-                                    Port = 80,
-                                },
-                            },
+                            Host = "HostSpec",
+                            Port = 80,
                         },
-                    };
+                    },
+                },
+            };
         }
 
         private void GivenTheEnvironmentIs(string env)


### PR DESCRIPTION
## Closes #1228 #1235 #1247 
- #1228 
- #1235 
- #1247 

## New Feature
Added an `AddOcelot` overload to load `FileConfiguration` directly from the application, so that all the routes could be made configurable and could be load from anywhere.

## Proposed Changes
  - Added a new overload to the `AddOcelot` in `ConfigurationBuilder` to remove Ocelot file dependency from the application.