### PR TITLE
#1550 #1706 Addressing the QoS options ExceptionsAllowedBeforeBreaking issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ _templates/
 
 # Test Results
 *.trx
+/Ocelot.sln.DotSettings

--- a/Ocelot.sln.DotSettings
+++ b/Ocelot.sln.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Ocelot.sln.DotSettings
+++ b/Ocelot.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Ocelot.Provider.Polly/CircuitBreaker.cs
+++ b/src/Ocelot.Provider.Polly/CircuitBreaker.cs
@@ -7,7 +7,7 @@ public class CircuitBreaker<TResult>
     /// Initializes a new instance of the <see cref="CircuitBreaker{TResult}"/> class.
     /// We expect at least one policy to be passed in, default can't be null.
     /// </summary>
-    /// <param name="policies">the policies with at least a timeout policy</param>
+    /// <param name="policies">The policies with at least a <see cref="Policy.Timeout(int)"/> policy.</param>
     public CircuitBreaker(params IAsyncPolicy<TResult>[] policies)
     {
         var allPolicies = policies.Where(p => p != null).ToArray();

--- a/src/Ocelot.Provider.Polly/CircuitBreaker.cs
+++ b/src/Ocelot.Provider.Polly/CircuitBreaker.cs
@@ -1,12 +1,17 @@
-namespace Ocelot.Provider.Polly
-{
-    public class CircuitBreaker
-    {
-        public CircuitBreaker(params IAsyncPolicy[] policies)
-        {
-            Policies = policies.Where(p => p != null).ToArray();
-        }
+namespace Ocelot.Provider.Polly;
 
-        public IAsyncPolicy[] Policies { get; }
+public class CircuitBreaker<TResult>
+    where TResult : class
+{
+    public CircuitBreaker(params IAsyncPolicy<TResult>[] policies)
+    {
+        var allPolicies = policies.Where(p => p != null).ToArray();
+        CircuitBreakerAsyncPolicy = allPolicies.FirstOrDefault();
+
+        if (allPolicies.Length > 1)
+        {
+            CircuitBreakerAsyncPolicy = Policy.WrapAsync(allPolicies);
+        }
     }
+    public IAsyncPolicy<TResult> CircuitBreakerAsyncPolicy { get; }
 }

--- a/src/Ocelot.Provider.Polly/CircuitBreaker.cs
+++ b/src/Ocelot.Provider.Polly/CircuitBreaker.cs
@@ -3,15 +3,21 @@ namespace Ocelot.Provider.Polly;
 public class CircuitBreaker<TResult>
     where TResult : class
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CircuitBreaker{TResult}"/> class.
+    /// We expect at least one policy to be passed in, default can't be null.
+    /// </summary>
+    /// <param name="policies">the policies with at least a timeout policy</param>
     public CircuitBreaker(params IAsyncPolicy<TResult>[] policies)
     {
         var allPolicies = policies.Where(p => p != null).ToArray();
-        CircuitBreakerAsyncPolicy = allPolicies.FirstOrDefault();
+        CircuitBreakerAsyncPolicy = allPolicies.First();
 
         if (allPolicies.Length > 1)
         {
             CircuitBreakerAsyncPolicy = Policy.WrapAsync(allPolicies);
         }
     }
+
     public IAsyncPolicy<TResult> CircuitBreakerAsyncPolicy { get; }
 }

--- a/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
@@ -5,5 +5,5 @@ namespace Ocelot.Provider.Polly.Interfaces;
 public interface IPollyQoSProvider<TResult>
     where TResult : class
 {
-    CircuitBreaker<TResult> GetCircuitBreaker(DownstreamRoute route);
+    PollyPolicyWrapper<TResult> GetPollyPolicyWrapper(DownstreamRoute route);
 }

--- a/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
@@ -2,7 +2,8 @@
 
 namespace Ocelot.Provider.Polly.Interfaces;
 
-public interface IPollyQoSProvider
+public interface IPollyQoSProvider<TResult>
+    where TResult : class
 {
-    CircuitBreaker GetCircuitBreaker(DownstreamRoute route);
+    CircuitBreaker<TResult> GetCircuitBreaker(DownstreamRoute route);
 }

--- a/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/Interfaces/IPollyQoSProvider.cs
@@ -1,6 +1,8 @@
-﻿namespace Ocelot.Provider.Polly.Interfaces;
+﻿using Ocelot.Configuration;
+
+namespace Ocelot.Provider.Polly.Interfaces;
 
 public interface IPollyQoSProvider
 {
-    CircuitBreaker CircuitBreaker { get; }
+    CircuitBreaker GetCircuitBreaker(DownstreamRoute route);
 }

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration;
 using Ocelot.DependencyInjection;
 using Ocelot.Errors;
 using Ocelot.Logging;
+using Ocelot.Provider.Polly.Interfaces;
 using Ocelot.Requester;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
@@ -22,11 +24,12 @@ namespace Ocelot.Provider.Polly
 
             builder.Services
                 .AddSingleton(errorMapping)
+                .AddSingleton<IPollyQoSProvider, PollyQoSProvider>()
                 .AddSingleton<QosDelegatingHandlerDelegate>(GetDelegatingHandler);
             return builder;
         }
 
-        private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IOcelotLoggerFactory logger)
-            => new PollyCircuitBreakingDelegatingHandler(new PollyQoSProvider(route, logger), logger);
+        private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
+            => new PollyCircuitBreakingDelegatingHandler(route, contextAccessor, loggerFactory);
     }
 }

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -31,5 +31,5 @@ public static class OcelotBuilderExtensions
     }
 
     private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory) 
-        => new PollyCircuitBreakingDelegatingHandler(route, contextAccessor, loggerFactory);
+        => new PollyPoliciesDelegatingHandler(route, contextAccessor, loggerFactory);
 }

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -30,9 +30,6 @@ public static class OcelotBuilderExtensions
         return builder;
     }
 
-    private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor,
-        IOcelotLoggerFactory loggerFactory)
-    {
-        return new PollyCircuitBreakingDelegatingHandler(route, contextAccessor, loggerFactory);
-    }
+    private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory) 
+        => new PollyCircuitBreakingDelegatingHandler(route, contextAccessor, loggerFactory);
 }

--- a/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
@@ -1,48 +1,76 @@
+using System.Diagnostics;
+using System.Net;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Ocelot.Configuration;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Polly.CircuitBreaker;
 
-namespace Ocelot.Provider.Polly
+namespace Ocelot.Provider.Polly;
+
+public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
 {
-    public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
+    private readonly DownstreamRoute _route;
+    private readonly IHttpContextAccessor _contextAccessor;
+    private readonly IOcelotLogger _logger;
+
+    public PollyCircuitBreakingDelegatingHandler(
+        DownstreamRoute route,
+        IHttpContextAccessor contextAccessor, 
+        IOcelotLoggerFactory loggerFactory)
     {
-        private readonly IPollyQoSProvider _qoSProvider;
-        private readonly IOcelotLogger _logger;
+        _route = route;
+        _contextAccessor = contextAccessor;
+        _logger = loggerFactory.CreateLogger<PollyCircuitBreakingDelegatingHandler>();
+    }
 
-        public PollyCircuitBreakingDelegatingHandler(
-            IPollyQoSProvider qoSProvider,
-            IOcelotLoggerFactory loggerFactory)
-        {
-            _qoSProvider = qoSProvider;
-            _logger = loggerFactory.CreateLogger<PollyCircuitBreakingDelegatingHandler>();
-        }
+    private IPollyQoSProvider GetQoSProvider()
+    {
+        Debug.Assert(_contextAccessor.HttpContext != null, "_contextAccessor.HttpContext != null");
+        return _contextAccessor.HttpContext.RequestServices.GetService<IPollyQoSProvider>();
+    }
 
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var qoSProvider = GetQoSProvider();
+        try
         {
-            try
+            var policies = qoSProvider.GetCircuitBreaker(_route).Policies;
+            if (!policies.Any())
             {
-                var policies = _qoSProvider.CircuitBreaker.Policies;
-                if (!policies.Any())
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            var policy = policies.Length > 1
+                ? Policy.WrapAsync(policies)
+                : policies[0];
+
+            var policyResult = await policy.ExecuteAsync(async () =>
+            {
+                var result = await base.SendAsync(request, cancellationToken);
+                if (result.StatusCode != HttpStatusCode.InternalServerError)
                 {
-                    return await base.SendAsync(request, cancellationToken);
+                    return result;
                 }
 
-                var policy = policies.Length > 1
-                    ? Policy.WrapAsync(policies)
-                    : policies[0];
+                var content = await result.Content.ReadAsStringAsync(cancellationToken);
+                throw new HttpRequestException(content);
 
-                return await policy.ExecuteAsync(() => base.SendAsync(request, cancellationToken));
-            }
-            catch (BrokenCircuitException ex)
-            {
-                _logger.LogError("Reached to allowed number of exceptions. Circuit is open", ex);
-                throw;
-            }
-            catch (HttpRequestException ex)
-            {
-                _logger.LogError($"Error in {nameof(PollyCircuitBreakingDelegatingHandler)}.{nameof(SendAsync)}", ex);
-                throw;
-            }
+            });
+
+            return policyResult;
+        }
+        catch (BrokenCircuitException ex)
+        {
+            _logger.LogError("Reached to allowed number of exceptions. Circuit is open", ex);
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError($"Error in {nameof(PollyCircuitBreakingDelegatingHandler)}.{nameof(SendAsync)}", ex);
+            throw;
         }
     }
 }

--- a/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
@@ -50,5 +50,10 @@ public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
             _logger.LogError("Reached to allowed number of exceptions. Circuit is open", ex);
             throw;
         }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogError($"Error in {nameof(PollyCircuitBreakingDelegatingHandler)}.{nameof(SendAsync)}", ex);
+            throw;
+        }
     }
 }

--- a/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Net;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration;
@@ -37,12 +36,10 @@ public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
         var qoSProvider = GetQoSProvider();
         try
         {
+            // at least one policy (timeout) will be returned
+            // CircuitBreakerAsyncPolicy can't be null
+            // CircuitBreaker constructor will throw if no policy is provided
             var policy = qoSProvider.GetCircuitBreaker(_route).CircuitBreakerAsyncPolicy;
-            if (policy == null)
-            {
-                return await base.SendAsync(request, cancellationToken);
-            }
-
             return await policy.ExecuteAsync(async () => await base.SendAsync(request, cancellationToken));
         }
         catch (BrokenCircuitException ex)

--- a/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyCircuitBreakingDelegatingHandler.cs
@@ -1,10 +1,10 @@
-using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Polly.CircuitBreaker;
+using System.Diagnostics;
 
 namespace Ocelot.Provider.Polly;
 
@@ -37,9 +37,9 @@ public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
         try
         {
             // at least one policy (timeout) will be returned
-            // CircuitBreakerAsyncPolicy can't be null
-            // CircuitBreaker constructor will throw if no policy is provided
-            var policy = qoSProvider.GetCircuitBreaker(_route).CircuitBreakerAsyncPolicy;
+            // AsyncPollyPolicy can't be null
+            // AsyncPollyPolicy constructor will throw if no policy is provided
+            var policy = qoSProvider.GetPollyPolicyWrapper(_route).AsyncPollyPolicy;
             return await policy.ExecuteAsync(async () => await base.SendAsync(request, cancellationToken));
         }
         catch (BrokenCircuitException ex)

--- a/src/Ocelot.Provider.Polly/PollyPoliciesDelegatingHandler.cs
+++ b/src/Ocelot.Provider.Polly/PollyPoliciesDelegatingHandler.cs
@@ -8,20 +8,20 @@ using System.Diagnostics;
 
 namespace Ocelot.Provider.Polly;
 
-public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
+public class PollyPoliciesDelegatingHandler : DelegatingHandler
 {
     private readonly DownstreamRoute _route;
     private readonly IHttpContextAccessor _contextAccessor;
     private readonly IOcelotLogger _logger;
 
-    public PollyCircuitBreakingDelegatingHandler(
+    public PollyPoliciesDelegatingHandler(
         DownstreamRoute route,
         IHttpContextAccessor contextAccessor,
         IOcelotLoggerFactory loggerFactory)
     {
         _route = route;
         _contextAccessor = contextAccessor;
-        _logger = loggerFactory.CreateLogger<PollyCircuitBreakingDelegatingHandler>();
+        _logger = loggerFactory.CreateLogger<PollyPoliciesDelegatingHandler>();
     }
 
     private IPollyQoSProvider<HttpResponseMessage> GetQoSProvider()
@@ -49,7 +49,7 @@ public class PollyCircuitBreakingDelegatingHandler : DelegatingHandler
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogError($"Error in {nameof(PollyCircuitBreakingDelegatingHandler)}.{nameof(SendAsync)}", ex);
+            _logger.LogError($"Error in {nameof(PollyPoliciesDelegatingHandler)}.{nameof(SendAsync)}", ex);
             throw;
         }
     }

--- a/src/Ocelot.Provider.Polly/PollyPolicyWrapper.cs
+++ b/src/Ocelot.Provider.Polly/PollyPolicyWrapper.cs
@@ -1,23 +1,23 @@
 namespace Ocelot.Provider.Polly;
 
-public class CircuitBreaker<TResult>
+public class PollyPolicyWrapper<TResult>
     where TResult : class
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CircuitBreaker{TResult}"/> class.
+    /// Initializes a new instance of the <see cref="PollyPolicyWrapper{TResult}"/> class.
     /// We expect at least one policy to be passed in, default can't be null.
     /// </summary>
     /// <param name="policies">The policies with at least a <see cref="Policy.Timeout(int)"/> policy.</param>
-    public CircuitBreaker(params IAsyncPolicy<TResult>[] policies)
+    public PollyPolicyWrapper(params IAsyncPolicy<TResult>[] policies)
     {
         var allPolicies = policies.Where(p => p != null).ToArray();
-        CircuitBreakerAsyncPolicy = allPolicies.First();
+        AsyncPollyPolicy = allPolicies.First();
 
         if (allPolicies.Length > 1)
         {
-            CircuitBreakerAsyncPolicy = Policy.WrapAsync(allPolicies);
+            AsyncPollyPolicy = Policy.WrapAsync(allPolicies);
         }
     }
 
-    public IAsyncPolicy<TResult> CircuitBreakerAsyncPolicy { get; }
+    public IAsyncPolicy<TResult> AsyncPollyPolicy { get; }
 }

--- a/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
@@ -64,11 +64,10 @@ public class PollyQoSProvider : IPollyQoSProvider<HttpResponseMessage>
                 .Or<TimeoutRejectedException>()
                 .Or<TimeoutException>()
                 .CircuitBreakerAsync(route.QosOptions.ExceptionsAllowedBeforeBreaking,
-                    TimeSpan.FromMilliseconds(route.QosOptions.DurationOfBreak), (ex, breakDelay) =>
-                        _logger.LogError(info + $"Breaking the circuit for {breakDelay.TotalMilliseconds} ms!",
-                            ex.Exception), () =>
-                        _logger.LogDebug(info + "Call OK! Closed the circuit again."), () =>
-                        _logger.LogDebug(info + "Half-open; Next call is a trial."));
+                    TimeSpan.FromMilliseconds(route.QosOptions.DurationOfBreak),
+                    (ex, breakDelay) => _logger.LogError(info + $"Breaking the circuit for {breakDelay.TotalMilliseconds} ms!", ex.Exception),
+                    () => _logger.LogDebug(info + "Call OK! Closed the circuit again."),
+                    () => _logger.LogDebug(info + "Half-open; Next call is a trial."));
         }
 
         var timeoutPolicy = Policy

--- a/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
@@ -32,11 +32,9 @@ public class PollyQoSProvider : IPollyQoSProvider<HttpResponseMessage>
     }
 
     private static string GetRouteName(DownstreamRoute route)
-    {
-        return string.IsNullOrWhiteSpace(route.ServiceName)
+        => string.IsNullOrWhiteSpace(route.ServiceName)
             ? route.UpstreamPathTemplate?.Template ?? route.DownstreamPathTemplate?.Value ?? string.Empty
             : route.ServiceName;
-    }
 
     public PollyPolicyWrapper<HttpResponseMessage> GetPollyPolicyWrapper(DownstreamRoute route)
     {

--- a/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
@@ -62,10 +62,10 @@ public class PollyQoSProvider : IPollyQoSProvider<HttpResponseMessage>
                 .Or<TimeoutRejectedException>()
                 .Or<TimeoutException>()
                 .CircuitBreakerAsync(route.QosOptions.ExceptionsAllowedBeforeBreaking,
-                    TimeSpan.FromMilliseconds(route.QosOptions.DurationOfBreak),
-                    (ex, breakDelay) => _logger.LogError(info + $"Breaking the circuit for {breakDelay.TotalMilliseconds} ms!", ex.Exception),
-                    () => _logger.LogDebug(info + "Call OK! Closed the circuit again."),
-                    () => _logger.LogDebug(info + "Half-open; Next call is a trial."));
+                    durationOfBreak: TimeSpan.FromMilliseconds(route.QosOptions.DurationOfBreak),
+                    onBreak: (ex, breakDelay) => _logger.LogError(info + $"Breaking the circuit for {breakDelay.TotalMilliseconds} ms!", ex.Exception),
+                    onReset: () => _logger.LogDebug(info + "Call OK! Closed the circuit again."),
+                    onHalfOpen: () => _logger.LogDebug(info + "Half-open; Next call is a trial."));
         }
 
         var timeoutPolicy = Policy

--- a/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
@@ -71,10 +71,10 @@ public class PollyQoSProvider : IPollyQoSProvider<HttpResponseMessage>
                         _logger.LogDebug(info + "Half-open; Next call is a trial."));
         }
 
-        _ = Enum.TryParse(route.QosOptions.TimeoutStrategy, out TimeoutStrategy strategy);
-        var timeoutPolicy =
-            Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromMilliseconds(route.QosOptions.TimeoutValue),
-                strategy);
+        var timeoutPolicy = Policy
+            .TimeoutAsync<HttpResponseMessage>(
+                TimeSpan.FromMilliseconds(route.QosOptions.TimeoutValue), 
+                TimeoutStrategy.Pessimistic);
 
         return new CircuitBreaker<HttpResponseMessage>(exceptionsAllowedBeforeBreakingPolicy, timeoutPolicy);
     }

--- a/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSProvider.cs
@@ -1,9 +1,9 @@
-using System.Net;
 using Ocelot.Configuration;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
+using System.Net;
 
 namespace Ocelot.Provider.Polly;
 

--- a/src/Ocelot/Configuration/File/FileAuthenticationOptions.cs
+++ b/src/Ocelot/Configuration/File/FileAuthenticationOptions.cs
@@ -7,6 +7,12 @@
             AllowedScopes = new List<string>();
         }
 
+        public FileAuthenticationOptions(FileAuthenticationOptions from)
+        {
+            AllowedScopes = new(from.AllowedScopes);
+            AuthenticationProviderKey = from.AuthenticationProviderKey;
+        }
+
         public string AuthenticationProviderKey { get; set; }
         public List<string> AllowedScopes { get; set; }
 

--- a/src/Ocelot/Configuration/File/FileCacheOptions.cs
+++ b/src/Ocelot/Configuration/File/FileCacheOptions.cs
@@ -2,8 +2,22 @@
 {
     public class FileCacheOptions
     {
-        public int TtlSeconds { get; set; }
-        public string Region { get; set; }
+        public FileCacheOptions()
+        {
+            Header = string.Empty;
+            Region = string.Empty;
+            TtlSeconds = 0;
+        }
+
+        public FileCacheOptions(FileCacheOptions from)
+        {
+            Header = from.Header;
+            Region = from.Region;
+            TtlSeconds = from.TtlSeconds;
+        }
+
         public string Header { get; set; }
+        public string Region { get; set; }
+        public int TtlSeconds { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileHostAndPort.cs
+++ b/src/Ocelot/Configuration/File/FileHostAndPort.cs
@@ -2,6 +2,20 @@ namespace Ocelot.Configuration.File
 {
     public class FileHostAndPort
     {
+        public FileHostAndPort() { }
+
+        public FileHostAndPort(FileHostAndPort from)
+        {
+            Host = from.Host;
+            Port = from.Port;
+        }
+
+        public FileHostAndPort(string host, int port)
+        {
+            Host = host;
+            Port = port;
+        }
+
         public string Host { get; set; }
         public int Port { get; set; }
     }

--- a/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
+++ b/src/Ocelot/Configuration/File/FileHttpHandlerOptions.cs
@@ -5,19 +5,23 @@
         public FileHttpHandlerOptions()
         {
             AllowAutoRedirect = false;
+            MaxConnectionsPerServer = int.MaxValue;
             UseCookieContainer = false;
             UseProxy = true;
-            MaxConnectionsPerServer = int.MaxValue;
+        }
+
+        public FileHttpHandlerOptions(FileHttpHandlerOptions from)
+        {
+            AllowAutoRedirect = from.AllowAutoRedirect;
+            MaxConnectionsPerServer = from.MaxConnectionsPerServer;
+            UseCookieContainer = from.UseCookieContainer;
+            UseProxy = from.UseProxy;
         }
 
         public bool AllowAutoRedirect { get; set; }
-
-        public bool UseCookieContainer { get; set; }
-
-        public bool UseTracing { get; set; }
-
-        public bool UseProxy { get; set; }
-
         public int MaxConnectionsPerServer { get; set; }
+        public bool UseCookieContainer { get; set; }
+        public bool UseProxy { get; set; }
+        public bool UseTracing { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileLoadBalancerOptions.cs
+++ b/src/Ocelot/Configuration/File/FileLoadBalancerOptions.cs
@@ -2,8 +2,22 @@ namespace Ocelot.Configuration.File
 {
     public class FileLoadBalancerOptions
     {
-        public string Type { get; set; }
-        public string Key { get; set; }
+        public FileLoadBalancerOptions()
+        {
+            Expiry = int.MaxValue;
+            Key = string.Empty;
+            Type = string.Empty;
+        }
+
+        public FileLoadBalancerOptions(FileLoadBalancerOptions from)
+        {
+            Expiry = from.Expiry;
+            Key = from.Key;
+            Type = from.Type;
+        }
+
         public int Expiry { get; set; }
+        public string Key { get; set; }
+        public string Type { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileQoSOptions.cs
+++ b/src/Ocelot/Configuration/File/FileQoSOptions.cs
@@ -2,10 +2,29 @@
 {
     public class FileQoSOptions
     {
-        public int ExceptionsAllowedBeforeBreaking { get; set; }
+        public FileQoSOptions()
+        {
+            DurationOfBreak = 1;
+            ExceptionsAllowedBeforeBreaking = 0;
+            TimeoutValue = int.MaxValue;
+        }
+
+        public FileQoSOptions(FileQoSOptions from)
+        {
+            DurationOfBreak = from.DurationOfBreak;
+            ExceptionsAllowedBeforeBreaking = from.ExceptionsAllowedBeforeBreaking;
+            TimeoutValue = from.TimeoutValue;
+        }
+
+        public FileQoSOptions(QoSOptions from)
+        {
+            DurationOfBreak = from.DurationOfBreak;
+            ExceptionsAllowedBeforeBreaking = from.ExceptionsAllowedBeforeBreaking;
+            TimeoutValue = from.TimeoutValue;
+        }
 
         public int DurationOfBreak { get; set; }
-
+        public int ExceptionsAllowedBeforeBreaking { get; set; }
         public int TimeoutValue { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileRateLimitRule.cs
+++ b/src/Ocelot/Configuration/File/FileRateLimitRule.cs
@@ -7,6 +7,15 @@
             ClientWhitelist = new List<string>();
         }
 
+        public FileRateLimitRule(FileRateLimitRule from)
+        {
+            ClientWhitelist = new(from.ClientWhitelist);
+            EnableRateLimiting = from.EnableRateLimiting;
+            Limit = from.Limit;
+            Period = from.Period;
+            PeriodTimespan = from.PeriodTimespan;
+        }
+
         /// <summary>
         /// The list of allowed clients.
         /// </summary>

--- a/src/Ocelot/Configuration/File/FileRoute.cs
+++ b/src/Ocelot/Configuration/File/FileRoute.cs
@@ -1,59 +1,110 @@
 ﻿namespace Ocelot.Configuration.File
 {
-    public class FileRoute : IRoute
+    public class FileRoute : IRoute, ICloneable
     {
         public FileRoute()
         {
-            UpstreamHttpMethod = new List<string>();
-            AddHeadersToRequest = new Dictionary<string, string>();
             AddClaimsToRequest = new Dictionary<string, string>();
-            RouteClaimsRequirement = new Dictionary<string, string>();
+            AddHeadersToRequest = new Dictionary<string, string>();
             AddQueriesToRequest = new Dictionary<string, string>();
+            AuthenticationOptions = new FileAuthenticationOptions();
             ChangeDownstreamPathTemplate = new Dictionary<string, string>();
+            DelegatingHandlers = new List<string>();
             DownstreamHeaderTransform = new Dictionary<string, string>();
+            DownstreamHostAndPorts = new List<FileHostAndPort>();
             FileCacheOptions = new FileCacheOptions();
+            HttpHandlerOptions = new FileHttpHandlerOptions();
+            LoadBalancerOptions = new FileLoadBalancerOptions();
+            Priority = 1;
             QoSOptions = new FileQoSOptions();
             RateLimitOptions = new FileRateLimitRule();
-            AuthenticationOptions = new FileAuthenticationOptions();
-            HttpHandlerOptions = new FileHttpHandlerOptions();
-            UpstreamHeaderTransform = new Dictionary<string, string>();
-            DownstreamHostAndPorts = new List<FileHostAndPort>();
-            DelegatingHandlers = new List<string>();
-            LoadBalancerOptions = new FileLoadBalancerOptions();
+            RouteClaimsRequirement = new Dictionary<string, string>();
             SecurityOptions = new FileSecurityOptions();
-            Priority = 1;
+            UpstreamHeaderTransform = new Dictionary<string, string>();
+            UpstreamHttpMethod = new List<string>();
         }
 
-        public string DownstreamPathTemplate { get; set; }
-        public string UpstreamPathTemplate { get; set; }
-        public List<string> UpstreamHttpMethod { get; set; }
-        public string DownstreamHttpMethod { get; set; }
-        public Dictionary<string, string> AddHeadersToRequest { get; set; }
-        public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
-        public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
+        public FileRoute(FileRoute from)
+        {
+            DeepCopy(from, this);
+        }
+
         public Dictionary<string, string> AddClaimsToRequest { get; set; }
-        public Dictionary<string, string> RouteClaimsRequirement { get; set; }
+        public Dictionary<string, string> AddHeadersToRequest { get; set; }
         public Dictionary<string, string> AddQueriesToRequest { get; set; }
+        public FileAuthenticationOptions AuthenticationOptions { get; set; }
         public Dictionary<string, string> ChangeDownstreamPathTemplate { get; set; }
-        public string RequestIdKey { get; set; }
+        public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
+        public List<string> DelegatingHandlers { get; set; }
+        public Dictionary<string, string> DownstreamHeaderTransform { get; set; }
+        public List<FileHostAndPort> DownstreamHostAndPorts { get; set; }
+        public string DownstreamHttpMethod { get; set; }
+        public string DownstreamHttpVersion { get; set; }
+        public string DownstreamPathTemplate { get; set; }
+        public string DownstreamScheme { get; set; }
         public FileCacheOptions FileCacheOptions { get; set; }
+        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
+        public string Key { get; set; }
+        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
+        public int Priority { get; set; }
+        public FileQoSOptions QoSOptions { get; set; }
+        public FileRateLimitRule RateLimitOptions { get; set; }
+        public string RequestIdKey { get; set; }
+        public Dictionary<string, string> RouteClaimsRequirement { get; set; }
         public bool RouteIsCaseSensitive { get; set; }
+        public FileSecurityOptions SecurityOptions { get; set; }
         public string ServiceName { get; set; }
         public string ServiceNamespace { get; set; }
-        public string DownstreamScheme { get; set; }
-        public FileQoSOptions QoSOptions { get; set; }
-        public FileLoadBalancerOptions LoadBalancerOptions { get; set; }
-        public FileRateLimitRule RateLimitOptions { get; set; }
-        public FileAuthenticationOptions AuthenticationOptions { get; set; }
-        public FileHttpHandlerOptions HttpHandlerOptions { get; set; }
-        public List<FileHostAndPort> DownstreamHostAndPorts { get; set; }
-        public string UpstreamHost { get; set; }
-        public string Key { get; set; }
-        public List<string> DelegatingHandlers { get; set; }
-        public int Priority { get; set; }
         public int Timeout { get; set; }
-        public bool DangerousAcceptAnyServerCertificateValidator { get; set; }
-        public FileSecurityOptions SecurityOptions { get; set; }
-        public string DownstreamHttpVersion { get; set; }
+        public Dictionary<string, string> UpstreamHeaderTransform { get; set; }
+        public string UpstreamHost { get; set; }
+        public List<string> UpstreamHttpMethod { get; set; }
+        public string UpstreamPathTemplate { get; set; }
+
+        /// <summary>
+        /// Clones this object by making a deep copy.
+        /// </summary>
+        /// <returns>A <see cref="FileRoute"/> deeply copied object.</returns>
+        public object Clone()
+        {
+            var other = (FileRoute)MemberwiseClone();
+            DeepCopy(this, other);
+            return other;
+        }
+
+        public static void DeepCopy(FileRoute from, FileRoute to)
+        {
+            to.AddClaimsToRequest = new(from.AddClaimsToRequest);
+            to.AddHeadersToRequest = new(from.AddHeadersToRequest);
+            to.AddQueriesToRequest = new(from.AddQueriesToRequest);
+            to.AuthenticationOptions = new(from.AuthenticationOptions);
+            to.ChangeDownstreamPathTemplate = new(from.ChangeDownstreamPathTemplate);
+            to.DangerousAcceptAnyServerCertificateValidator = from.DangerousAcceptAnyServerCertificateValidator;
+            to.DelegatingHandlers = new(from.DelegatingHandlers);
+            to.DownstreamHeaderTransform = new(from.DownstreamHeaderTransform);
+            to.DownstreamHostAndPorts = from.DownstreamHostAndPorts.Select(x => new FileHostAndPort(x)).ToList();
+            to.DownstreamHttpMethod = from.DownstreamHttpMethod;
+            to.DownstreamHttpVersion = from.DownstreamHttpVersion;
+            to.DownstreamPathTemplate = from.DownstreamPathTemplate;
+            to.DownstreamScheme = from.DownstreamScheme;
+            to.FileCacheOptions = new(from.FileCacheOptions);
+            to.HttpHandlerOptions = new(from.HttpHandlerOptions);
+            to.Key = from.Key;
+            to.LoadBalancerOptions = new(from.LoadBalancerOptions);
+            to.Priority = from.Priority;
+            to.QoSOptions = new(from.QoSOptions);
+            to.RateLimitOptions = new(from.RateLimitOptions);
+            to.RequestIdKey = from.RequestIdKey;
+            to.RouteClaimsRequirement = new(from.RouteClaimsRequirement);
+            to.RouteIsCaseSensitive = from.RouteIsCaseSensitive;
+            to.SecurityOptions = new(from.SecurityOptions);
+            to.ServiceName = from.ServiceName;
+            to.ServiceNamespace = from.ServiceNamespace;
+            to.Timeout = from.Timeout;
+            to.UpstreamHeaderTransform = new(from.UpstreamHeaderTransform);
+            to.UpstreamHost = from.UpstreamHost;
+            to.UpstreamHttpMethod = new(from.UpstreamHttpMethod);
+            to.UpstreamPathTemplate = from.UpstreamPathTemplate;
+        }
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -9,6 +9,13 @@ namespace Ocelot.Configuration.File
             ExcludeAllowedFromBlocked = false;
         }
 
+        public FileSecurityOptions(FileSecurityOptions from)
+        {
+            IPAllowedList = new(from.IPAllowedList);
+            IPBlockedList = new(from.IPBlockedList);
+            ExcludeAllowedFromBlocked = from.ExcludeAllowedFromBlocked;
+        }
+
         public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
             : this()
         {

--- a/src/Ocelot/Configuration/QoSOptions.cs
+++ b/src/Ocelot/Configuration/QoSOptions.cs
@@ -4,15 +4,13 @@
     {
         public QoSOptions(
             int exceptionsAllowedBeforeBreaking,
-            int durationofBreak,
-            int timeoutValue,
-            string key,
-            string timeoutStrategy = "Pessimistic")
+            int durationOfBreak,
+            int timeoutValue, 
+            string key)
         {
             ExceptionsAllowedBeforeBreaking = exceptionsAllowedBeforeBreaking;
-            DurationOfBreak = durationofBreak;
+            DurationOfBreak = durationOfBreak;
             TimeoutValue = timeoutValue;
-            TimeoutStrategy = timeoutStrategy;
             Key = key;
         }
 
@@ -22,10 +20,7 @@
 
         public int TimeoutValue { get; }
 
-        public string TimeoutStrategy { get; }
-
         public bool UseQos => ExceptionsAllowedBeforeBreaking > 0 || TimeoutValue > 0;
-
         public string Key { get; }
     }
 }

--- a/src/Ocelot/Configuration/QoSOptions.cs
+++ b/src/Ocelot/Configuration/QoSOptions.cs
@@ -1,26 +1,41 @@
-﻿namespace Ocelot.Configuration
+﻿using Ocelot.Configuration.File;
+
+namespace Ocelot.Configuration
 {
     public class QoSOptions
     {
+        public QoSOptions(QoSOptions from)
+        {
+            DurationOfBreak = from.DurationOfBreak;
+            ExceptionsAllowedBeforeBreaking = from.ExceptionsAllowedBeforeBreaking;
+            Key = from.Key;
+            TimeoutValue = from.TimeoutValue;
+        }
+
+        public QoSOptions(FileQoSOptions from)
+        {
+            DurationOfBreak = from.DurationOfBreak;
+            ExceptionsAllowedBeforeBreaking = from.ExceptionsAllowedBeforeBreaking;
+            Key = string.Empty;
+            TimeoutValue = from.TimeoutValue;
+        }
+
         public QoSOptions(
             int exceptionsAllowedBeforeBreaking,
             int durationOfBreak,
             int timeoutValue, 
             string key)
         {
-            ExceptionsAllowedBeforeBreaking = exceptionsAllowedBeforeBreaking;
             DurationOfBreak = durationOfBreak;
-            TimeoutValue = timeoutValue;
+            ExceptionsAllowedBeforeBreaking = exceptionsAllowedBeforeBreaking;
             Key = key;
+            TimeoutValue = timeoutValue;
         }
 
-        public int ExceptionsAllowedBeforeBreaking { get; }
-
         public int DurationOfBreak { get; }
-
-        public int TimeoutValue { get; }
-
-        public bool UseQos => ExceptionsAllowedBeforeBreaking > 0 || TimeoutValue > 0;
+        public int ExceptionsAllowedBeforeBreaking { get; }
         public string Key { get; }
+        public int TimeoutValue { get; }
+        public bool UseQos => ExceptionsAllowedBeforeBreaking > 0 || TimeoutValue > 0;
     }
 }

--- a/src/Ocelot/Requester/HttpExceptionToErrorMapper.cs
+++ b/src/Ocelot/Requester/HttpExceptionToErrorMapper.cs
@@ -16,9 +16,9 @@ namespace Ocelot.Requester
         {
             var type = exception.GetType();
 
-            if (_mappers != null && _mappers.ContainsKey(type))
+            if (_mappers != null && _mappers.TryGetValue(type, out var mapper))
             {
-                return _mappers[type](exception);
+                return mapper(exception);
             }
 
             if (type == typeof(OperationCanceledException) || type.IsSubclassOf(typeof(OperationCanceledException)))

--- a/src/Ocelot/Requester/QoS/QosFactory.cs
+++ b/src/Ocelot/Requester/QoS/QosFactory.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration;
 using Ocelot.Logging;
@@ -9,11 +10,13 @@ namespace Ocelot.Requester.QoS
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly IOcelotLoggerFactory _ocelotLoggerFactory;
+        private readonly IHttpContextAccessor _contextAccessor;
 
-        public QoSFactory(IServiceProvider serviceProvider, IOcelotLoggerFactory ocelotLoggerFactory)
+        public QoSFactory(IServiceProvider serviceProvider, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory ocelotLoggerFactory)
         {
             _serviceProvider = serviceProvider;
             _ocelotLoggerFactory = ocelotLoggerFactory;
+            _contextAccessor = contextAccessor;
         }
 
         public Response<DelegatingHandler> Get(DownstreamRoute request)
@@ -22,7 +25,7 @@ namespace Ocelot.Requester.QoS
 
             if (handler != null)
             {
-                return new OkResponse<DelegatingHandler>(handler(request, _ocelotLoggerFactory));
+                return new OkResponse<DelegatingHandler>(handler(request, _contextAccessor, _ocelotLoggerFactory));
             }
 
             return new ErrorResponse<DelegatingHandler>(new UnableToFindQoSProviderError($"could not find qosProvider for {request.DownstreamScheme}{request.DownstreamAddresses}{request.DownstreamPathTemplate}"));

--- a/src/Ocelot/Requester/QosDelegatingHandlerDelegate.cs
+++ b/src/Ocelot/Requester/QosDelegatingHandlerDelegate.cs
@@ -1,7 +1,8 @@
+using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration;
 using Ocelot.Logging;
 
 namespace Ocelot.Requester
 {
-    public delegate DelegatingHandler QosDelegatingHandlerDelegate(DownstreamRoute route, IOcelotLoggerFactory logger);
+    public delegate DelegatingHandler QosDelegatingHandlerDelegate(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory);
 }

--- a/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
@@ -99,7 +99,7 @@ namespace Ocelot.AcceptanceTests
         [Fact]
         public void should_open_circuit_breaker_after_two_exceptions()
         {
-            var port = RandomPortFinder.GetRandomPort();
+            var port = PortFinder.GetRandomPort();
 
             var configuration = new FileConfiguration
             {

--- a/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
@@ -123,7 +123,7 @@ namespace Ocelot.AcceptanceTests
                         {
                             ExceptionsAllowedBeforeBreaking = 2,
                             TimeoutValue = 5000,
-                            DurationOfBreak = 1000,
+                            DurationOfBreak = 100000,
                         },
                     },
                 },

--- a/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
@@ -65,7 +65,7 @@ public class PollyQoSTests : IDisposable
     }
 
     [Fact]
-    public void should_open_circuit_breaker_after_two_exceptions()
+    public void Should_open_circuit_breaker_after_two_exceptions()
     {
         var port = PortFinder.GetRandomPort();
         var configuration = FileConfigurationFactory(port, new QoSOptions(2, 5000, 100000, null));

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -124,6 +124,7 @@ namespace Ocelot.AcceptanceTests
         {
             _serviceHandler?.Dispose();
             _steps.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -111,7 +111,7 @@ namespace Ocelot.AcceptanceTests
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunningWithLogger())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenWarningShouldBeLogged())
+                .Then(x => _steps.ThenWarningShouldBeLogged(2))
                 .BDDfy();
         }
 

--- a/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
+++ b/test/Ocelot.AcceptanceTests/ReturnsErrorTests.cs
@@ -14,7 +14,7 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_bad_gateway_error_if_downstream_service_doesnt_respond()
+        public void Should_return_bad_gateway_error_if_downstream_service_doesnt_respond()
         {
             var configuration = new FileConfiguration
             {
@@ -46,7 +46,7 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_internal_server_error_if_downstream_service_returns_internal_server_error()
+        public void Should_return_internal_server_error_if_downstream_service_returns_internal_server_error()
         {
             var port = PortFinder.GetRandomPort();
 
@@ -81,7 +81,7 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_log_warning_if_downstream_service_returns_internal_server_error()
+        public void Should_log_warning_if_downstream_service_returns_internal_server_error()
         {
             var port = PortFinder.GetRandomPort();
 

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -916,6 +916,10 @@ namespace Ocelot.AcceptanceTests
                     config.AddJsonFile(_ocelotConfigFileName, false, false);
                     config.AddEnvironmentVariables();
                 })
+                .ConfigureLogging(logging => {
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                    logging.AddConsole();
+                })
                 .ConfigureServices(s =>
                 {
                     s.AddOcelot()

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -1243,10 +1243,10 @@ namespace Ocelot.AcceptanceTests
             _ocelotClient = _ocelotServer.CreateClient();
         }
 
-        public void ThenWarningShouldBeLogged()
+        public void ThenWarningShouldBeLogged(int howMany)
         {
             var loggerFactory = (MockLoggerFactory)_ocelotServer.Host.Services.GetService<IOcelotLoggerFactory>();
-            loggerFactory.Verify();
+            loggerFactory.Verify(Times.Exactly(howMany));
         }
 
         internal class MockLoggerFactory : IOcelotLoggerFactory
@@ -1264,9 +1264,9 @@ namespace Ocelot.AcceptanceTests
                 return _logger.Object;
             }
 
-            public void Verify()
+            public void Verify(Times howMany)
             {
-                _logger.Verify(x => x.LogWarning(It.IsAny<string>()), Times.Once);
+                _logger.Verify(x => x.LogWarning(It.IsAny<string>()), howMany);
             }
         }
 

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -916,10 +916,6 @@ namespace Ocelot.AcceptanceTests
                     config.AddJsonFile(_ocelotConfigFileName, false, false);
                     config.AddEnvironmentVariables();
                 })
-                .ConfigureLogging(logging => {
-                    logging.SetMinimumLevel(LogLevel.Trace);
-                    logging.AddConsole();
-                })
                 .ConfigureServices(s =>
                 {
                     s.AddOcelot()

--- a/test/Ocelot.ManualTest/Program.cs
+++ b/test/Ocelot.ManualTest/Program.cs
@@ -33,7 +33,7 @@ namespace Ocelot.ManualTest
                         x.Audience = "test";
                     });*/
 
-                    s.AddSingleton<QosDelegatingHandlerDelegate>((x, t) => new FakeHandler());
+                    s.AddSingleton<QosDelegatingHandlerDelegate>((x, t, z) => new FakeHandler());
                     s.AddOcelot()
                        .AddDelegatingHandler<FakeHandler>(true);
                     /*.AddCacheManager(x =>

--- a/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
@@ -12,6 +12,9 @@ using Ocelot.UnitTests.Requester;
 using Ocelot.Values;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration;
+using Ocelot.Logging;
 
 namespace Ocelot.UnitTests.Configuration.Validation
 {
@@ -1536,8 +1539,8 @@ namespace Ocelot.UnitTests.Configuration.Validation
         private void GivenAQoSHandler()
         {
             var collection = new ServiceCollection();
-            QosDelegatingHandlerDelegate del = (a, b) => new FakeDelegatingHandler();
-            collection.AddSingleton<QosDelegatingHandlerDelegate>(del);
+            DelegatingHandler Del(DownstreamRoute a, IHttpContextAccessor b, IOcelotLoggerFactory c) => new FakeDelegatingHandler();
+            collection.AddSingleton((QosDelegatingHandlerDelegate)Del);
             var provider = collection.BuildServiceProvider();
             _configurationValidator = new FileConfigurationFluentValidator(provider, new RouteFluentValidator(_authProvider.Object, new HostAndPortValidator(), new FileQoSOptionsFluentValidator(provider)), new FileGlobalConfigurationFluentValidator(new FileQoSOptionsFluentValidator(provider)));
         }

--- a/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Ocelot.Configuration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Validator;
+using Ocelot.Logging;
 using Ocelot.Requester;
 using Ocelot.Responses;
 using Ocelot.ServiceDiscovery;
@@ -12,9 +15,6 @@ using Ocelot.UnitTests.Requester;
 using Ocelot.Values;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration;
-using Ocelot.Logging;
 
 namespace Ocelot.UnitTests.Configuration.Validation
 {

--- a/test/Ocelot.UnitTests/Configuration/Validation/FileQoSOptionsFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/FileQoSOptionsFluentValidatorTests.cs
@@ -1,7 +1,10 @@
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Ocelot.Configuration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Validator;
+using Ocelot.Logging;
 using Ocelot.Requester;
 
 namespace Ocelot.UnitTests.Configuration.Validation
@@ -73,11 +76,8 @@ namespace Ocelot.UnitTests.Configuration.Validation
 
         private void GivenAQosDelegate()
         {
-            QosDelegatingHandlerDelegate fake = (a, b) =>
-            {
-                return null;
-            };
-            _services.AddSingleton(fake);
+            DelegatingHandler Fake(DownstreamRoute a, IHttpContextAccessor b, IOcelotLoggerFactory c) => null;
+            _services.AddSingleton((QosDelegatingHandlerDelegate)Fake);
             var provider = _services.BuildServiceProvider();
             _validator = new FileQoSOptionsFluentValidator(provider);
         }

--- a/test/Ocelot.UnitTests/Polly/OcelotBuilderExtensionsTests.cs
+++ b/test/Ocelot.UnitTests/Polly/OcelotBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration.Builder;
 using Ocelot.DependencyInjection;
@@ -14,6 +15,7 @@ namespace Ocelot.UnitTests.Polly
         public void Should_build()
         {
             var loggerFactory = new Mock<IOcelotLoggerFactory>();
+            var contextAccessor = new Mock<IHttpContextAccessor>();
             var services = new ServiceCollection();
             var options = new QoSOptionsBuilder()
                 .WithTimeoutValue(100)
@@ -34,7 +36,7 @@ namespace Ocelot.UnitTests.Polly
             var handler = provider.GetService<QosDelegatingHandlerDelegate>();
             handler.ShouldNotBeNull();
 
-            var delgatingHandler = handler(route, loggerFactory.Object);
+            var delgatingHandler = handler(route, contextAccessor.Object, loggerFactory.Object);
             delgatingHandler.ShouldNotBeNull();
         }
     }

--- a/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
@@ -16,8 +16,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
 {
     private readonly Mock<IPollyQoSProvider<HttpResponseMessage>> _pollyQoSProviderMock;
     private readonly Mock<IHttpContextAccessor> _contextAccessorMock;
-
-    private readonly PollyCircuitBreakingDelegatingHandler sut;
+    private readonly PollyCircuitBreakingDelegatingHandler _sut;
 
     public PollyCircuitBreakingDelegatingHandlerTests()
     {
@@ -31,7 +30,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
             .Returns(loggerMock.Object);
         loggerMock.Setup(x => x.LogError(It.IsAny<string>(), It.IsAny<Exception>()));
 
-        sut = new PollyCircuitBreakingDelegatingHandler(DownstreamRouteFactory(), _contextAccessorMock.Object, loggerFactoryMock.Object);
+        _sut = new PollyCircuitBreakingDelegatingHandler(DownstreamRouteFactory(), _contextAccessorMock.Object, loggerFactoryMock.Object);
     }
 
     [Fact]
@@ -137,7 +136,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
     private async Task<HttpResponseMessage> InvokeAsync(string methodName)
     {
         var m = typeof(PollyCircuitBreakingDelegatingHandler).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
-        var task = (Task<HttpResponseMessage>)m.Invoke(sut, new object[] { new HttpRequestMessage(), CancellationToken.None });
+        var task = (Task<HttpResponseMessage>)m.Invoke(_sut, new object[] { new HttpRequestMessage(), CancellationToken.None });
         var actual = await task;
         return actual;
     }

--- a/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
@@ -60,7 +60,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
 
         // Assert
         ShouldHaveXunitHeaderWithNoContent(actual, nameof(SendAsync_OnePolicy_NoWrapping));
-        method.DeclaringType.Name.ShouldBe(nameof(IAsyncPolicy));
+        method.DeclaringType.Name.ShouldBe("IAsyncPolicy`1");
         method.DeclaringType.ShouldNotBeOfType<AsyncPolicyWrap>();
     }
 

--- a/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
@@ -44,8 +44,8 @@ public class PollyCircuitBreakingDelegatingHandlerTests
             .Callback((IInvocation x) => method = x.Method)
             .ReturnsAsync(fakeResponse);
 
-        _pollyQoSProviderMock.Setup(x => x.GetCircuitBreaker(It.IsAny<DownstreamRoute>()))
-            .Returns(new CircuitBreaker<HttpResponseMessage>(onePolicy.Object));
+        _pollyQoSProviderMock.Setup(x => x.GetPollyPolicyWrapper(It.IsAny<DownstreamRoute>()))
+            .Returns(new PollyPolicyWrapper<HttpResponseMessage>(onePolicy.Object));
 
         var httpContext = new Mock<HttpContext>();
         httpContext.Setup(x => x.RequestServices.GetService(typeof(IPollyQoSProvider<HttpResponseMessage>)))
@@ -75,8 +75,8 @@ public class PollyCircuitBreakingDelegatingHandlerTests
             IsLast = true,
         };
 
-        _pollyQoSProviderMock.Setup(x => x.GetCircuitBreaker(It.IsAny<DownstreamRoute>()))
-            .Returns(new CircuitBreaker<HttpResponseMessage>(policy1, policy2));
+        _pollyQoSProviderMock.Setup(x => x.GetPollyPolicyWrapper(It.IsAny<DownstreamRoute>()))
+            .Returns(new PollyPolicyWrapper<HttpResponseMessage>(policy1, policy2));
 
         var httpContext = new Mock<HttpContext>();
         httpContext.Setup(x => x.RequestServices.GetService(typeof(IPollyQoSProvider<HttpResponseMessage>)))

--- a/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
@@ -54,6 +54,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
             .Returns(_pollyQoSProviderMock.Object);
 
         _contextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext.Object);
+
         // Act
         var actual = await InvokeAsync("SendAsync");
 
@@ -94,7 +95,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
         ShouldBeWrappedBy(policy2, typeof(AsyncPolicy).FullName);
     }
 
-    private DownstreamRoute DownstreamRouteFactory()
+    private static DownstreamRoute DownstreamRouteFactory()
     {
         var options = new QoSOptionsBuilder()
             .WithTimeoutValue(100)
@@ -179,7 +180,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
             return result;
         }
 
-        public IAsyncPolicy WithPolicyKey(string policyKey)
+        public new IAsyncPolicy WithPolicyKey(string policyKey)
         {
             throw new NotImplementedException();
         }

--- a/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyCircuitBreakingDelegatingHandlerTests.cs
@@ -1,14 +1,12 @@
-﻿using Moq;
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration;
+using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly;
 using Ocelot.Provider.Polly.Interfaces;
 using Polly;
 using Polly.Wrap;
 using System.Reflection;
-using Microsoft.AspNetCore.Http;
-using Ocelot.Configuration;
-using Ocelot.Configuration.Builder;
-using Ocelot.Values;
 
 namespace Ocelot.UnitTests.Polly;
 

--- a/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
@@ -10,13 +10,13 @@ using System.Reflection;
 
 namespace Ocelot.UnitTests.Polly;
 
-public class PollyCircuitBreakingDelegatingHandlerTests
+public class PollyPoliciesDelegatingHandlerTests
 {
     private readonly Mock<IPollyQoSProvider<HttpResponseMessage>> _pollyQoSProviderMock;
     private readonly Mock<IHttpContextAccessor> _contextAccessorMock;
     private readonly PollyPoliciesDelegatingHandler _sut;
 
-    public PollyCircuitBreakingDelegatingHandlerTests()
+    public PollyPoliciesDelegatingHandlerTests()
     {
         _pollyQoSProviderMock = new Mock<IPollyQoSProvider<HttpResponseMessage>>();
 

--- a/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
@@ -14,7 +14,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
 {
     private readonly Mock<IPollyQoSProvider<HttpResponseMessage>> _pollyQoSProviderMock;
     private readonly Mock<IHttpContextAccessor> _contextAccessorMock;
-    private readonly PollyCircuitBreakingDelegatingHandler _sut;
+    private readonly PollyPoliciesDelegatingHandler _sut;
 
     public PollyCircuitBreakingDelegatingHandlerTests()
     {
@@ -24,11 +24,11 @@ public class PollyCircuitBreakingDelegatingHandlerTests
         var loggerMock = new Mock<IOcelotLogger>();
         _contextAccessorMock = new Mock<IHttpContextAccessor>();
 
-        loggerFactoryMock.Setup(x => x.CreateLogger<PollyCircuitBreakingDelegatingHandler>())
+        loggerFactoryMock.Setup(x => x.CreateLogger<PollyPoliciesDelegatingHandler>())
             .Returns(loggerMock.Object);
         loggerMock.Setup(x => x.LogError(It.IsAny<string>(), It.IsAny<Exception>()));
 
-        _sut = new PollyCircuitBreakingDelegatingHandler(DownstreamRouteFactory(), _contextAccessorMock.Object, loggerFactoryMock.Object);
+        _sut = new PollyPoliciesDelegatingHandler(DownstreamRouteFactory(), _contextAccessorMock.Object, loggerFactoryMock.Object);
     }
 
     [Fact]
@@ -134,7 +134,7 @@ public class PollyCircuitBreakingDelegatingHandlerTests
 
     private async Task<HttpResponseMessage> InvokeAsync(string methodName)
     {
-        var m = typeof(PollyCircuitBreakingDelegatingHandler).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        var m = typeof(PollyPoliciesDelegatingHandler).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
         var task = (Task<HttpResponseMessage>)m.Invoke(_sut, new object[] { new HttpRequestMessage(), CancellationToken.None });
         var actual = await task;
         return actual;

--- a/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyPoliciesDelegatingHandlerTests.cs
@@ -178,196 +178,78 @@ public class PollyPoliciesDelegatingHandlerTests
             return result;
         }
 
-        public new IAsyncPolicy WithPolicyKey(string policyKey)
-        {
-            throw new NotImplementedException();
-        }
+        public new IAsyncPolicy WithPolicyKey(string policyKey) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Task> action)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Task> action) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, Task> action, IDictionary<string, object> contextData)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, Task> action, IDictionary<string, object> contextData) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, Task> action, Context context)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, Task> action, Context context) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task ExecuteAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Task<TResult1>> action)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Task<TResult1>> action) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, Task<TResult1>> action, Context context)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, Task<TResult1>> action, Context context) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, Task<TResult1>> action, IDictionary<string, object> contextData)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, Task<TResult1>> action, IDictionary<string, object> contextData) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<TResult1> ExecuteAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Task> action) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, IDictionary<string, object> contextData)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, IDictionary<string, object> contextData) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, Context context)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, Task> action, Context context) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult> ExecuteAndCaptureAsync(Func<Context, CancellationToken, Task> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Task<TResult1>> action)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Task<TResult1>> action) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, Task<TResult1>> action, IDictionary<string, object> contextData)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, Task<TResult1>> action, IDictionary<string, object> contextData) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, Task<TResult1>> action, Context context)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, Task<TResult1>> action, Context context) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken, bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<CancellationToken, Task<TResult1>> action, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, IDictionary<string, object> contextData, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
 
-        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken,
-            bool continueOnCapturedContext)
-        {
-            throw new NotImplementedException();
-        }
+        public Task<PolicyResult<TResult1>> ExecuteAndCaptureAsync<TResult1>(Func<Context, CancellationToken, Task<TResult1>> action, Context context, CancellationToken cancellationToken, bool continueOnCapturedContext) => throw new NotImplementedException();
     }
 }

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -85,7 +85,7 @@ public class PollyQoSProviderTests
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-        await Task.Delay(101);
+        await Task.Delay(100);
 
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -159,7 +159,7 @@ public class PollyQoSProviderTests
     private static CircuitBreaker<HttpResponseMessage> CircuitBreakerFactory(string routeTemplate, PollyQoSProvider pollyQoSProvider)
     {
         var options = new QoSOptionsBuilder()
-            .WithTimeoutValue(100)
+            .WithTimeoutValue(5000)
             .WithExceptionsAllowedBeforeBreaking(2)
             .WithDurationOfBreak(200)
             .Build();

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly;
+using Polly;
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 
@@ -20,11 +21,9 @@ namespace Ocelot.UnitTests.Polly
                 .Build();
             var factory = new Mock<IOcelotLoggerFactory>();
             var pollyQoSProvider = new PollyQoSProvider(factory.Object);
-            var policies = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull()
-                .Policies.ShouldNotBeNull();
-            policies.Length.ShouldBeGreaterThan(0);
-            policies.ShouldContain(p => p is AsyncCircuitBreakerPolicy);
-            policies.ShouldContain(p => p is AsyncTimeoutPolicy);
+            var policy = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull()
+                .CircuitBreakerAsyncPolicy.ShouldNotBeNull();
+            policy.ShouldNotBeNull();
         }
 
         [Fact]

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -19,12 +19,80 @@ namespace Ocelot.UnitTests.Polly
             var route = new DownstreamRouteBuilder().WithQosOptions(options)
                 .Build();
             var factory = new Mock<IOcelotLoggerFactory>();
-            var pollyQoSProvider = new PollyQoSProvider(route, factory.Object);
-            var policies = pollyQoSProvider.CircuitBreaker.ShouldNotBeNull()
+            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
+            var policies = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull()
                 .Policies.ShouldNotBeNull();
             policies.Length.ShouldBeGreaterThan(0);
             policies.ShouldContain(p => p is AsyncCircuitBreakerPolicy);
             policies.ShouldContain(p => p is AsyncTimeoutPolicy);
+        }
+
+        [Fact]
+        public void should_return_same_circuit_breaker_for_given_route()
+        {
+            var options = new QoSOptionsBuilder()
+                .WithTimeoutValue(100)
+                .WithExceptionsAllowedBeforeBreaking(2)
+                .WithDurationOfBreak(200)
+                .Build();
+
+            var upstreamPath = new UpstreamPathTemplateBuilder()
+                .WithTemplate("/")
+                .WithContainsQueryString(false)
+                .WithPriority(1)
+                .WithOriginalValue("/").Build();
+
+            var route = new DownstreamRouteBuilder()
+                .WithQosOptions(options)
+                .WithUpstreamPathTemplate(upstreamPath).Build();
+
+            var factory = new Mock<IOcelotLoggerFactory>();
+            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
+            var circuitBreaker = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
+            var circuitBreaker2 = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
+            circuitBreaker.ShouldBe(circuitBreaker2);
+        }
+
+        [Fact]
+        public void should_return_different_circuit_breaker_for_two_different_routes()
+        {
+            var options = new QoSOptionsBuilder()
+                .WithTimeoutValue(100)
+                .WithExceptionsAllowedBeforeBreaking(2)
+                .WithDurationOfBreak(200)
+                .Build();
+
+            var upstreamPath = new UpstreamPathTemplateBuilder()
+                .WithTemplate("/")
+                .WithContainsQueryString(false)
+                .WithPriority(1)
+                .WithOriginalValue("/").Build();
+
+            var route = new DownstreamRouteBuilder()
+                .WithQosOptions(options)
+                .WithUpstreamPathTemplate(upstreamPath).Build();
+
+            var options2 = new QoSOptionsBuilder()
+                .WithTimeoutValue(100)
+                .WithExceptionsAllowedBeforeBreaking(2)
+                .WithDurationOfBreak(200)
+                .Build();
+
+            var upstreamPath2 = new UpstreamPathTemplateBuilder()
+                .WithTemplate("/test2")
+                .WithContainsQueryString(false)
+                .WithPriority(1)
+                .WithOriginalValue("/test2").Build();
+
+            var route2 = new DownstreamRouteBuilder()
+                .WithQosOptions(options2)
+                .WithUpstreamPathTemplate(upstreamPath2).Build();
+
+            var factory = new Mock<IOcelotLoggerFactory>();
+            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
+            var circuitBreaker = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
+            var circuitBreaker2 = pollyQoSProvider.GetCircuitBreaker(route2).ShouldNotBeNull();
+            circuitBreaker.ShouldNotBe(circuitBreaker2);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -102,7 +102,7 @@ public class PollyQoSProviderTests
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
                        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-        await Task.Delay(200);
+        await Task.Delay(500);
 
         Assert.Equal(HttpStatusCode.InternalServerError, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
     }
@@ -118,7 +118,7 @@ public class PollyQoSProviderTests
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-        await Task.Delay(200);
+        await Task.Delay(500);
 
         Assert.Equal(HttpStatusCode.InternalServerError, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -136,7 +136,7 @@ public class PollyQoSProviderTests
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-        await Task.Delay(200);
+        await Task.Delay(500);
 
         var response2 = new HttpResponseMessage(HttpStatusCode.OK);
         Assert.Equal(HttpStatusCode.OK, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response2))).StatusCode);

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -50,10 +50,10 @@ public class PollyQoSProviderTests
 
                 switch (convertedPolicy)
                 {
-                    case AsyncCircuitBreakerPolicy<HttpResponseMessage> circuitBreakerPolicy:
+                    case AsyncCircuitBreakerPolicy<HttpResponseMessage>:
                         circuitBreakerPolicyFound = true;
                         continue;
-                    case AsyncTimeoutPolicy<HttpResponseMessage> timeoutPolicy:
+                    case AsyncTimeoutPolicy<HttpResponseMessage>:
                         timeoutPolicyFound = true;
                         break;
                 }

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -85,7 +85,7 @@ public class PollyQoSProviderTests
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-        await Task.Delay(100);
+        await Task.Delay(101);
 
         await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
             await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -1,97 +1,183 @@
 ﻿using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly;
-using Polly;
 using Polly.CircuitBreaker;
-using Polly.Timeout;
 
-namespace Ocelot.UnitTests.Polly
+namespace Ocelot.UnitTests.Polly;
+
+public class PollyQoSProviderTests
 {
-    public class PollyQoSProviderTests
+    [Fact]
+    public void Should_build()
     {
-        [Fact]
-        public void Should_build()
-        {
-            var options = new QoSOptionsBuilder()
-                .WithTimeoutValue(100)
-                .WithExceptionsAllowedBeforeBreaking(1)
-                .WithDurationOfBreak(200)
-                .Build();
-            var route = new DownstreamRouteBuilder().WithQosOptions(options)
-                .Build();
-            var factory = new Mock<IOcelotLoggerFactory>();
-            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
-            var policy = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull()
-                .CircuitBreakerAsyncPolicy.ShouldNotBeNull();
-            policy.ShouldNotBeNull();
-        }
+        var options = new QoSOptionsBuilder()
+            .WithTimeoutValue(100)
+            .WithExceptionsAllowedBeforeBreaking(1)
+            .WithDurationOfBreak(200)
+            .Build();
+        var route = new DownstreamRouteBuilder().WithQosOptions(options)
+            .Build();
+        var factory = new Mock<IOcelotLoggerFactory>();
+        var pollyQoSProvider = new PollyQoSProvider(factory.Object);
+        var policy = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull()
+            .CircuitBreakerAsyncPolicy.ShouldNotBeNull();
+        policy.ShouldNotBeNull();
+    }
 
-        [Fact]
-        public void should_return_same_circuit_breaker_for_given_route()
-        {
-            var options = new QoSOptionsBuilder()
-                .WithTimeoutValue(100)
-                .WithExceptionsAllowedBeforeBreaking(2)
-                .WithDurationOfBreak(200)
-                .Build();
+    [Fact]
+    public void should_return_same_circuit_breaker_for_given_route()
+    {
+        var pollyQosProvider = PollyQoSProviderFactory();
+        var circuitBreaker = CircuitBreakerFactory("/", pollyQosProvider);
+        var circuitBreaker2 = CircuitBreakerFactory("/", pollyQosProvider);
+        circuitBreaker.ShouldBe(circuitBreaker2);
+    }
 
-            var upstreamPath = new UpstreamPathTemplateBuilder()
-                .WithTemplate("/")
-                .WithContainsQueryString(false)
-                .WithPriority(1)
-                .WithOriginalValue("/").Build();
+    [Fact]
+    public void should_return_different_circuit_breaker_for_two_different_routes()
+    {
+        var pollyQosProvider = PollyQoSProviderFactory();
+        var circuitBreaker = CircuitBreakerFactory("/", pollyQosProvider);
+        var circuitBreaker2 = CircuitBreakerFactory("/test", pollyQosProvider);
+        circuitBreaker.ShouldNotBe(circuitBreaker2);
+    }
 
-            var route = new DownstreamRouteBuilder()
-                .WithQosOptions(options)
-                .WithUpstreamPathTemplate(upstreamPath).Build();
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.NotImplemented)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    [InlineData(HttpStatusCode.HttpVersionNotSupported)]
+    [InlineData(HttpStatusCode.VariantAlsoNegotiates)]
+    [InlineData(HttpStatusCode.InsufficientStorage)]
+    [InlineData(HttpStatusCode.LoopDetected)]
+    public async Task should_throw_broken_circuit_exception_after_two_exceptions(HttpStatusCode errorCode)
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
 
-            var factory = new Mock<IOcelotLoggerFactory>();
-            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
-            var circuitBreaker = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
-            var circuitBreaker2 = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
-            circuitBreaker.ShouldBe(circuitBreaker2);
-        }
+        var response = new HttpResponseMessage(errorCode);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+    }
 
-        [Fact]
-        public void should_return_different_circuit_breaker_for_two_different_routes()
-        {
-            var options = new QoSOptionsBuilder()
-                .WithTimeoutValue(100)
-                .WithExceptionsAllowedBeforeBreaking(2)
-                .WithDurationOfBreak(200)
-                .Build();
+    [Fact]
+    public async Task should_not_throw_broken_circuit_exception_if_status_code_ok()
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
 
-            var upstreamPath = new UpstreamPathTemplateBuilder()
-                .WithTemplate("/")
-                .WithContainsQueryString(false)
-                .WithPriority(1)
-                .WithOriginalValue("/").Build();
+        var response = new HttpResponseMessage(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
+    }
 
-            var route = new DownstreamRouteBuilder()
-                .WithQosOptions(options)
-                .WithUpstreamPathTemplate(upstreamPath).Build();
+    [Fact]
+    public async Task should_throw_and_before_delay_should_not_allow_requests()
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
 
-            var options2 = new QoSOptionsBuilder()
-                .WithTimeoutValue(100)
-                .WithExceptionsAllowedBeforeBreaking(2)
-                .WithDurationOfBreak(200)
-                .Build();
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
 
-            var upstreamPath2 = new UpstreamPathTemplateBuilder()
-                .WithTemplate("/test2")
-                .WithContainsQueryString(false)
-                .WithPriority(1)
-                .WithOriginalValue("/test2").Build();
+        await Task.Delay(100);
 
-            var route2 = new DownstreamRouteBuilder()
-                .WithQosOptions(options2)
-                .WithUpstreamPathTemplate(upstreamPath2).Build();
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+    }
 
-            var factory = new Mock<IOcelotLoggerFactory>();
-            var pollyQoSProvider = new PollyQoSProvider(factory.Object);
-            var circuitBreaker = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
-            var circuitBreaker2 = pollyQoSProvider.GetCircuitBreaker(route2).ShouldNotBeNull();
-            circuitBreaker.ShouldNotBe(circuitBreaker2);
-        }
+    [Fact]
+    public async Task should_throw_but_after_delay_should_allow_one_more_internal_server_error()
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+                       await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+
+        await Task.Delay(200);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
+    }
+
+    [Fact]
+    public async Task should_throw_but_after_delay_should_allow_one_more_internal_server_error_and_throw()
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+
+        await Task.Delay(200);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+    }
+
+    [Fact]
+    public async Task should_throw_but_after_delay_should_allow_one_more_ok_request_and_put_counter_back_to_zero()
+    {
+        var circuitBreaker = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+
+        await Task.Delay(200);
+
+        var response2 = new HttpResponseMessage(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, (await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response2))).StatusCode);
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response));
+        await Assert.ThrowsAsync<BrokenCircuitException<HttpResponseMessage>>(async () =>
+            await circuitBreaker.CircuitBreakerAsyncPolicy.ExecuteAsync(() => Task.FromResult(response)));
+    }
+
+    private PollyQoSProvider PollyQoSProviderFactory()
+    {
+        var factory = new Mock<IOcelotLoggerFactory>();
+        factory.Setup(x => x.CreateLogger<PollyQoSProvider>())
+            .Returns(new Mock<IOcelotLogger>().Object);
+
+        var pollyQoSProvider = new PollyQoSProvider(factory.Object);
+        return pollyQoSProvider;
+    }
+
+    private static CircuitBreaker<HttpResponseMessage> CircuitBreakerFactory(string routeTemplate, PollyQoSProvider pollyQoSProvider)
+    {
+        var options = new QoSOptionsBuilder()
+            .WithTimeoutValue(100)
+            .WithExceptionsAllowedBeforeBreaking(2)
+            .WithDurationOfBreak(200)
+            .Build();
+
+        var upstreamPath = new UpstreamPathTemplateBuilder()
+            .WithTemplate(routeTemplate)
+            .WithContainsQueryString(false)
+            .WithPriority(1)
+            .WithOriginalValue(routeTemplate).Build();
+
+        var route = new DownstreamRouteBuilder()
+            .WithQosOptions(options)
+            .WithUpstreamPathTemplate(upstreamPath).Build();
+
+        var circuitBreaker = pollyQoSProvider.GetCircuitBreaker(route).ShouldNotBeNull();
+        circuitBreaker.ShouldNotBeNull();
+        circuitBreaker.CircuitBreakerAsyncPolicy.ShouldNotBeNull();
+
+        return circuitBreaker;
     }
 }

--- a/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSProviderTests.cs
@@ -31,7 +31,7 @@ public class PollyQoSProviderTests
     public void should_build_and_wrap_contains_two_policies()
     {
         var pollyQosProvider = PollyQoSProviderFactory();
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", pollyQosProvider);
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", pollyQosProvider);
         var policy = pollyPolicyWrapper.AsyncPollyPolicy;
 
         if (policy is AsyncPolicyWrap<HttpResponseMessage> policyWrap)
@@ -72,7 +72,7 @@ public class PollyQoSProviderTests
     public void should_build_and_contains_one_policy_when_with_exceptions_allowed_before_breaking_is_zero()
     {
         var pollyQosProvider = PollyQoSProviderFactory();
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", pollyQosProvider, true);
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", pollyQosProvider, true);
         var policy = pollyPolicyWrapper.AsyncPollyPolicy;
 
         if (policy is AsyncTimeoutPolicy<HttpResponseMessage> convertedPolicy)
@@ -88,8 +88,8 @@ public class PollyQoSProviderTests
     public void should_return_same_circuit_breaker_for_given_route()
     {
         var pollyQosProvider = PollyQoSProviderFactory();
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", pollyQosProvider);
-        var pollyPolicyWrapper2 = CircuitBreakerFactory("/", pollyQosProvider);
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", pollyQosProvider);
+        var pollyPolicyWrapper2 = PolicyWrapperFactory("/", pollyQosProvider);
         pollyPolicyWrapper.ShouldBe(pollyPolicyWrapper2);
     }
 
@@ -97,8 +97,8 @@ public class PollyQoSProviderTests
     public void should_return_different_circuit_breaker_for_two_different_routes()
     {
         var pollyQosProvider = PollyQoSProviderFactory();
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", pollyQosProvider);
-        var pollyPolicyWrapper2 = CircuitBreakerFactory("/test", pollyQosProvider);
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", pollyQosProvider);
+        var pollyPolicyWrapper2 = PolicyWrapperFactory("/test", pollyQosProvider);
         pollyPolicyWrapper.ShouldNotBe(pollyPolicyWrapper2);
     }
 
@@ -114,7 +114,7 @@ public class PollyQoSProviderTests
     [InlineData(HttpStatusCode.LoopDetected)]
     public async Task should_throw_broken_circuit_exception_after_two_exceptions(HttpStatusCode errorCode)
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(errorCode);
         await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response));
@@ -126,7 +126,7 @@ public class PollyQoSProviderTests
     [Fact]
     public async Task should_not_throw_broken_circuit_exception_if_status_code_ok()
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(HttpStatusCode.OK);
         Assert.Equal(HttpStatusCode.OK, (await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response))).StatusCode);
@@ -137,7 +137,7 @@ public class PollyQoSProviderTests
     [Fact]
     public async Task should_throw_and_before_delay_should_not_allow_requests()
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
         await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response));
@@ -154,7 +154,7 @@ public class PollyQoSProviderTests
     [Fact]
     public async Task should_throw_but_after_delay_should_allow_one_more_internal_server_error()
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
         await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response));
@@ -170,7 +170,7 @@ public class PollyQoSProviderTests
     [Fact]
     public async Task should_throw_but_after_delay_should_allow_one_more_internal_server_error_and_throw()
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
         await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response));
@@ -188,7 +188,7 @@ public class PollyQoSProviderTests
     [Fact]
     public async Task should_throw_but_after_delay_should_allow_one_more_ok_request_and_put_counter_back_to_zero()
     {
-        var pollyPolicyWrapper = CircuitBreakerFactory("/", PollyQoSProviderFactory());
+        var pollyPolicyWrapper = PolicyWrapperFactory("/", PollyQoSProviderFactory());
 
         var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
         await pollyPolicyWrapper.AsyncPollyPolicy.ExecuteAsync(() => Task.FromResult(response));
@@ -216,7 +216,7 @@ public class PollyQoSProviderTests
         return pollyQoSProvider;
     }
 
-    private static PollyPolicyWrapper<HttpResponseMessage> CircuitBreakerFactory(string routeTemplate, PollyQoSProvider pollyQoSProvider, bool inactiveExceptionsAllowedBeforeBreaking = false)
+    private static PollyPolicyWrapper<HttpResponseMessage> PolicyWrapperFactory(string routeTemplate, PollyQoSProvider pollyQoSProvider, bool inactiveExceptionsAllowedBeforeBreaking = false)
     {
         var options = new QoSOptionsBuilder()
             .WithTimeoutValue(5000)

--- a/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Requester/DelegatingHandlerHandlerProviderFactoryTests.cs
@@ -24,7 +24,7 @@ namespace Ocelot.UnitTests.Requester
 
         public DelegatingHandlerHandlerProviderFactoryTests()
         {
-            _qosDelegate = (a, b) => new FakeQoSHandler();
+            _qosDelegate = (a, b, c) => new FakeQoSHandler();
             _tracingFactory = new Mock<ITracingHandlerFactory>();
             _qosFactory = new Mock<IQoSFactory>();
             _loggerFactory = new Mock<IOcelotLoggerFactory>();

--- a/test/Ocelot.UnitTests/Requester/QoSFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Requester/QoSFactoryTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
 using Ocelot.Logging;
@@ -12,13 +13,15 @@ namespace Ocelot.UnitTests.Requester
         private QoSFactory _factory;
         private ServiceCollection _services;
         private readonly Mock<IOcelotLoggerFactory> _loggerFactory;
+        private readonly Mock<IHttpContextAccessor> _contextAccessor;
 
         public QoSFactoryTests()
         {
             _services = new ServiceCollection();
             _loggerFactory = new Mock<IOcelotLoggerFactory>();
+            _contextAccessor = new Mock<IHttpContextAccessor>();
             var provider = _services.BuildServiceProvider();
-            _factory = new QoSFactory(provider, _loggerFactory.Object);
+            _factory = new QoSFactory(provider, _contextAccessor.Object, _loggerFactory.Object);
         }
 
         [Fact]
@@ -34,10 +37,10 @@ namespace Ocelot.UnitTests.Requester
         public void should_return_handler()
         {
             _services = new ServiceCollection();
-            DelegatingHandler QosDelegatingHandlerDelegate(DownstreamRoute a, IOcelotLoggerFactory b) => new FakeDelegatingHandler();
+            DelegatingHandler QosDelegatingHandlerDelegate(DownstreamRoute a, IHttpContextAccessor b, IOcelotLoggerFactory c) => new FakeDelegatingHandler();
             _services.AddSingleton<QosDelegatingHandlerDelegate>(QosDelegatingHandlerDelegate);
             var provider = _services.BuildServiceProvider();
-            _factory = new QoSFactory(provider, _loggerFactory.Object);
+            _factory = new QoSFactory(provider, _contextAccessor.Object, _loggerFactory.Object);
             var downstreamRoute = new DownstreamRouteBuilder().Build();
             var handler = _factory.Get(downstreamRoute);
             handler.IsError.ShouldBeFalse();


### PR DESCRIPTION
## Fixes #1550 #1706 
- #1550 
- #1706 

## Proposed Changes
- We shouldn't create a Circuit Breaker per route / request, only maintain one Circuit Breaker per route
- The Circuit Breaker is Expecting an Exception to kick in, a response with status 500 is not an Exception. If status 500, then throwing.
