### PR TITLE
fixed PollyQoSTests AcceptanceTests

### DIFF
--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -20,7 +20,7 @@ public static class OcelotBuilderExtensions
         {typeof(TaskCanceledException), e => new RequestTimedOutError(e)},
         {typeof(TimeoutRejectedException), e => new RequestTimedOutError(e)},
         {typeof(BrokenCircuitException), e => new RequestTimedOutError(e)},
-        {typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e)}
+        {typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e)},
     };
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
@@ -36,26 +36,23 @@ public static class OcelotBuilderExtensions
         return builder;
     }
 
-
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
-        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, GetDelegatingHandlerV7, errorMapping);
+        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> 
+        => AddPolly<T>(builder, GetDelegatingHandler, errorMapping);
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
-        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, delegatingHandler, ErrorMapping);
+        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> 
+        => AddPolly<T>(builder, delegatingHandler, ErrorMapping);
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
-        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, GetDelegatingHandlerV7, ErrorMapping);
+        where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage> 
+        => AddPolly<T>(builder, GetDelegatingHandler, ErrorMapping);
 
-    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
-    {
-        return AddPolly<PollyQoSResiliencePipelineProvider>(builder, GetDelegatingHandler, ErrorMapping);
-    }
+    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder) 
+        => AddPolly<PollyQoSResiliencePipelineProvider>(builder, GetDelegatingHandler, ErrorMapping);
 
     private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
-        => new PollyPoliciesDelegatingHandler(route, contextAccessor, loggerFactory);
+        => new PollyResiliencePipelineDelegatingHandler(route, contextAccessor, loggerFactory);
 
     #region Obsolete (to remove in a future verison)
     public static IOcelotBuilder AddPollyV7<T>(this IOcelotBuilder builder,
@@ -90,7 +87,6 @@ public static class OcelotBuilderExtensions
 
     private static DelegatingHandler GetDelegatingHandlerV7(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
         => new PollyPoliciesDelegatingHandler(route, contextAccessor, loggerFactory);
-
 
     #endregion
 }

--- a/src/Ocelot.Provider.Polly/PollyQoSResiliencePipelineProvider.cs
+++ b/src/Ocelot.Provider.Polly/PollyQoSResiliencePipelineProvider.cs
@@ -41,6 +41,8 @@ public class PollyQoSResiliencePipelineProvider : IPollyQoSResiliencePipelinePro
 
     public ResiliencePipeline<HttpResponseMessage> GetResiliencePipeline(DownstreamRoute route)
     {
+        // TODO: use ResiliencePipelineRegistry<TKey>.GetOrAddPipeline, it is thread-safe
+        // do the check if we need pipeline at all before calling GetOrAddPipeline
         lock (_lockObject)
         {
             var currentRouteName = GetRouteName(route);
@@ -74,7 +76,7 @@ public class PollyQoSResiliencePipelineProvider : IPollyQoSResiliencePipelinePro
             {
                 FailureRatio = 0.8,
                 SamplingDuration = TimeSpan.FromSeconds(10),
-                MinimumThroughput = 2, //route.QosOptions.ExceptionsAllowedBeforeBreaking,
+                MinimumThroughput = route.QosOptions.ExceptionsAllowedBeforeBreaking, 
                 BreakDuration = TimeSpan.FromMilliseconds(route.QosOptions.DurationOfBreak),
                 ShouldHandle = new PredicateBuilder<HttpResponseMessage>()
                     .HandleResult(message => ServerErrorCodes.Contains(message.StatusCode))


### PR DESCRIPTION
Fixes / New Feature #

The most significant changes involve updates to the `OcelotBuilderExtensions` and `PollyQoSResiliencePipelineProvider` classes, as well as modifications to the `PollyQoSTests` class.

In the `OcelotBuilderExtensions` class, the `GetDelegatingHandler` method is now used instead of `GetDelegatingHandlerV7` in the `AddPolly` methods. The `AddPolly` method without parameters has been simplified using a lambda expression. The `GetDelegatingHandler` method now returns a new instance of `PollyResiliencePipelineDelegatingHandler` instead of `PollyPoliciesDelegatingHandler`.

In the `PollyQoSResiliencePipelineProvider` class, a comment has been added suggesting the use of `ResiliencePipelineRegistry<TKey>.GetOrAddPipeline` due to its thread-safe nature. The `MinimumThroughput` property in `circuitBreakerStrategyOptions` now uses the value from `route.QosOptions.ExceptionsAllowedBeforeBreaking`.

In the `PollyQoSTests` class, the `QoSOptions` used in the test configurations have been updated. Two tests, `Should_open_circuit_breaker_then_close` and `Open_circuit_should_not_effect_different_route`, have been modified to repeat the same request as the minimum `ExceptionsAllowedBeforeBreaking` is now 2. The `GivenThereIsAPossiblyBrokenServiceRunningOn` method now delays for 2.1 seconds when the request count is 2, to ensure the circuit is open.

## Proposed Changes

1. `OcelotBuilderExtensions` class updated to use `GetDelegatingHandler` method.
2. `AddPolly` methods in `OcelotBuilderExtensions` class simplified.
3. `GetDelegatingHandler` method in `OcelotBuilderExtensions` class now returns a new instance of `PollyResiliencePipelineDelegatingHandler`.
4. Comment added in `PollyQoSResiliencePipelineProvider` class suggesting the use of `ResiliencePipelineRegistry<TKey>.GetOrAddPipeline`.
5. `MinimumThroughput` property in `circuitBreakerStrategyOptions` updated to use value from `route.QosOptions.ExceptionsAllowedBeforeBreaking`.
6. `QoSOptions` in `PollyQoSTests` class updated.
7. `Should_open_circuit_breaker_then_close` and `Open_circuit_should_not_effect_different_route` tests in `PollyQoSTests` class updated.
8. `GivenThereIsAPossiblyBrokenServiceRunningOn` method in `PollyQoSTests` class updated to delay for 2.1 seconds when request count is 2.

