### PR TITLE
WebSocketsProxyMiddleware does not support DangerousAcceptAnyServerCertificateValidator

### DIFF
--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Description>Ocelot is an API Gateway. The project is aimed at people using .NET running a micro services / service orientated architecture that need a unified point of entry into their system. In particular I want easy integration with IdentityServer reference and bearer tokens.  reference tokens. Ocelot is a bunch of middlewares in a specific order. Ocelot manipulates the HttpRequest object into a state specified by its configuration until it reaches a request builder middleware where it creates a HttpRequestMessage object which is used to make a request to a downstream service. The middleware that makes the request is the last thing in the Ocelot pipeline. It does not call the next middleware. The response from the downstream service is stored in a per request scoped repository and retrived as the requests goes back up the Ocelot pipeline. There is a piece of middleware that maps the HttpResponseMessage onto the HttpResponse object and that is returned to the client. That is basically it with a bunch of other features.</Description>
+    <Description>This Library is a fork to Ocelot to fix certified error in WebSocket. Ocelot is an API Gateway. The project is aimed at people using .NET running a micro services / service orientated architecture that need a unified point of entry into their system. In particular I want easy integration with IdentityServer reference and bearer tokens.  reference tokens. Ocelot is a bunch of middlewares in a specific order. Ocelot manipulates the HttpRequest object into a state specified by its configuration until it reaches a request builder middleware where it creates a HttpRequestMessage object which is used to make a request to a downstream service. The middleware that makes the request is the last thing in the Ocelot pipeline. It does not call the next middleware. The response from the downstream service is stored in a per request scoped repository and retrived as the requests goes back up the Ocelot pipeline. There is a piece of middleware that maps the HttpResponseMessage onto the HttpResponse object and that is returned to the client. That is basically it with a bunch of other features.</Description>
     <AssemblyTitle>Ocelot</AssemblyTitle>
-    <VersionPrefix>0.0.0-dev</VersionPrefix>
-    <AssemblyName>Ocelot</AssemblyName>
-    <PackageId>Ocelot</PackageId>
+    <VersionPrefix>18.0.0</VersionPrefix>
+    <AssemblyName>LanzSoft.Ocelot</AssemblyName>
+    <PackageId>LanzSoft.Ocelot</PackageId>
     <PackageTags>API Gateway;.NET core</PackageTags>
     <PackageProjectUrl>https://github.com/ThreeMammals/Ocelot</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/ThreeMammals/Ocelot/develop/images/ocelot_logo.png</PackageIconUrl>
@@ -15,7 +15,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Authors>Tom Pallister</Authors>
+    <Authors>Antonio Lanzolla, Tom Pallister</Authors>
     <CodeAnalysisRuleSet>..\..\codeanalysis.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <Description>This Library is a fork to Ocelot to fix certified error in WebSocket. Ocelot is an API Gateway. The project is aimed at people using .NET running a micro services / service orientated architecture that need a unified point of entry into their system. In particular I want easy integration with IdentityServer reference and bearer tokens.  reference tokens. Ocelot is a bunch of middlewares in a specific order. Ocelot manipulates the HttpRequest object into a state specified by its configuration until it reaches a request builder middleware where it creates a HttpRequestMessage object which is used to make a request to a downstream service. The middleware that makes the request is the last thing in the Ocelot pipeline. It does not call the next middleware. The response from the downstream service is stored in a per request scoped repository and retrived as the requests goes back up the Ocelot pipeline. There is a piece of middleware that maps the HttpResponseMessage onto the HttpResponse object and that is returned to the client. That is basically it with a bunch of other features.</Description>
+    <Description>Ocelot is an API Gateway. The project is aimed at people using .NET running a micro services / service orientated architecture that need a unified point of entry into their system. In particular I want easy integration with IdentityServer reference and bearer tokens.  reference tokens. Ocelot is a bunch of middlewares in a specific order. Ocelot manipulates the HttpRequest object into a state specified by its configuration until it reaches a request builder middleware where it creates a HttpRequestMessage object which is used to make a request to a downstream service. The middleware that makes the request is the last thing in the Ocelot pipeline. It does not call the next middleware. The response from the downstream service is stored in a per request scoped repository and retrived as the requests goes back up the Ocelot pipeline. There is a piece of middleware that maps the HttpResponseMessage onto the HttpResponse object and that is returned to the client. That is basically it with a bunch of other features.</Description>
     <AssemblyTitle>Ocelot</AssemblyTitle>
-    <VersionPrefix>18.0.0</VersionPrefix>
-    <AssemblyName>LanzSoft.Ocelot</AssemblyName>
-    <PackageId>LanzSoft.Ocelot</PackageId>
+    <VersionPrefix>0.0.0-dev</VersionPrefix>
+    <AssemblyName>Ocelot</AssemblyName>
+    <PackageId>Ocelot</PackageId>
     <PackageTags>API Gateway;.NET core</PackageTags>
     <PackageProjectUrl>https://github.com/ThreeMammals/Ocelot</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/ThreeMammals/Ocelot/develop/images/ocelot_logo.png</PackageIconUrl>
@@ -15,7 +15,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Authors>Antonio Lanzolla, Tom Pallister</Authors>
+    <Authors>Tom Pallister</Authors>
     <CodeAnalysisRuleSet>..\..\codeanalysis.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>

--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -96,6 +96,7 @@ namespace Ocelot.WebSockets.Middleware
 
             var client = new ClientWebSocket();
 
+
             if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
             {
                 client.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;

--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -98,7 +98,7 @@ namespace Ocelot.WebSockets.Middleware
 
             if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
             {
-                client.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+                client.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
             }
 
             foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)

--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -95,6 +95,12 @@ namespace Ocelot.WebSockets.Middleware
             }
 
             var client = new ClientWebSocket();
+
+            if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
+            {
+                client.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+            }
+
             foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)
             {
                 client.Options.AddSubProtocol(protocol);

--- a/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
+++ b/src/Ocelot/WebSockets/Middleware/WebSocketsProxyMiddleware.cs
@@ -95,12 +95,6 @@ namespace Ocelot.WebSockets.Middleware
             }
 
             var client = new ClientWebSocket();
-
-            if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
-            {
-                client.Options.RemoteCertificateValidationCallback = (_, _, _, _) => true;
-            }
-
             foreach (var protocol in context.WebSockets.WebSocketRequestedProtocols)
             {
                 client.Options.AddSubProtocol(protocol);


### PR DESCRIPTION
Fixes / New Feature #
Actually the `WebSocketsProxyMiddleware` doesn't support `DangerousAcceptAnyServerCertificateValidator`.

## Proposed Changes
I've added in the `WebSocketsProxyMiddleware` class
 ```csharp
if (context.Items.DownstreamRoute()?.DangerousAcceptAnyServerCertificateValidator == true)
{
    client.Options.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
}
```
In order to ignore SSL Certified validation
