### PR TITLE
#479 UpstreamPathTemplate hard-coded priority 0

### DIFF
--- a/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
@@ -30,7 +30,7 @@ namespace Ocelot.Configuration.Creator
                     //hack to handle /{url} case
                     if (ForwardSlashAndOnePlaceHolder(upstreamTemplate, placeholders, postitionOfPlaceHolderClosingBracket))
                     {
-                        return new UpstreamPathTemplate(RegExForwardSlashAndOnePlaceHolder, 0, false, route.UpstreamPathTemplate);
+                        return new UpstreamPathTemplate(RegExForwardSlashAndOnePlaceHolder, route.Priority, false, route.UpstreamPathTemplate);
                     }
                 }
             }

--- a/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
@@ -30,7 +30,7 @@ namespace Ocelot.Configuration.Creator
                     //hack to handle /{url} case
                     if (ForwardSlashAndOnePlaceHolder(upstreamTemplate, placeholders, postitionOfPlaceHolderClosingBracket))
                     {
-                        return new UpstreamPathTemplate(RegExForwardSlashAndOnePlaceHolder, route.Priority, false, route.UpstreamPathTemplate);
+                        return new UpstreamPathTemplate(RegExForwardSlashAndOnePlaceHolder, route.Priority + int.MinValue, false, route.UpstreamPathTemplate);
                     }
                 }
             }

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -43,7 +43,7 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenTheFollowingFileRoute(fileRoute))
                 .When(x => x.WhenICreateTheTemplatePattern())
                 .Then(x => x.ThenTheFollowingIsReturned("^(?i)/orders/.+$"))
-                .And(x => ThenThePriorityIs(0))
+                .And(x => ThenThePriorityIs(0 + int.MinValue))
                 .BDDfy();
         }
 
@@ -59,7 +59,7 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenTheFollowingFileRoute(fileRoute))
                 .When(x => x.WhenICreateTheTemplatePattern())
                 .Then(x => x.ThenTheFollowingIsReturned("^/.*"))
-                .And(x => ThenThePriorityIs(0))
+                .And(x => ThenThePriorityIs(0 + int.MinValue))
                 .BDDfy();
         }
 
@@ -185,7 +185,7 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenTheFollowingFileRoute(fileRoute))
                 .When(x => x.WhenICreateTheTemplatePattern())
                 .Then(x => x.ThenTheFollowingIsReturned("^/.*"))
-                .And(x => ThenThePriorityIs(0))
+                .And(x => ThenThePriorityIs(0 + int.MinValue))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -53,7 +53,7 @@ namespace Ocelot.UnitTests.Configuration
             var fileRoute = new FileRoute
             {
                 UpstreamPathTemplate = "/{catchAll}",
-                Priority = 1,
+                Priority = 0,
             };
 
             this.Given(x => x.GivenTheFollowingFileRoute(fileRoute))

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -179,6 +179,7 @@ namespace Ocelot.UnitTests.Configuration
             var fileRoute = new FileRoute
             {
                 UpstreamPathTemplate = "/{url}",
+                Priority = 0,
             };
 
             this.Given(x => x.GivenTheFollowingFileRoute(fileRoute))


### PR DESCRIPTION
## Fixes #479 
- #479 

## Proposed Changes
  - Fix UpstreamPathTemplate hard-coded priority 0 : Change the priority during a template path "{" to be route.Priority
