### PR TITLE
#1724 Reverting back HttpClient full buffering

### DIFF
--- a/src/Ocelot/Requester/HttpClientWrapper.cs
+++ b/src/Ocelot/Requester/HttpClientWrapper.cs
@@ -12,13 +12,9 @@ namespace Ocelot.Requester
             Client = client;
         }
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-            CancellationToken cancellationToken = default)
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
         {
-            // https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet
-            // When using this option, we avoid the intermediate MemoryStream buffer, instead of getting the content directly from the stream exposed on the Socket.
-            // This avoids unnecessary allocations which is a goal in highly optimised situations.
-            return Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            return Client.SendAsync(request, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Follows up #1724 
- #1724 


After testing the new http message invoker pool on a test environment, we noticed that some resources were not being released. After further checks, we realised that some streams were not being closed correctly. 

This doesn't appear in the application with the standard http client, but I made a mistake by adding the ```HttpCompletionOption.ResponseHeadersRead``` property when calling the SendAsync method, which could potentially cause the same problems as with the new message invoker pool. 

A revert should therefore be performed for the time being, and this problem will be addressed in the new message invoker pool.

🙈 🙉 🙊 

## Proposed Changes
- Reverting back `HttpClientWrapper` keeping the full buffering for now. Usage of the new option is out of scope and hazardous!!!
