### PR TITLE
#749 Bad error handling for IOException while reading incoming request body

### DIFF
--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -119,6 +119,7 @@ namespace Ocelot.DependencyInjection
             Services.TryAddSingleton<ICacheKeyGenerator, CacheKeyGenerator>();
             Services.TryAddSingleton<IOcelotConfigurationChangeTokenSource, OcelotConfigurationChangeTokenSource>();
             Services.TryAddSingleton<IOptionsMonitor<IInternalConfiguration>, OcelotConfigurationMonitor>();
+            Services.TryAddScoped<IRequestMapperExceptionConditions, RequestMapperExceptionConditions>();
 
             // See this for why we register this as singleton:
             // http://stackoverflow.com/questions/37371264/invalidoperationexception-unable-to-resolve-service-for-type-microsoft-aspnetc

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -119,7 +119,7 @@ namespace Ocelot.DependencyInjection
             Services.TryAddSingleton<ICacheKeyGenerator, CacheKeyGenerator>();
             Services.TryAddSingleton<IOcelotConfigurationChangeTokenSource, OcelotConfigurationChangeTokenSource>();
             Services.TryAddSingleton<IOptionsMonitor<IInternalConfiguration>, OcelotConfigurationMonitor>();
-            Services.TryAddScoped<IRequestMapperExceptionConditions, RequestMapperExceptionConditions>();
+            Services.TryAddSingleton<IRequestMapperExceptionConditions, RequestMapperExceptionConditions>();
 
             // See this for why we register this as singleton:
             // http://stackoverflow.com/questions/37371264/invalidoperationexception-unable-to-resolve-service-for-type-microsoft-aspnetc

--- a/src/Ocelot/Errors/OcelotErrorCode.cs
+++ b/src/Ocelot/Errors/OcelotErrorCode.cs
@@ -43,5 +43,6 @@
         ConnectionToDownstreamServiceError = 38,
         CouldNotFindLoadBalancerCreator = 39,
         ErrorInvokingLoadBalancerCreator = 40,
+        PayloadTooLargeError = 41,
     }
 }

--- a/src/Ocelot/Request/Mapper/IRequestMapperExceptionConditions.cs
+++ b/src/Ocelot/Request/Mapper/IRequestMapperExceptionConditions.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Ocelot.Request.Mapper
+{
+    public interface IRequestMapperExceptionConditions
+    {
+        bool PayloadTooLargeOnAnyHostedServer(HttpRequest request, Exception ex);
+    }
+}

--- a/src/Ocelot/Request/Mapper/PayloadTooLargeError.cs
+++ b/src/Ocelot/Request/Mapper/PayloadTooLargeError.cs
@@ -1,0 +1,12 @@
+﻿using Ocelot.Errors;
+
+namespace Ocelot.Request.Mapper
+{
+    public class PayloadTooLargeError : Error
+    {
+        public PayloadTooLargeError(Exception exception) : base(exception.Message, OcelotErrorCode.PayloadTooLargeError, 413)
+        {
+
+        }
+    }
+}

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -83,7 +83,7 @@ namespace Ocelot.Request.Mapper
         /// Check if this process is running on Windows in an in process instance in IIS.
         /// </summary>
         /// <returns>True if Windows and in an in process instance on IIS, false otherwise.</returns>
-        public static bool IsRunningInProcessIIS()
+        private static bool IsRunningInProcessIIS()
         {
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -1,35 +1,18 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.AspNetCore.Server.HttpSys;
-using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Ocelot.Configuration;
 using Ocelot.Responses;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
 
 namespace Ocelot.Request.Mapper
 {
     public class RequestMapper : IRequestMapper
     {
         private readonly string[] _unsupportedHeaders = { "host" };
-        private readonly long? maxRequestBodySizeHttpsSys;
-        private readonly long? maxRequestBodySizeKerstrelServer;
-        private readonly long? maxRequestBodySizeIISServer;
-        private IServer _server;
-        public RequestMapper()
+        private readonly IRequestMapperExceptionConditions _requestMapperExceptionConditions;
+        public RequestMapper(IRequestMapperExceptionConditions requestMapperExceptionConditions)
         {
-        }
-
-        public RequestMapper(IOptions<HttpSysOptions> httpSysOptions, IOptions<KestrelServerOptions> kerstrelServerOptions, IOptions<IISServerOptions> iISOptions,IServer server)
-        {
-            maxRequestBodySizeHttpsSys = httpSysOptions.Value.MaxRequestBodySize.GetValueOrDefault();
-            maxRequestBodySizeKerstrelServer = kerstrelServerOptions.Value.Limits.MaxRequestBodySize;
-            maxRequestBodySizeIISServer = iISOptions.Value.MaxRequestBodySize;
-            _server = server;
+            _requestMapperExceptionConditions = requestMapperExceptionConditions;
         }
 
         public async Task<Response<HttpRequestMessage>> Map(HttpRequest request, DownstreamRoute downstreamRoute)
@@ -50,49 +33,13 @@ namespace Ocelot.Request.Mapper
             }
             catch (Exception ex)
             {
-                if (PayloadTooLargeOnAnyHostedServer(request, ex))
+                if (_requestMapperExceptionConditions.PayloadTooLargeOnAnyHostedServer(request, ex))
                 {
                     return new ErrorResponse<HttpRequestMessage>(new PayloadTooLargeError(ex));
                 }
 
                 return new ErrorResponse<HttpRequestMessage>(new UnmappableRequestError(ex));
             }
-        }
-
-        private bool PayloadTooLargeOnAnyHostedServer(HttpRequest request, Exception ex)
-        {
-            bool isHeavyPayload = false;
-
-            if(_server is KestrelServer)
-            {
-                isHeavyPayload = maxRequestBodySizeKerstrelServer < request.ContentLength;
-            }
-            else if (IsRunningInProcessIIS())
-            {
-               isHeavyPayload = maxRequestBodySizeIISServer < request.ContentLength;
-            }
-            else
-            {
-                isHeavyPayload = maxRequestBodySizeHttpsSys < request.ContentLength && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            }
-
-            return isHeavyPayload && ex is Microsoft.AspNetCore.Http.BadHttpRequestException;
-        }
-
-        /// <summary>
-        /// Check if this process is running on Windows in an in process instance in IIS.
-        /// </summary>
-        /// <returns>True if Windows and in an in process instance on IIS, false otherwise.</returns>
-        private static bool IsRunningInProcessIIS()
-        {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return false;
-            }
-
-            string processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
-            return processName.Contains("w3wp", StringComparison.OrdinalIgnoreCase) ||
-                processName.Contains("iisexpress", StringComparison.OrdinalIgnoreCase);
         }
 
         private static async Task<HttpContent> MapContent(HttpRequest request)

--- a/src/Ocelot/Request/Mapper/RequestMapperExceptionConditions.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapperExceptionConditions.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.HttpSys;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Ocelot.Request.Mapper
+{
+    public class RequestMapperExceptionConditions : IRequestMapperExceptionConditions
+    {
+        private readonly long? maxRequestBodySizeHttpsSys;
+        private readonly long? maxRequestBodySizeKerstrelServer;
+        private readonly long? maxRequestBodySizeIISServer;
+        private IServer _server;
+        public RequestMapperExceptionConditions(IOptions<HttpSysOptions> httpSysOptions, IOptions<KestrelServerOptions> kerstrelServerOptions, IOptions<IISServerOptions> iISOptions, IServer server)
+        {
+            maxRequestBodySizeHttpsSys = httpSysOptions.Value.MaxRequestBodySize.GetValueOrDefault();
+            maxRequestBodySizeKerstrelServer = kerstrelServerOptions.Value.Limits.MaxRequestBodySize;
+            maxRequestBodySizeIISServer = iISOptions.Value.MaxRequestBodySize;
+            _server = server;
+        }
+
+        /// <summary>
+        /// Check if this process is running on Windows in an in process instance in IIS.
+        /// </summary>
+        /// <returns>True if Windows and in an in process instance on IIS, false otherwise.</returns>
+        private static bool IsRunningInProcessIIS()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return false;
+            }
+
+            string processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
+            return processName.Contains("w3wp", StringComparison.OrdinalIgnoreCase) ||
+                processName.Contains("iisexpress", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool PayloadTooLargeOnAnyHostedServer(HttpRequest request, Exception ex)
+        {
+            bool isHeavyPayload = false;
+
+            if (_server is KestrelServer)
+            {
+                isHeavyPayload = maxRequestBodySizeKerstrelServer < request.ContentLength;
+            }
+            else if (IsRunningInProcessIIS())
+            {
+                isHeavyPayload = maxRequestBodySizeIISServer < request.ContentLength;
+            }
+            else
+            {
+                isHeavyPayload = maxRequestBodySizeHttpsSys < request.ContentLength && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+
+            return isHeavyPayload && ex is Microsoft.AspNetCore.Http.BadHttpRequestException;
+        }
+    }
+}

--- a/src/Ocelot/Request/Mapper/RequestMapperExceptionConditions.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapperExceptionConditions.cs
@@ -16,6 +16,8 @@ namespace Ocelot.Request.Mapper
         private readonly long? _maxRequestBodySizeKerstrelServer;
         private readonly long? _maxRequestBodySizeIISServer;
         private IServiceProvider _serviceProvider;
+        const string _iisServiceName = "W3SVC";
+        const string _kestrelServer = "Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer";
         public RequestMapperExceptionConditions(IOptions<HttpSysOptions> httpSysOptions, IOptions<KestrelServerOptions> kerstrelServerOptions, IOptions<IISServerOptions> iISOptions, IServiceProvider serviceProvider)
         {
             _maxRequestBodySizeHttpsSys = httpSysOptions.Value.MaxRequestBodySize.GetValueOrDefault();
@@ -27,7 +29,6 @@ namespace Ocelot.Request.Mapper
         public bool PayloadTooLargeOnAnyHostedServer(HttpRequest request, Exception ex)
         {
             var server = _serviceProvider.GetRequiredService<IServer>();
-            const string iisServiceName = "W3SVC";
 
             if (server != null && ex is Microsoft.AspNetCore.Http.BadHttpRequestException)
             {
@@ -35,9 +36,9 @@ namespace Ocelot.Request.Mapper
 
                 switch (serverName)
                 {
-                    case "Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServer":
+                    case _kestrelServer:
                         return _maxRequestBodySizeKerstrelServer < request.ContentLength;
-                    case iisServiceName:
+                    case _iisServiceName:
                         return _maxRequestBodySizeIISServer < request.ContentLength;
                     default:
                         return _maxRequestBodySizeHttpsSys < request.ContentLength && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
+++ b/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
@@ -55,6 +55,11 @@ namespace Ocelot.Responder
                 return 500;
             }
 
+            if (errors.Any(e => e.Code == OcelotErrorCode.PayloadTooLargeError))
+            {
+                return 413;
+            }
+
             return 404;
         }
     }

--- a/test/Ocelot.UnitTests/Request/Mapper/RequestMapperTests.cs
+++ b/test/Ocelot.UnitTests/Request/Mapper/RequestMapperTests.cs
@@ -22,11 +22,13 @@ namespace Ocelot.UnitTests.Request.Mapper
 
         private DownstreamRoute _downstreamRoute;
 
+        private Mock<IRequestMapperExceptionConditions> _requestMapperExceptionConditionsMock;
         public RequestMapperTests()
         {
             _httpContext = new DefaultHttpContext();
             _inputRequest = _httpContext.Request;
-            _requestMapper = new RequestMapper();
+            _requestMapperExceptionConditionsMock = new();
+            _requestMapper = new RequestMapper(_requestMapperExceptionConditionsMock.Object);
         }
 
         [Theory]

--- a/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -84,6 +84,12 @@ namespace Ocelot.UnitTests.Responder
         }
 
         [Fact]
+        public void should_return_RequestEntityTooLarge()
+        {
+            ShouldMapErrorsToStatusCode(new List<OcelotErrorCode>() { OcelotErrorCode.PayloadTooLargeError }, HttpStatusCode.RequestEntityTooLarge);
+        }
+
+        [Fact]
         public void AuthenticationErrorsHaveHighestPriority()
         {
             var errors = new List<OcelotErrorCode>
@@ -128,7 +134,7 @@ namespace Ocelot.UnitTests.Responder
             // If this test fails then it's because the number of error codes has changed.
             // You should make the appropriate changes to the test cases here to ensure
             // they cover all the error codes, and then modify this assertion.
-            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(41, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
+            Enum.GetNames(typeof(OcelotErrorCode)).Length.ShouldBe(42, "Looks like the number of error codes has changed. Do you need to modify ErrorsToHttpStatusCodeMapper?");
         }
 
         private void ShouldMapErrorToStatusCode(OcelotErrorCode errorCode, HttpStatusCode expectedHttpStatusCode)


### PR DESCRIPTION
## Fixes #749 
- #749 
- Fixing issue for status code 404, when content length is large than body size. will be displaying **413** status code ("Entity Payload too large"). 
- Considered scenario when application is hosted on Kestrel , IIS or Http.Sys and have different options configured as per host server.

**For example**:
```c#
builder.WebHost.UseHttpSys(options =>
{
    options.MaxRequestBodySize = 60000000;
});
```
Above code have `MaxRequestBodySize  `configured manually (default is ~28.6MB), so changes will handle this case too.

## Proposed Changes
- I have done manual testing, writing test case to fake server host was tough, as per my research on ASP.NET Core there is no exposed way to directly write this fake server test.
- I also faced issue with access level of `ToByteArray` of `RequestMapper`, so I could have marked it null and `ByteArrayContent` constructor have given me error and hence I could have tested it.
- Open for discussion how we can test this functionality :D
