### PR TITLE
Copy RequestAborted

### DIFF
--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -184,6 +184,7 @@ namespace Ocelot.Multiplexer
             target.Request.RouteValues = source.Request.RouteValues;
             target.Connection.RemoteIpAddress = source.Connection.RemoteIpAddress;
             target.RequestServices = source.RequestServices;
+            target.RequestAborted = source.RequestAborted;
             return target;
         }
 


### PR DESCRIPTION
Copy RequestAborted when creating a new HttpContext in MultiplexingMiddleware

Fixes / New Feature #

## Proposed Changes

  - Fixes issue where request is not properly cancelled if cancelled by the client
