### PR TITLE
Adding configs factory to avoid side effects of changing the same con…

### DIFF
--- a/test/Ocelot.AcceptanceTests/ConfigurationReloadTests.cs
+++ b/test/Ocelot.AcceptanceTests/ConfigurationReloadTests.cs
@@ -1,70 +1,71 @@
-﻿using System;
-
-using Ocelot.Configuration.ChangeTracking;
+﻿using Ocelot.Configuration.ChangeTracking;
 using Ocelot.Configuration.File;
-
+using System;
 using TestStack.BDDfy;
-
 using Xunit;
 
 namespace Ocelot.AcceptanceTests
 {
     public class ConfigurationReloadTests : IDisposable
     {
-        private readonly FileConfiguration _initialConfig;
-        private readonly FileConfiguration _anotherConfig;
-        private readonly Steps _steps;
+        private readonly Steps _steps = new();
 
-        public ConfigurationReloadTests()
+        /// <summary>
+        /// Configs factory to avoid side effects of changing the same config.
+        /// xUnit assumes that tests are isolated and side-effect-free, meaning they don't interfere with one another,
+        /// so it permits parallel execution to speed up test runs.
+        /// </summary>
+        /// <param name="id">The current config id.</param>
+        /// <returns>A tuple containing the initial config and the other config.</returns>
+        private static (FileConfiguration InitialConfig, FileConfiguration AnotherConfig) GetConfigs(int id)
         {
-            _steps = new Steps();
-
-            _initialConfig = new FileConfiguration
+            return (new FileConfiguration
             {
                 GlobalConfiguration = new FileGlobalConfiguration
                 {
-                    RequestIdKey = "initialKey",
+                    RequestIdKey = $"initialKey-{id}",
                 },
-            };
-
-            _anotherConfig = new FileConfiguration
+            }, new FileConfiguration
             {
                 GlobalConfiguration = new FileGlobalConfiguration
                 {
-                    RequestIdKey = "someOtherKey",
+                    RequestIdKey = $"someOtherKey-{id}",
                 },
-            };
+            });
         }
 
         [Fact]
         public void should_reload_config_on_change()
         {
-            this.Given(x => _steps.GivenThereIsAConfiguration(_initialConfig))
+            var (initialConfig, anotherConfig) = GetConfigs(1);
+            this.Given(x => _steps.GivenThereIsAConfiguration(initialConfig))
                 .And(x => _steps.GivenOcelotIsRunningReloadingConfig(true))
-                .And(x => _steps.GivenThereIsAConfiguration(_anotherConfig))
+                .And(x => _steps.GivenThereIsAConfiguration(anotherConfig))
                 .And(x => _steps.GivenIWait(5000))
-                .And(x => _steps.ThenConfigShouldBe(_anotherConfig))
+                .And(x => _steps.ThenConfigShouldBe(anotherConfig))
                 .BDDfy();
         }
 
         [Fact]
         public void should_not_reload_config_on_change()
         {
-            this.Given(x => _steps.GivenThereIsAConfiguration(_initialConfig))
+            var (initialConfig, anotherConfig) = GetConfigs(2);
+            this.Given(x => _steps.GivenThereIsAConfiguration(initialConfig))
                 .And(x => _steps.GivenOcelotIsRunningReloadingConfig(false))
-                .And(x => _steps.GivenThereIsAConfiguration(_anotherConfig))
+                .And(x => _steps.GivenThereIsAConfiguration(anotherConfig))
                 .And(x => _steps.GivenIWait(MillisecondsToWaitForChangeToken))
-                .And(x => _steps.ThenConfigShouldBe(_initialConfig))
+                .And(x => _steps.ThenConfigShouldBe(initialConfig))
                 .BDDfy();
         }
 
         [Fact]
         public void should_trigger_change_token_on_change()
         {
-            this.Given(x => _steps.GivenThereIsAConfiguration(_initialConfig))
+            var (initialConfig, anotherConfig) = GetConfigs(3);
+            this.Given(x => _steps.GivenThereIsAConfiguration(initialConfig))
                 .And(x => _steps.GivenOcelotIsRunningReloadingConfig(true))
                 .And(x => _steps.GivenIHaveAChangeToken())
-                .And(x => _steps.GivenThereIsAConfiguration(_anotherConfig))
+                .And(x => _steps.GivenThereIsAConfiguration(anotherConfig))
                 .And(x => _steps.GivenIWait(MillisecondsToWaitForChangeToken))
                 .Then(x => _steps.TheChangeTokenShouldBeActive(true))
                 .BDDfy();
@@ -73,11 +74,12 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_not_trigger_change_token_with_no_change()
         {
-            this.Given(x => _steps.GivenThereIsAConfiguration(_initialConfig))
+            var (initialConfig, anotherConfig) = GetConfigs(4);
+            this.Given(x => _steps.GivenThereIsAConfiguration(initialConfig))
                 .And(x => _steps.GivenOcelotIsRunningReloadingConfig(false))
                 .And(x => _steps.GivenIHaveAChangeToken())
                 .And(x => _steps.GivenIWait(MillisecondsToWaitForChangeToken)) // Wait for prior activation to expire.
-                .And(x => _steps.GivenThereIsAConfiguration(_anotherConfig))
+                .And(x => _steps.GivenThereIsAConfiguration(anotherConfig))
                 .And(x => _steps.GivenIWait(MillisecondsToWaitForChangeToken))
                 .Then(x => _steps.TheChangeTokenShouldBeActive(false))
                 .BDDfy();


### PR DESCRIPTION
…fig.

Fixes / New Feature #1700 

## Proposed Changes
  - Adding configs factory to avoid side effects of changing the same config.
xUnit assumes that tests are isolated and side-effect-free, meaning they don't interfere with one another