### PR TITLE
#1825 #1330 #1287 #1069 Improvements of the multiplexing middleware

### DIFF
--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -13,12 +13,90 @@ We then specify an Aggregate that composes the two Routes using their keys in th
 Obviously you cannot have duplicate **UpstreamPathTemplates** between **Routes** and **Aggregates**.
 You can use all of Ocelot's normal Route options apart from **RequestIdKey** (explained in `gotchas <#gotchas>`_ below).
 
-Advanced Register Your Own Aggregators
---------------------------------------
+Basic Expecting JSON from Downstream Services
+---------------------------------------------
+
+.. code-block:: json
+  {
+    "Routes": [
+      {
+        "UpstreamHttpMethod": [ "Get" ],
+        "UpstreamPathTemplate": "/laura",
+        "DownstreamPathTemplate": "/",
+        "DownstreamScheme": "http",
+        "DownstreamHostAndPorts": [
+          { "Host": "localhost", "Port": 51881 }
+        ],
+        "Key": "Laura"
+      },
+      {
+        "UpstreamHttpMethod": [ "Get" ],
+        "UpstreamPathTemplate": "/tom",
+        "DownstreamPathTemplate": "/",
+        "DownstreamScheme": "http",
+        "DownstreamHostAndPorts": [
+          { "Host": "localhost", "Port": 51882 }
+        ],
+        "Key": "Tom"
+      }
+    ],
+    "Aggregates": [
+      {
+        "UpstreamPathTemplate": "/",
+        "RouteKeys": [
+          "Tom",
+          "Laura"
+        ]
+      }
+    ]
+  }
+
+You can also set **UpstreamHost** and **RouteIsCaseSensitive** in the Aggregate configuration. These behave the same as any other Routes.
+
+If the Route ``/tom`` returned a body of ``{"Age": 19}`` and ``/laura`` returned ``{"Age": 25}``, the the response after aggregation would be as follows:
+
+.. code-block:: json
+
+    {"Tom":{"Age": 19},"Laura":{"Age": 25}}
+
+At the moment the aggregation is very simple. Ocelot just gets the response from your downstream service and sticks it into a JSON dictionary as above.
+With the Route key being the key of the dictionary and the value the response body from your downstream service.
+You can see that the object is just JSON without any pretty spaces etc.
+
+Note, all headers will be lost from the downstream services response.
+
+Ocelot will always return content type ``application/json`` with an aggregate request.
+
+If you downstream services return a `404 Not Found <https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404>`_, the aggregate will just return nothing for that downstream service. 
+It will not change the aggregate response into a ``404`` even if all the downstreams return a ``404``.
+
+Use Complex Aggregation
+-----------------------
+
+Imagine you'd like to use aggregated queries, but you don't know all the parameters of your queries. You first need to call an endpoint to obtain the necessary data, for example a user's id, and then return the user's details.
+
+Let's say we have an endpoint that returns a series of comments with references to various users or threads. The author of the comments is referenced by his Id, but you'd like to return all the details about the author.
+
+Here, you could use aggregation to get 1) all the comments, 2) attach the author details. In fact there are 2 endpoints that are called, but for the 2nd, you dynamically replace the user's Id in the route to obtain the details.
+
+In concrete terms:
+
+1) "/Comments" -> contains the authorId property
+2) "/users/{userId}" with {userId} replaced by authorId to obtain the user's details.
+
+This functionality is still in its early stages, but it does allow you to search for data based on an initial request. To perform the mapping, you need to use **AggregateRouteConfig**.
+
+.. code-block:: csharp
+
+    new AggregateRouteConfig{ RouteKey = "UserDetails", JsonPath = "$[*].authorId", Parameter = "userId" };
+
+**RouteKey** is used as a reference for the route, **JsonPath** indicates where the parameter you are interested in is located in the first request response body and **Parameter** tells us that the value for authorId should be used for the request parameter userId.
+
+Register Your Own Aggregators
+-----------------------------
 
 Ocelot started with just the basic request aggregation and since then we have added a more advanced method that let's the user take in the responses from the 
 downstream services and then aggregate them into a response object.
-
 The **ocelot.json** setup is pretty much the same as the basic aggregation approach apart from you need to add an **Aggregator** property like below:
 
 .. code-block:: json
@@ -98,66 +176,35 @@ In order to make an Aggregator you must implement this interface:
     }
 
 With this feature you can pretty much do whatever you want because the ``HttpContext`` objects contain the results of all the aggregate requests.
-Please note, if the ``HttpClient`` throws an exception when making a request to a Route in the aggregate then you will not get a ``HttpContext`` for it, but you would for any that succeed.
-If it does throw an exception, this will be logged.
 
-Basic Expecting JSON from Downstream Services
----------------------------------------------
+Please note, if the ``HttpClient`` throws an exception when making a request to a Route in the aggregate then you will not get a ``HttpContext`` for it, but you would for any that succeed. If it does throw an exception, this will be logged. 
 
-.. code-block:: json
+Below is an example of an aggregator that you could implement for your solution:
 
+.. code-block:: csharp
+
+  public class FakeDefinedAggregator : IDefinedAggregator
   {
-    "Routes": [
+      public async Task<DownstreamResponse> Aggregate(List<HttpContext> responseHttpContexts)
       {
-        "UpstreamHttpMethod": [ "Get" ],
-        "UpstreamPathTemplate": "/laura",
-        "DownstreamPathTemplate": "/",
-        "DownstreamScheme": "http",
-        "DownstreamHostAndPorts": [
-          { "Host": "localhost", "Port": 51881 }
-        ],
-        "Key": "Laura"
-      },
-      {
-        "UpstreamHttpMethod": [ "Get" ],
-        "UpstreamPathTemplate": "/tom",
-        "DownstreamPathTemplate": "/",
-        "DownstreamScheme": "http",
-        "DownstreamHostAndPorts": [
-          { "Host": "localhost", "Port": 51882 }
-        ],
-        "Key": "Tom"
+          var responses = responseHttpContexts.Select(x => x.Items.DownstreamResponse());
+  
+          var statusCodes = responses.Select(x => x.StatusCode);
+          var headers = responses.SelectMany(x => x.Headers).ToList();
+          var contentList = new List<string>();
+          foreach (var response in responses)
+          {
+              var content = await response.Content.ReadAsStringAsync();
+              contentList.Add(content);
+          }
+  
+          return new DownstreamResponse(
+              new StringContent(JsonConvert.SerializeObject(contentList)),
+              HttpStatusCode.OK,
+              headers,
+              "reason");
       }
-    ],
-    "Aggregates": [
-      {
-        "UpstreamPathTemplate": "/",
-        "RouteKeys": [
-          "Tom",
-          "Laura"
-        ]
-      }
-    ]
   }
-
-You can also set **UpstreamHost** and **RouteIsCaseSensitive** in the Aggregate configuration. These behave the same as any other Routes.
-
-If the Route ``/tom`` returned a body of ``{"Age": 19}`` and ``/laura`` returned ``{"Age": 25}``, the the response after aggregation would be as follows:
-
-.. code-block:: json
-
-    {"Tom":{"Age": 19},"Laura":{"Age": 25}}
-
-At the moment the aggregation is very simple. Ocelot just gets the response from your downstream service and sticks it into a JSON dictionary as above.
-With the Route key being the key of the dictionary and the value the response body from your downstream service.
-You can see that the object is just JSON without any pretty spaces etc.
-
-Note, all headers will be lost from the downstream services response.
-
-Ocelot will always return content type ``application/json`` with an aggregate request.
-
-If you downstream services return a `404 Not Found <https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404>`_, the aggregate will just return nothing for that downstream service. 
-It will not change the aggregate response into a ``404`` even if all the downstreams return a ``404``.
 
 Gotchas
 -------

--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -183,28 +183,31 @@ Below is an example of an aggregator that you could implement for your solution:
 
 .. code-block:: csharp
 
-  public class FakeDefinedAggregator : IDefinedAggregator
-  {
-      public async Task<DownstreamResponse> Aggregate(List<HttpContext> responseHttpContexts)
-      {
-          var responses = responseHttpContexts.Select(x => x.Items.DownstreamResponse());
-  
-          var statusCodes = responses.Select(x => x.StatusCode);
-          var headers = responses.SelectMany(x => x.Headers).ToList();
-          var contentList = new List<string>();
-          foreach (var response in responses)
-          {
-              var content = await response.Content.ReadAsStringAsync();
-              contentList.Add(content);
-          }
-  
-          return new DownstreamResponse(
-              new StringContent(JsonConvert.SerializeObject(contentList)),
-              HttpStatusCode.OK,
-              headers,
-              "reason");
-      }
-  }
+public class FakeDefinedAggregator : IDefinedAggregator
+{
+    public async Task<DownstreamResponse> Aggregate(List<HttpContext> responseHttpContexts)
+    {
+        // The aggregator gets a list of downstream responses as parameter.
+        // You can now implement your own logic to aggregate the responses (including bodies and headers) from the downstream services
+        var responses = responseHttpContexts.Select(x => x.Items.DownstreamResponse()).ToArray();
+
+        // In this example we are concatenating the results,
+        // but you could create a more complex construct, up to you.
+        var contentList = new List<string>();
+        foreach (var response in responses)
+        {
+            var content = await response.Content.ReadAsStringAsync();
+            contentList.Add(content);
+        }
+
+        // The only constraint here: You must return a DownstreamResponse object.
+        return new DownstreamResponse(
+            new StringContent(JsonConvert.SerializeObject(contentList)),
+            HttpStatusCode.OK,
+            responses.SelectMany(x => x.Headers).ToList(),
+            "reason");
+    }
+}
 
 Gotchas
 -------

--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -183,31 +183,31 @@ Below is an example of an aggregator that you could implement for your solution:
 
 .. code-block:: csharp
 
-public class FakeDefinedAggregator : IDefinedAggregator
-{
-    public async Task<DownstreamResponse> Aggregate(List<HttpContext> responseHttpContexts)
-    {
-        // The aggregator gets a list of downstream responses as parameter.
-        // You can now implement your own logic to aggregate the responses (including bodies and headers) from the downstream services
-        var responses = responseHttpContexts.Select(x => x.Items.DownstreamResponse()).ToArray();
-
-        // In this example we are concatenating the results,
-        // but you could create a more complex construct, up to you.
-        var contentList = new List<string>();
-        foreach (var response in responses)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            contentList.Add(content);
-        }
-
-        // The only constraint here: You must return a DownstreamResponse object.
-        return new DownstreamResponse(
-            new StringContent(JsonConvert.SerializeObject(contentList)),
-            HttpStatusCode.OK,
-            responses.SelectMany(x => x.Headers).ToList(),
-            "reason");
-    }
-}
+  public class FakeDefinedAggregator : IDefinedAggregator
+  {
+      public async Task<DownstreamResponse> Aggregate(List<HttpContext> responseHttpContexts)
+      {
+          // The aggregator gets a list of downstream responses as parameter.
+          // You can now implement your own logic to aggregate the responses (including bodies and headers) from the downstream services
+          var responses = responseHttpContexts.Select(x => x.Items.DownstreamResponse()).ToArray();
+  
+          // In this example we are concatenating the results,
+          // but you could create a more complex construct, up to you.
+          var contentList = new List<string>();
+          foreach (var response in responses)
+          {
+              var content = await response.Content.ReadAsStringAsync();
+              contentList.Add(content);
+          }
+  
+          // The only constraint here: You must return a DownstreamResponse object.
+          return new DownstreamResponse(
+              new StringContent(JsonConvert.SerializeObject(contentList)),
+              HttpStatusCode.OK,
+              responses.SelectMany(x => x.Headers).ToList(),
+              "reason");
+      }
+  }
 
 Gotchas
 -------

--- a/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
@@ -25,15 +25,14 @@ namespace Ocelot.Configuration.Creator
             var applicableRoutes = new List<DownstreamRoute>();
             var allRoutes = routes.SelectMany(x => x.DownstreamRoute);
 
-            foreach (var routeKey in aggregateRoute.RouteKeys)
+            foreach (var downstreamRoute in aggregateRoute.RouteKeys.Select(routeKey => allRoutes.FirstOrDefault(q => q.Key == routeKey)))
             {
-                var selec = allRoutes.FirstOrDefault(q => q.Key == routeKey);
-                if (selec == null)
+                if (downstreamRoute == null)
                 {
                     return null;
                 }
 
-                applicableRoutes.Add(selec);
+                applicableRoutes.Add(downstreamRoute);
             }
 
             var upstreamTemplatePattern = _creator.Create(aggregateRoute);

--- a/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/AggregatesCreator.cs
@@ -24,8 +24,8 @@ namespace Ocelot.Configuration.Creator
         {
             var applicableRoutes = new List<DownstreamRoute>();
             var allRoutes = routes.SelectMany(x => x.DownstreamRoute);
-
-            foreach (var downstreamRoute in aggregateRoute.RouteKeys.Select(routeKey => allRoutes.FirstOrDefault(q => q.Key == routeKey)))
+            var downstreamRoutes = aggregateRoute.RouteKeys.Select(routeKey => allRoutes.FirstOrDefault(q => q.Key == routeKey));
+            foreach (var downstreamRoute in downstreamRoutes)
             {
                 if (downstreamRoute == null)
                 {

--- a/src/Ocelot/Middleware/HttpItemsExtensions.cs
+++ b/src/Ocelot/Middleware/HttpItemsExtensions.cs
@@ -70,8 +70,7 @@ namespace Ocelot.Middleware
         public static DownstreamRequest DownstreamRequest(this IDictionary<object, object> input) =>
             input.Get<DownstreamRequest>("DownstreamRequest");
 
-        public static DownstreamResponse 
-            DownstreamResponse(this IDictionary<object, object> input) =>
+        public static DownstreamResponse DownstreamResponse(this IDictionary<object, object> input) =>
             input.Get<DownstreamResponse>("DownstreamResponse");
 
         public static DownstreamRoute DownstreamRoute(this IDictionary<object, object> input) =>

--- a/src/Ocelot/Middleware/HttpItemsExtensions.cs
+++ b/src/Ocelot/Middleware/HttpItemsExtensions.cs
@@ -70,7 +70,8 @@ namespace Ocelot.Middleware
         public static DownstreamRequest DownstreamRequest(this IDictionary<object, object> input) =>
             input.Get<DownstreamRequest>("DownstreamRequest");
 
-        public static DownstreamResponse DownstreamResponse(this IDictionary<object, object> input) =>
+        public static DownstreamResponse 
+            DownstreamResponse(this IDictionary<object, object> input) =>
             input.Get<DownstreamResponse>("DownstreamResponse");
 
         public static DownstreamRoute DownstreamRoute(this IDictionary<object, object> input) =>

--- a/src/Ocelot/Multiplexer/InMemoryResponseAggregatorFactory.cs
+++ b/src/Ocelot/Multiplexer/InMemoryResponseAggregatorFactory.cs
@@ -15,12 +15,7 @@ namespace Ocelot.Multiplexer
 
         public IResponseAggregator Get(Route route)
         {
-            if (!string.IsNullOrEmpty(route.Aggregator))
-            {
-                return _userDefined;
-            }
-
-            return _simple;
+            return !string.IsNullOrEmpty(route.Aggregator) ? _userDefined : _simple;
         }
     }
 }

--- a/src/Ocelot/Multiplexer/InMemoryResponseAggregatorFactory.cs
+++ b/src/Ocelot/Multiplexer/InMemoryResponseAggregatorFactory.cs
@@ -14,8 +14,6 @@ namespace Ocelot.Multiplexer
         }
 
         public IResponseAggregator Get(Route route)
-        {
-            return !string.IsNullOrEmpty(route.Aggregator) ? _userDefined : _simple;
-        }
+            => !string.IsNullOrEmpty(route.Aggregator) ? _userDefined : _simple;
     }
 }

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -106,7 +106,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
 
     /// <summary>
     /// When using route keys, the first route is the main route and the rest are additional routes.
-    /// Since we need to break if the main route response is null, we need to process the main route first.
+    /// Since we need to break if the main route response is null, we must process the main route first.
     /// </summary>
     /// <param name="context">The http context.</param>
     /// <param name="route">The first route, the main route.</param>

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -1,219 +1,260 @@
+using System.Collections;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json.Linq;
 using Ocelot.Configuration;
+using Ocelot.Configuration.File;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Logging;
 using Ocelot.Middleware;
+using Route = Ocelot.Configuration.Route;
 
-namespace Ocelot.Multiplexer
+namespace Ocelot.Multiplexer;
+
+public class MultiplexingMiddleware : OcelotMiddleware
 {
-    public class MultiplexingMiddleware : OcelotMiddleware
+    private readonly RequestDelegate _next;
+    private readonly IResponseAggregatorFactory _factory;
+
+    public MultiplexingMiddleware(RequestDelegate next,
+        IOcelotLoggerFactory loggerFactory,
+        IResponseAggregatorFactory factory
+    )
+        : base(loggerFactory.CreateLogger<MultiplexingMiddleware>())
     {
-        private readonly RequestDelegate _next;
-        private readonly IResponseAggregatorFactory _factory;
+        _factory = factory;
+        _next = next;
+    }
 
-        public MultiplexingMiddleware(
-            RequestDelegate next,
-            IOcelotLoggerFactory loggerFactory,
-            IResponseAggregatorFactory factory)
-            : base(loggerFactory.CreateLogger<MultiplexingMiddleware>())
+    public async Task Invoke(HttpContext httpContext)
+    {
+        var downstreamRouteHolder = httpContext.Items.DownstreamRouteHolder();
+        var route = downstreamRouteHolder.Route;
+        var downstreamRoutes = route.DownstreamRoute;
+
+        // case 1: if websocket request or single downstream route
+        if (ShouldProcessSingleRoute(httpContext, downstreamRoutes))
         {
-            _factory = factory;
-            _next = next;
+            await ProcessSingleRoute(httpContext, downstreamRoutes.First());
+            return;
         }
 
-        public async Task Invoke(HttpContext httpContext)
+        // case 2: if no downstream routes
+        if (downstreamRoutes.Count == 0)
         {
-            var route = httpContext.Items.DownstreamRouteHolder().Route;
-            if (httpContext.WebSockets.IsWebSocketRequest)
-            {
-                // TODO: This is obviously stupid
-                httpContext.Items.UpsertDownstreamRoute(route.DownstreamRoute[0]);
-                await _next.Invoke(httpContext);
-                return;
-            }
-
-            // Don't do anything extra if downstream route is single
-            if (route.DownstreamRoute.Count == 1)
-            {
-                httpContext.Items.UpsertDownstreamRoute(route.DownstreamRoute[0]);
-                var singleResponse = await Fire(httpContext, _next);
-                MapNotAggregate(httpContext, singleResponse);
-                return;
-            }
-
-            if (route.DownstreamRouteConfig?.Any() != true)
-            {
-                var tasks = new Task<HttpContext>[route.DownstreamRoute.Count];
-
-                for (var i = 0; i < route.DownstreamRoute.Count; i++)
-                {
-                    var newHttpContext = Copy(httpContext);
-
-                    newHttpContext.Items
-                        .Add("RequestId", httpContext.Items["RequestId"]);
-                    newHttpContext.Items
-                        .SetIInternalConfiguration(httpContext.Items.IInternalConfiguration());
-                    newHttpContext.Items
-                        .UpsertTemplatePlaceholderNameAndValues(httpContext.Items.TemplatePlaceholderNameAndValues());
-                    newHttpContext.Items
-                        .UpsertDownstreamRoute(route.DownstreamRoute[i]);
-
-                    tasks[i] = Fire(newHttpContext, _next);
-                }
-
-                await Task.WhenAll(tasks);
-
-                var contexts = new List<HttpContext>();
-
-                foreach (var task in tasks)
-                {
-                    var finished = await task;
-                    contexts.Add(finished);
-                }
-
-                await Map(httpContext, route, contexts);
-            }
-            else
-            {
-                httpContext.Items.UpsertDownstreamRoute(route.DownstreamRoute[0]);
-                var mainResponse = await Fire(httpContext, _next);
-
-                var tasks = new List<Task<HttpContext>>();
-
-                if (mainResponse.Items.DownstreamResponse() == null)
-                {
-                    return;
-                }
-
-                var content = await mainResponse.Items.DownstreamResponse().Content.ReadAsStringAsync();
-
-                var jObject = Newtonsoft.Json.Linq.JToken.Parse(content);
-
-                for (var i = 1; i < route.DownstreamRoute.Count; i++)
-                {
-                    var templatePlaceholderNameAndValues = httpContext.Items.TemplatePlaceholderNameAndValues();
-
-                    var downstreamRoute = route.DownstreamRoute[i];
-
-                    var matchAdvancedAgg = route.DownstreamRouteConfig
-                        .FirstOrDefault(q => q.RouteKey == downstreamRoute.Key);
-
-                    if (matchAdvancedAgg != null)
-                    {
-                        var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath).Select(s => s.ToString()).Distinct();
-
-                        foreach (var value in values)
-                        {
-                            var newHttpContext = Copy(httpContext);
-
-                            var tPnv = httpContext.Items.TemplatePlaceholderNameAndValues();
-                            tPnv.Add(new PlaceholderNameAndValue('{' + matchAdvancedAgg.Parameter + '}', value));
-
-                            newHttpContext.Items
-                                .Add("RequestId", httpContext.Items["RequestId"]);
-
-                            newHttpContext.Items
-                                .SetIInternalConfiguration(httpContext.Items.IInternalConfiguration());
-
-                            newHttpContext.Items
-                                .UpsertTemplatePlaceholderNameAndValues(tPnv);
-
-                            newHttpContext.Items
-                                .UpsertDownstreamRoute(downstreamRoute);
-
-                            tasks.Add(Fire(newHttpContext, _next));
-                        }
-                    }
-                    else
-                    {
-                        var newHttpContext = Copy(httpContext);
-
-                        newHttpContext.Items
-                               .Add("RequestId", httpContext.Items["RequestId"]);
-
-                        newHttpContext.Items
-                            .SetIInternalConfiguration(httpContext.Items.IInternalConfiguration());
-
-                        newHttpContext.Items
-                            .UpsertTemplatePlaceholderNameAndValues(templatePlaceholderNameAndValues);
-
-                        newHttpContext.Items
-                            .UpsertDownstreamRoute(downstreamRoute);
-
-                        tasks.Add(Fire(newHttpContext, _next));
-                    }
-                }
-
-                await Task.WhenAll(tasks);
-
-                var contexts = new List<HttpContext> { mainResponse };
-
-                foreach (var task in tasks)
-                {
-                    var finished = await task;
-                    contexts.Add(finished);
-                }
-
-                await Map(httpContext, route, contexts);
-            }
+            return;
         }
 
-        private static HttpContext Copy(HttpContext source)
+        // case 3: if multiple downstream routes
+        var routeKeysConfigs = route.DownstreamRouteConfig;
+        if (routeKeysConfigs == null || !routeKeysConfigs.Any())
         {
-            var target = new DefaultHttpContext();
+            await ProcessRoutes(httpContext, route);
+            return;
+        }
 
-            foreach (var header in source.Request.Headers)
+        // case 4: if multiple downstream routes with route keys
+        var mainResponse = await ProcessMainRoute(httpContext, downstreamRoutes.First());
+        if (mainResponse == null)
+        {
+            return;
+        }
+
+        var tasksList = await ProcessRoutesWithRouteKeys(httpContext, downstreamRoutes, routeKeysConfigs, mainResponse);
+        if (!tasksList.Any())
+        {
+            return;
+        }
+
+        await MapResponses(httpContext, route, mainResponse, tasksList.ToList());
+    }
+
+    /// <summary>
+    /// Helper method to determine if only the first downstream route should be processed.
+    /// It is the case if the request is a websocket request or if there is only one downstream route.
+    /// </summary>
+    /// <param name="context">The http context.</param>
+    /// <param name="routes">The downstream routes.</param>
+    /// <returns>True if only the first downstream route should be processed.</returns>
+    private static bool ShouldProcessSingleRoute(HttpContext context, ICollection routes) => context.WebSockets.IsWebSocketRequest || routes.Count == 1;
+
+    /// <summary>
+    /// Processing a single downstream route (no route keys).
+    /// In that case, no need to make copies of the http context.
+    /// </summary>
+    /// <param name="context">The http context.</param>
+    /// <param name="route">The downstream route.</param>
+    private async Task ProcessSingleRoute(HttpContext context, DownstreamRoute route)
+    {
+        context.Items.UpsertDownstreamRoute(route);
+        await _next.Invoke(context);
+    }
+
+    /// <summary>
+    /// Processing the downstream routes (no route keys).
+    /// </summary>
+    /// <param name="context">The main http context.</param>
+    /// <param name="route">The route.</param>
+    private async Task ProcessRoutes(HttpContext context, Route route)
+    {
+        var tasks = route.DownstreamRoute.Select(downstreamRoute => ProcessRouteAsync(context, downstreamRoute, _next))
+            .ToArray();
+        var contexts = await Task.WhenAll(tasks);
+        await Map(context, route, contexts.ToList());
+    }
+
+    /// <summary>
+    /// When using route keys, the first route is the main route and the rest are additional routes.
+    /// Since we need to break if the main route response is null, we need to process the main route first.
+    /// </summary>
+    /// <param name="context">The http context.</param>
+    /// <param name="route">The first route, the main route.</param>
+    /// <returns>The updated http context.</returns>
+    private async Task<HttpContext> ProcessMainRoute(HttpContext context, DownstreamRoute route)
+    {
+        context.Items.UpsertDownstreamRoute(route);
+        return await Fire(context, _next);
+    }
+
+    /// <summary>
+    /// Processing the downstream routes with route keys except the main route that has already been processed.
+    /// </summary>
+    /// <param name="context">The main http context.</param>
+    /// <param name="routes">The downstream routes.</param>
+    /// <param name="routeKeysConfigs">The route keys config.</param>
+    /// <param name="mainResponse">The response from the main route.</param>
+    /// <returns>A list of the tasks' http contexts.</returns>
+    private async Task<HttpContext[]> ProcessRoutesWithRouteKeys(HttpContext context,
+        IEnumerable<DownstreamRoute> routes, IReadOnlyCollection<AggregateRouteConfig> routeKeysConfigs,
+        HttpContext mainResponse)
+    {
+        var tasksList = new List<Task<HttpContext>>();
+        var content = await mainResponse.Items.DownstreamResponse().Content.ReadAsStringAsync();
+        var jObject = JToken.Parse(content);
+
+        foreach (var downstreamRoute in routes.Skip(1))
+        {
+            var matchAdvancedAgg = routeKeysConfigs.FirstOrDefault(q => q.RouteKey == downstreamRoute.Key);
+            if (matchAdvancedAgg != null)
             {
-                target.Request.Headers.TryAdd(header.Key, header.Value);
+                tasksList.AddRange(ProcessRouteWithAggregation(matchAdvancedAgg, jObject, context, downstreamRoute));
+                continue;
             }
 
-            target.Request.Body = source.Request.Body;
-            target.Request.ContentLength = source.Request.ContentLength;
-            target.Request.ContentType = source.Request.ContentType;
-            target.Request.Host = source.Request.Host;
-            target.Request.Method = source.Request.Method;
-            target.Request.Path = source.Request.Path;
-            target.Request.PathBase = source.Request.PathBase;
-            target.Request.Protocol = source.Request.Protocol;
-            target.Request.Query = source.Request.Query;
-            target.Request.QueryString = source.Request.QueryString;
-            target.Request.Scheme = source.Request.Scheme;
-            target.Request.IsHttps = source.Request.IsHttps;
-            target.Request.RouteValues = source.Request.RouteValues;
-            target.Connection.RemoteIpAddress = source.Connection.RemoteIpAddress;
-            target.RequestServices = source.RequestServices;
-            target.RequestAborted = source.RequestAborted;
-            target.User = source.User;
-            return target;
+            tasksList.Add(ProcessRouteAsync(context, downstreamRoute, _next));
         }
 
-        private async Task Map(HttpContext httpContext, Route route, List<HttpContext> contexts)
+        return await Task.WhenAll(tasksList);
+    }
+
+    /// <summary>
+    /// Mapping responses.
+    /// </summary>
+    private async Task MapResponses(HttpContext context, Route route, HttpContext mainResponse,
+        IEnumerable<HttpContext> additionalResponses)
+    {
+        var contexts = new List<HttpContext> { mainResponse };
+        contexts.AddRange(additionalResponses);
+        await Map(context, route, contexts);
+    }
+
+    /// <summary>
+    /// Processing a route with aggregation.
+    /// </summary>
+    private IEnumerable<Task<HttpContext>> ProcessRouteWithAggregation(AggregateRouteConfig matchAdvancedAgg,
+        JToken jObject, HttpContext httpContext, DownstreamRoute downstreamRoute)
+    {
+        var tasks = new List<Task<HttpContext>>();
+        var values = jObject.SelectTokens(matchAdvancedAgg.JsonPath).Select(s => s.ToString()).Distinct();
+        foreach (var value in values)
         {
-            if (route.DownstreamRoute.Count > 1)
-            {
-                var aggregator = _factory.Get(route);
-                await aggregator.Aggregate(route, httpContext, contexts);
-            }
-            else
-            {
-                // Assume at least one... if this errors then it will be caught by global exception handler
-                MapNotAggregate(httpContext, contexts.First());
-            }
+            var tPnv = httpContext.Items.TemplatePlaceholderNameAndValues();
+            tPnv.Add(new PlaceholderNameAndValue('{' + matchAdvancedAgg.Parameter + '}', value));
+            tasks.Add(ProcessRouteAsync(httpContext, downstreamRoute, _next, tPnv));
         }
 
-        private static void MapNotAggregate(HttpContext httpContext, HttpContext finished)
+        return tasks;
+    }
+
+    /// <summary>
+    /// Process a downstream route asynchronously.
+    /// </summary>
+    /// <returns>The cloned Http context.</returns>
+    private static async Task<HttpContext> ProcessRouteAsync(HttpContext sourceContext, DownstreamRoute route,
+        RequestDelegate next, List<PlaceholderNameAndValue> placeholders = null)
+    {
+        var newHttpContext = CreateThreadContext(sourceContext);
+        CopyItemsToNewContext(newHttpContext, sourceContext, placeholders);
+        newHttpContext.Items.UpsertDownstreamRoute(route);
+
+        return await Fire(newHttpContext, next);
+    }
+
+    /// <summary>
+    /// Copying some needed parameters to the Http context items.
+    /// </summary>
+    private static void CopyItemsToNewContext(HttpContext target, HttpContext source,
+        List<PlaceholderNameAndValue> placeholders = null)
+    {
+        target.Items.Add("RequestId", source.Items["RequestId"]);
+        target.Items.SetIInternalConfiguration(source.Items.IInternalConfiguration());
+        target.Items.UpsertTemplatePlaceholderNameAndValues(placeholders ??
+                                                            source.Items.TemplatePlaceholderNameAndValues());
+    }
+
+    /// <summary>
+    /// Creates a new HttpContext based on the source.
+    /// </summary>
+    /// <param name="source">The base http context.</param>
+    /// <returns>The cloned context.</returns>
+    private static HttpContext CreateThreadContext(HttpContext source)
+    {
+        var target = new DefaultHttpContext();
+
+        foreach (var header in source.Request.Headers)
         {
-            httpContext.Items.UpsertErrors(finished.Items.Errors());
-
-            httpContext.Items.UpsertDownstreamRequest(finished.Items.DownstreamRequest());
-
-            httpContext.Items.UpsertDownstreamResponse(finished.Items.DownstreamResponse());
+            target.Request.Headers[header.Key] = header.Value.ToArray();
         }
 
-        private static async Task<HttpContext> Fire(HttpContext httpContext, RequestDelegate next)
+        target.Request.Body = source.Request.Body; // Consider stream cloning for multiple reads
+        target.Request.ContentLength = source.Request.ContentLength;
+        target.Request.ContentType = source.Request.ContentType;
+        target.Request.Host = source.Request.Host;
+        target.Request.Method = source.Request.Method;
+        target.Request.Path = source.Request.Path;
+        target.Request.PathBase = source.Request.PathBase;
+        target.Request.Protocol = source.Request.Protocol;
+        target.Request.QueryString = source.Request.QueryString;
+        target.Request.Scheme = source.Request.Scheme;
+        target.Request.IsHttps = source.Request.IsHttps;
+
+        target.Request.Query = new QueryCollection(new Dictionary<string, StringValues>(source.Request.Query));
+        target.Request.RouteValues = new RouteValueDictionary(source.Request.RouteValues);
+
+        target.Connection.RemoteIpAddress = source.Connection.RemoteIpAddress;
+
+        // Caution: Directly copying RequestServices might not be safe
+        target.RequestServices = source.RequestServices;
+        target.RequestAborted = source.RequestAborted;
+
+        return target;
+    }
+
+    private async Task Map(HttpContext httpContext, Route route, List<HttpContext> contexts)
+    {
+        if (route.DownstreamRoute.Count == 1)
         {
-            await next.Invoke(httpContext);
-            return httpContext;
+            return;
         }
+
+        var aggregator = _factory.Get(route);
+        await aggregator.Aggregate(route, httpContext, contexts);
+    }
+
+    private static async Task<HttpContext> Fire(HttpContext httpContext, RequestDelegate next)
+    {
+        await next.Invoke(httpContext);
+        return httpContext;
     }
 }

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -237,7 +237,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
         // Caution: Directly copying RequestServices might not be safe
         target.RequestServices = source.RequestServices;
         target.RequestAborted = source.RequestAborted;
-
+        target.User = source.User;
         return target;
     }
 

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -62,7 +62,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
         }
 
         var tasksList = await ProcessRoutesWithRouteKeys(httpContext, downstreamRoutes, routeKeysConfigs, mainResponse);
-        if (!tasksList.Any())
+        if (tasksList.Length == 0)
         {
             return;
         }
@@ -112,10 +112,10 @@ public class MultiplexingMiddleware : OcelotMiddleware
     /// <param name="context">The http context.</param>
     /// <param name="route">The first route, the main route.</param>
     /// <returns>The updated http context.</returns>
-    private async Task<HttpContext> ProcessMainRoute(HttpContext context, DownstreamRoute route)
+    private Task<HttpContext> ProcessMainRoute(HttpContext context, DownstreamRoute route)
     {
         context.Items.UpsertDownstreamRoute(route);
-        return await Fire(context, _next);
+        return Fire(context, _next);
     }
 
     /// <summary>
@@ -152,12 +152,12 @@ public class MultiplexingMiddleware : OcelotMiddleware
     /// <summary>
     /// Mapping responses.
     /// </summary>
-    private async Task MapResponses(HttpContext context, Route route, HttpContext mainResponse,
+    private Task MapResponses(HttpContext context, Route route, HttpContext mainResponse,
         IEnumerable<HttpContext> additionalResponses)
     {
         var contexts = new List<HttpContext> { mainResponse };
         contexts.AddRange(additionalResponses);
-        await Map(context, route, contexts);
+        return Map(context, route, contexts);
     }
 
     /// <summary>
@@ -182,14 +182,14 @@ public class MultiplexingMiddleware : OcelotMiddleware
     /// Process a downstream route asynchronously.
     /// </summary>
     /// <returns>The cloned Http context.</returns>
-    private static async Task<HttpContext> ProcessRouteAsync(HttpContext sourceContext, DownstreamRoute route,
+    private static Task<HttpContext> ProcessRouteAsync(HttpContext sourceContext, DownstreamRoute route,
         RequestDelegate next, List<PlaceholderNameAndValue> placeholders = null)
     {
         var newHttpContext = CreateThreadContext(sourceContext);
         CopyItemsToNewContext(newHttpContext, sourceContext, placeholders);
         newHttpContext.Items.UpsertDownstreamRoute(route);
 
-        return await Fire(newHttpContext, next);
+        return Fire(newHttpContext, next);
     }
 
     /// <summary>

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -126,7 +126,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
     /// <param name="routeKeysConfigs">The route keys config.</param>
     /// <param name="mainResponse">The response from the main route.</param>
     /// <returns>A list of the tasks' http contexts.</returns>
-    private async Task<HttpContext[]> ProcessRoutesWithRouteKeys(HttpContext context,
+    protected virtual async Task<HttpContext[]> ProcessRoutesWithRouteKeys(HttpContext context,
         IEnumerable<DownstreamRoute> routes, IReadOnlyCollection<AggregateRouteConfig> routeKeysConfigs,
         HttpContext mainResponse)
     {

--- a/src/Ocelot/Multiplexer/ServiceLocatorDefinedAggregatorProvider.cs
+++ b/src/Ocelot/Multiplexer/ServiceLocatorDefinedAggregatorProvider.cs
@@ -15,9 +15,9 @@ namespace Ocelot.Multiplexer
 
         public Response<IDefinedAggregator> Get(Route route)
         {
-            if (_aggregators.ContainsKey(route.Aggregator))
+            if (_aggregators.TryGetValue(route.Aggregator, out var aggregator))
             {
-                return new OkResponse<IDefinedAggregator>(_aggregators[route.Aggregator]);
+                return new OkResponse<IDefinedAggregator>(aggregator);
             }
 
             return new ErrorResponse<IDefinedAggregator>(new CouldNotFindAggregatorError(route.Aggregator));

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -4,8 +4,11 @@ using IdentityServer4.Models;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Ocelot.AcceptanceTests.Authentication;
 using Ocelot.Configuration.File;
@@ -15,17 +18,21 @@ using Ocelot.Multiplexer;
 
 namespace Ocelot.AcceptanceTests
 {
-    public class AggregateTests : IDisposable
+    public sealed class AggregateTests : Steps, IDisposable
     {
-        private readonly Steps _steps;
         private readonly ServiceHandler _serviceHandler;
         private readonly string[] _downstreamPaths;
 
         public AggregateTests()
         {
             _serviceHandler = new ServiceHandler();
-            _steps = new Steps();
             _downstreamPaths = new string[3];
+        }
+
+        public override void Dispose()
+        {
+            _serviceHandler.Dispose();
+            base.Dispose();
         }
 
         [Fact]
@@ -134,11 +141,11 @@ namespace Ocelot.AcceptanceTests
             var expected = "{\"key1\":some_data,\"key2\":some_data}";
 
             this.Given(x => x.GivenServiceIsRunning($"http://localhost:{port}", 200, "some_data"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/EmpDetail/US/1"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/EmpDetail/US/1"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
                 .BDDfy();
         }
 
@@ -233,11 +240,11 @@ namespace Ocelot.AcceptanceTests
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, commentsResponseContent))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/users/1", 200, userDetailsResponseContent))
                 .Given(x => x.GivenServiceIsRunning(2, port3, "/posts/2", 200, postDetailsResponseContent))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
                 .BDDfy();
         }
 
@@ -304,11 +311,11 @@ namespace Ocelot.AcceptanceTests
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, "{Hello from Laura}"))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 200, "{Hello from Tom}"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<FakeDefinedAggregator, FakeDep>())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<FakeDefinedAggregator, FakeDep>())
+                .When(x => WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
                 .And(x => ThenTheDownstreamUrlPathShouldBe("/", "/"))
                 .BDDfy();
         }
@@ -324,11 +331,11 @@ namespace Ocelot.AcceptanceTests
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, "{Hello from Laura}"))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 200, "{Hello from Tom}"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("{\"Laura\":{Hello from Laura},\"Tom\":{Hello from Tom}}"))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe("{\"Laura\":{Hello from Laura},\"Tom\":{Hello from Tom}}"))
                 .And(x => ThenTheDownstreamUrlPathShouldBe("/", "/"))
                 .BDDfy();
         }
@@ -394,11 +401,11 @@ namespace Ocelot.AcceptanceTests
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 404, ""))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 200, "{Hello from Tom}"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
                 .And(x => ThenTheDownstreamUrlPathShouldBe("/", "/"))
                 .BDDfy();
         }
@@ -464,11 +471,11 @@ namespace Ocelot.AcceptanceTests
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 404, ""))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 404, ""))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
                 .And(x => ThenTheDownstreamUrlPathShouldBe("/", "/"))
                 .BDDfy();
         }
@@ -532,16 +539,16 @@ namespace Ocelot.AcceptanceTests
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, "{Hello from Laura}"))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 200, "{Hello from Tom}"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIMakeLotsOfDifferentRequestsToTheApiGateway())
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIMakeLotsOfDifferentRequestsToTheApiGateway())
                 .And(x => ThenTheDownstreamUrlPathShouldBe("/", "/"))
                 .BDDfy();
         }
 
         [Fact]
         [Trait("Bug", "1396")]
-        public void should_return_response_200_with_user_forwarding()
+        public void Should_return_response_200_with_user_forwarding()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
@@ -651,7 +658,36 @@ namespace Ocelot.AcceptanceTests
             });
         }
 
-        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPathOne, string expectedDownstreamPath)
+        private void GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<TAggregator, TDependency>()
+            where TAggregator : class, IDefinedAggregator
+            where TDependency : class
+        {
+            _webHostBuilder = new WebHostBuilder();
+
+            _webHostBuilder
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
+                    var env = hostingContext.HostingEnvironment;
+                    config.AddJsonFile("appsettings.json", true, false)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", true, false);
+                    config.AddJsonFile(_ocelotConfigFileName, true, false);
+                    config.AddEnvironmentVariables();
+                })
+                .ConfigureServices(s =>
+                {
+                    s.AddSingleton(_webHostBuilder);
+                    s.AddSingleton<TDependency>();
+                    s.AddOcelot()
+                        .AddSingletonDefinedAggregator<TAggregator>();
+                })
+                .Configure(a => { a.UseOcelot().Wait(); });
+
+            _ocelotServer = new TestServer(_webHostBuilder);
+            _ocelotClient = _ocelotServer.CreateClient();
+        }
+
+        private void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPathOne, string expectedDownstreamPath)
         {
             _downstreamPaths[0].ShouldBe(expectedDownstreamPathOne);
             _downstreamPaths[1].ShouldBe(expectedDownstreamPath);
@@ -667,24 +703,18 @@ namespace Ocelot.AcceptanceTests
             Key = key,
         };
 
-        private static FileConfiguration GivenConfiguration(params FileRoute[] routes) => new()
+        private static new FileConfiguration GivenConfiguration(params FileRoute[] routes)
         {
-            Routes = [..routes],
-            Aggregates =
-            [
-                new FileAggregateRoute
+            var obj = Steps.GivenConfiguration(routes);
+            obj.Aggregates.Add(
+                new()
                 {
                     UpstreamPathTemplate = "/",
                     UpstreamHost = "localhost",
                     RouteKeys = routes.Select(r => r.Key).ToList(), // [ "Laura", "Tom" ],
-                },
-            ],
-        };
-
-        public void Dispose()
-        {
-            _serviceHandler.Dispose();
-            _steps.Dispose();
+                }
+            );
+            return obj;
         }
     }
 

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -30,99 +30,101 @@ namespace Ocelot.AcceptanceTests
 
         [Fact]
         [Trait("Issue", "597")]
-        public void should_fix_issue_597()
+        public void Should_fix_issue_597()
         {
             var port = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
-                {
-                    new()
+                Routes =
+                [
+                    new FileRoute
                     {
                         DownstreamPathTemplate = "/api/values?MailId={userid}",
                         UpstreamPathTemplate = "/key1data/{userid}",
-                        UpstreamHttpMethod = new List<string> {"Get"},
+                        UpstreamHttpMethod = ["Get"],
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
                                 Host = "localhost",
                                 Port = port,
                             },
-                        },
+                        ],
                         Key = "key1",
                     },
-                    new()
+                    new FileRoute
                     {
                         DownstreamPathTemplate = "/api/values?MailId={userid}",
                         UpstreamPathTemplate = "/key2data/{userid}",
-                        UpstreamHttpMethod = new List<string> {"Get"},
+                        UpstreamHttpMethod = ["Get"],
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
                                 Host = "localhost",
                                 Port = port,
                             },
-                        },
+                        ],
                         Key = "key2",
                     },
-                    new()
+                    new FileRoute
                     {
                         DownstreamPathTemplate = "/api/values?MailId={userid}",
                         UpstreamPathTemplate = "/key3data/{userid}",
-                        UpstreamHttpMethod = new List<string> {"Get"},
+                        UpstreamHttpMethod = ["Get"],
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
                                 Host = "localhost",
                                 Port = port,
                             },
-                        },
+                        ],
                         Key = "key3",
                     },
-                    new()
+                    new FileRoute
                     {
                         DownstreamPathTemplate = "/api/values?MailId={userid}",
                         UpstreamPathTemplate = "/key4data/{userid}",
-                        UpstreamHttpMethod = new List<string> {"Get"},
+                        UpstreamHttpMethod = ["Get"],
                         DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
                                 Host = "localhost",
                                 Port = port,
                             },
-                        },
+                        ],
                         Key = "key4",
                     },
-                },
-                Aggregates = new List<FileAggregateRoute>
-                {
-                    new()
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
                     {
-                        RouteKeys = new List<string>{
+                        RouteKeys =
+                        [
                             "key1",
                             "key2",
                             "key3",
-                            "key4",
-                        },
+                            "key4"
+                        ],
                         UpstreamPathTemplate = "/EmpDetail/IN/{userid}",
                     },
-                    new()
+                    new FileAggregateRoute
                     {
-                        RouteKeys = new List<string>{
+                        RouteKeys =
+                        [
                             "key1",
-                            "key2",
-                        },
+                            "key2"
+                        ],
                         UpstreamPathTemplate = "/EmpDetail/US/{userid}",
                     },
-                },
+                ],
                 GlobalConfiguration = new FileGlobalConfiguration
                 {
                     RequestIdKey = "CorrelationID",
@@ -141,83 +143,85 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_response_200_with_advanced_aggregate_configs()
+        public void Should_return_response_200_with_advanced_aggregate_configs()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
             var port3 = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
+                Routes =
+                [
+                    new FileRoute
                     {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port1,
-                                },
+                                Host = "localhost",
+                                Port = port1,
                             },
-                            UpstreamPathTemplate = "/Comments",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Comments",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/users/{userId}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port2,
-                                },
-                            },
-                            UpstreamPathTemplate = "/UserDetails",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "UserDetails",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/posts/{postId}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port3,
-                                },
-                            },
-                            UpstreamPathTemplate = "/PostDetails",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "PostDetails",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/Comments",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Comments",
                     },
-                Aggregates = new List<FileAggregateRoute>
+                    new FileRoute
                     {
-                        new()
-                        {
-                            UpstreamPathTemplate = "/",
-                            UpstreamHost = "localhost",
-                            RouteKeys = new List<string>
+                        DownstreamPathTemplate = "/users/{userId}",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                "Comments",
-                                "UserDetails",
-                                "PostDetails",
+                                Host = "localhost",
+                                Port = port2,
                             },
-                            RouteKeysConfig = new List<AggregateRouteConfig>()
-                            {
-                                new(){RouteKey = "UserDetails",JsonPath = "$[*].writerId",Parameter = "userId"},
-                                new(){RouteKey = "PostDetails",JsonPath = "$[*].postId",Parameter = "postId"},
-                            },
-                        },
+                        ],
+                        UpstreamPathTemplate = "/UserDetails",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "UserDetails",
                     },
+                    new FileRoute
+                    {
+                        DownstreamPathTemplate = "/posts/{postId}",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
+                            {
+                                Host = "localhost",
+                                Port = port3,
+                            },
+                        ],
+                        UpstreamPathTemplate = "/PostDetails",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "PostDetails",
+                    },
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys =
+                        [
+                            "Comments",
+                            "UserDetails",
+                            "PostDetails"
+                        ],
+                        RouteKeysConfig =
+                        [
+                            new AggregateRouteConfig
+                                { RouteKey = "UserDetails", JsonPath = "$[*].writerId", Parameter = "userId" },
+                            new AggregateRouteConfig
+                                { RouteKey = "PostDetails", JsonPath = "$[*].postId", Parameter = "postId" },
+                        ],
+                    },
+                ],
             };
 
             var userDetailsResponseContent = @"{""id"":1,""firstName"":""abolfazl"",""lastName"":""rajabpour""}";
@@ -238,61 +242,62 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_response_200_with_simple_url_user_defined_aggregate()
+        public void Should_return_response_200_with_simple_url_user_defined_aggregate()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
+                Routes =
+                [
+                    new FileRoute
                     {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port1,
-                                },
+                                Host = "localhost",
+                                Port = port1,
                             },
-                            UpstreamPathTemplate = "/laura",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Laura",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port2,
-                                },
-                            },
-                            UpstreamPathTemplate = "/tom",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Tom",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/laura",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Laura",
                     },
-                Aggregates = new List<FileAggregateRoute>
+
+                    new FileRoute
                     {
-                        new()
-                        {
-                            UpstreamPathTemplate = "/",
-                            UpstreamHost = "localhost",
-                            RouteKeys = new List<string>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                "Laura",
-                                "Tom",
+                                Host = "localhost",
+                                Port = port2,
                             },
-                            Aggregator = "FakeDefinedAggregator",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/tom",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Tom",
                     },
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys =
+                        [
+                            "Laura",
+                            "Tom"
+                        ],
+                        Aggregator = "FakeDefinedAggregator",
+                    },
+                ],
             };
 
             var expected = "Bye from Laura, Bye from Tom";
@@ -300,7 +305,7 @@ namespace Ocelot.AcceptanceTests
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, "{Hello from Laura}"))
                 .Given(x => x.GivenServiceIsRunning(1, port2, "/", 200, "{Hello from Tom}"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<FakeDefinedAggregator, FakeDepdendency>())
+                .And(x => _steps.GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<FakeDefinedAggregator, FakeDep>())
                 .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
                 .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
                 .And(x => _steps.ThenTheResponseBodyShouldBe(expected))
@@ -309,7 +314,7 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_response_200_with_simple_url()
+        public void Should_return_response_200_with_simple_url()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
@@ -329,60 +334,60 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_response_200_with_simple_url_one_service_404()
+        public void Should_return_response_200_with_simple_url_one_service_404()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
+                Routes =
+                [
+                    new FileRoute
                     {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port1,
-                                },
+                                Host = "localhost",
+                                Port = port1,
                             },
-                            UpstreamPathTemplate = "/laura",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Laura",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port2,
-                                },
-                            },
-                            UpstreamPathTemplate = "/tom",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Tom",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/laura",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Laura",
                     },
-                Aggregates = new List<FileAggregateRoute>
+                    new FileRoute
                     {
-                        new()
-                        {
-                            UpstreamPathTemplate = "/",
-                            UpstreamHost = "localhost",
-                            RouteKeys = new List<string>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                "Laura",
-                                "Tom",
+                                Host = "localhost",
+                                Port = port2,
                             },
-                        },
+                        ],
+                        UpstreamPathTemplate = "/tom",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Tom",
                     },
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys =
+                        [
+                            "Laura",
+                            "Tom"
+                        ],
+                    },
+                ],
             };
 
             var expected = "{\"Laura\":,\"Tom\":{Hello from Tom}}";
@@ -399,60 +404,60 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_return_response_200_with_simple_url_both_service_404()
+        public void Should_return_response_200_with_simple_url_both_service_404()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
+                Routes =
+                [
+                    new FileRoute
                     {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port1,
-                                },
+                                Host = "localhost",
+                                Port = port1,
                             },
-                            UpstreamPathTemplate = "/laura",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Laura",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port2,
-                                },
-                            },
-                            UpstreamPathTemplate = "/tom",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Tom",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/laura",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Laura",
                     },
-                Aggregates = new List<FileAggregateRoute>
+                    new FileRoute
                     {
-                        new()
-                        {
-                            UpstreamPathTemplate = "/",
-                            UpstreamHost = "localhost",
-                            RouteKeys = new List<string>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                "Laura",
-                                "Tom",
+                                Host = "localhost",
+                                Port = port2,
                             },
-                        },
+                        ],
+                        UpstreamPathTemplate = "/tom",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Tom",
                     },
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys =
+                        [
+                            "Laura",
+                            "Tom"
+                        ],
+                    },
+                ],
             };
 
             var expected = "{\"Laura\":,\"Tom\":}";
@@ -469,60 +474,60 @@ namespace Ocelot.AcceptanceTests
         }
 
         [Fact]
-        public void should_be_thread_safe()
+        public void Should_be_thread_safe()
         {
             var port1 = PortFinder.GetRandomPort();
             var port2 = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
             {
-                Routes = new List<FileRoute>
+                Routes =
+                [
+                    new FileRoute
                     {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port1,
-                                },
+                                Host = "localhost",
+                                Port = port1,
                             },
-                            UpstreamPathTemplate = "/laura",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Laura",
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port2,
-                                },
-                            },
-                            UpstreamPathTemplate = "/tom",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            Key = "Tom",
-                        },
+                        ],
+                        UpstreamPathTemplate = "/laura",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Laura",
                     },
-                Aggregates = new List<FileAggregateRoute>
+                    new FileRoute
                     {
-                        new()
-                        {
-                            UpstreamPathTemplate = "/",
-                            UpstreamHost = "localhost",
-                            RouteKeys = new List<string>
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts =
+                        [
+                            new FileHostAndPort
                             {
-                                "Laura",
-                                "Tom",
+                                Host = "localhost",
+                                Port = port2,
                             },
-                        },
+                        ],
+                        UpstreamPathTemplate = "/tom",
+                        UpstreamHttpMethod = ["Get"],
+                        Key = "Tom",
                     },
+                ],
+                Aggregates =
+                [
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys =
+                        [
+                            "Laura",
+                            "Tom"
+                        ],
+                    },
+                ],
             };
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/", 200, "{Hello from Laura}"))
@@ -606,14 +611,14 @@ namespace Ocelot.AcceptanceTests
             }
 
             // Assert
-            for (int i = 0; i < actualContexts.Length; i++)
+            for (var i = 0; i < actualContexts.Length; i++)
             {
                 var ctx = actualContexts[i].ShouldNotBeNull();
                 ctx.Items.DownstreamRoute().Key.ShouldBe(configuration.Routes[i].Key);
                 var user = ctx.User.ShouldNotBeNull();
                 user.IsAuthenticated().ShouldBeTrue();
                 user.Claims.Count().ShouldBeGreaterThan(1);
-                user.Claims.FirstOrDefault(c => c.Type == "scope" && c.Value == "api").ShouldNotBeNull();
+                user.Claims.FirstOrDefault(c => c is { Type: "scope", Value: "api" }).ShouldNotBeNull();
             }
         }
 
@@ -636,7 +641,7 @@ namespace Ocelot.AcceptanceTests
                 if (_downstreamPaths[index] != basePath)
                 {
                     context.Response.StatusCode = statusCode;
-                    await context.Response.WriteAsync("downstream path didnt match base path");
+                    await context.Response.WriteAsync("downstream path didn't match base path");
                 }
                 else
                 {
@@ -656,7 +661,7 @@ namespace Ocelot.AcceptanceTests
         {
             DownstreamPathTemplate = "/",
             DownstreamScheme = Uri.UriSchemeHttp,
-            DownstreamHostAndPorts = [new("localhost", port)],
+            DownstreamHostAndPorts = [new FileHostAndPort("localhost", port)],
             UpstreamPathTemplate = upstream,
             UpstreamHttpMethod = [HttpMethods.Get],
             Key = key,
@@ -664,10 +669,10 @@ namespace Ocelot.AcceptanceTests
 
         private static FileConfiguration GivenConfiguration(params FileRoute[] routes) => new()
         {
-            Routes = new(routes),
+            Routes = [..routes],
             Aggregates =
             [
-                new()
+                new FileAggregateRoute
                 {
                     UpstreamPathTemplate = "/",
                     UpstreamHost = "localhost",
@@ -683,17 +688,14 @@ namespace Ocelot.AcceptanceTests
         }
     }
 
-    public class FakeDepdendency
+    public class FakeDep
     {
     }
 
     public class FakeDefinedAggregator : IDefinedAggregator
     {
-        private readonly FakeDepdendency _dep;
-
-        public FakeDefinedAggregator(FakeDepdendency dep)
+        public FakeDefinedAggregator(FakeDep dep)
         {
-            _dep = dep;
         }
 
         public async Task<DownstreamResponse> Aggregate(List<HttpContext> responses)

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -19,7 +19,6 @@ using Ocelot.DependencyInjection;
 using Ocelot.LoadBalancer.LoadBalancers;
 using Ocelot.Logging;
 using Ocelot.Middleware;
-using Ocelot.Multiplexer;
 using Ocelot.Provider.Consul;
 using Ocelot.Provider.Eureka;
 using Ocelot.Provider.Polly;
@@ -503,36 +502,6 @@ public class Steps : IDisposable
                 s.AddOcelot()
                     .AddDelegatingHandler<TOne>()
                     .AddDelegatingHandler<TWo>();
-            })
-            .Configure(a => { a.UseOcelot().Wait(); });
-
-        _ocelotServer = new TestServer(_webHostBuilder);
-
-        _ocelotClient = _ocelotServer.CreateClient();
-    }
-
-    public void GivenOcelotIsRunningWithSpecificAggregatorsRegisteredInDi<TAggregator, TDependency>()
-        where TAggregator : class, IDefinedAggregator
-        where TDependency : class
-    {
-        _webHostBuilder = new WebHostBuilder();
-
-        _webHostBuilder
-            .ConfigureAppConfiguration((hostingContext, config) =>
-            {
-                config.SetBasePath(hostingContext.HostingEnvironment.ContentRootPath);
-                var env = hostingContext.HostingEnvironment;
-                config.AddJsonFile("appsettings.json", true, false)
-                    .AddJsonFile($"appsettings.{env.EnvironmentName}.json", true, false);
-                config.AddJsonFile(_ocelotConfigFileName, true, false);
-                config.AddEnvironmentVariables();
-            })
-            .ConfigureServices(s =>
-            {
-                s.AddSingleton(_webHostBuilder);
-                s.AddSingleton<TDependency>();
-                s.AddOcelot()
-                    .AddSingletonDefinedAggregator<TAggregator>();
             })
             .Configure(a => { a.UseOcelot().Wait(); });
 

--- a/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
@@ -64,7 +64,7 @@ namespace Ocelot.UnitTests.Multiplexing
             GivenUser("test", "Copy", nameof(Copy_User_ToTarget));
 
             // Act
-            var method = _middleware.GetType().GetMethod("Copy", BindingFlags.NonPublic | BindingFlags.Static);
+            var method = _middleware.GetType().GetMethod("CreateThreadContext", BindingFlags.NonPublic | BindingFlags.Static);
             HttpContext actual = (HttpContext)method.Invoke(_middleware, [_httpContext]);
 
             // Assert


### PR DESCRIPTION
## Closes #1825 #1287 #1069 
- #1825 
- #1287 
- #1069 

## Includes #1330 
- #1330 

## Proposed Changes
  - Reviewed Multiplexing middleware with comments and code splitting
  - Shouldn't create a new HttpContext if only 1 downstream Route
  - Should Process the downstream Route directly, without parallelization logic if 1 Route


Some benchmarks (based on develop branch 30.11.2023):
![image](https://github.com/ThreeMammals/Ocelot/assets/58469901/e5f6532a-9733-47d7-89f7-584bdda79739)
Before

![image](https://github.com/ThreeMammals/Ocelot/assets/58469901/87bbde0b-9227-4b36-aa58-3eb7a23396b1)
After

We have a performance increase of around 6% if only 1 downstream route.

@raman-m @RaynaldM
