### PR TITLE
Incorrect port number

### DIFF
--- a/docs/features/websockets.rst
+++ b/docs/features/websockets.rst
@@ -66,7 +66,7 @@ Then in your ocelot.json add the following to proxy a Route using SignalR. Note 
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 50000
+          "Port": 5000
         }
       ],
       "UpstreamPathTemplate": "/gateway/{catchAll}",

--- a/docs/features/websockets.rst
+++ b/docs/features/websockets.rst
@@ -66,7 +66,7 @@ Then in your ocelot.json add the following to proxy a Route using SignalR. Note 
       "DownstreamHostAndPorts": [
         {
           "Host": "localhost",
-          "Port": 5000
+          "Port": 5001
         }
       ],
       "UpstreamPathTemplate": "/gateway/{catchAll}",


### PR DESCRIPTION
In websocket config docs, port number have to be `5001` as described in text explanation instead of `50000`.
