### PR TITLE
Use `ResiliencePipelineRegistry` 

### DIFF
--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -9,6 +9,7 @@ using Ocelot.Provider.Polly.Interfaces;
 using Ocelot.Requester;
 
 using Polly.CircuitBreaker;
+using Polly.Registry;
 using Polly.Timeout;
 
 namespace Ocelot.Provider.Polly;
@@ -29,6 +30,7 @@ public static class OcelotBuilderExtensions
         where T : class, IPollyQoSResiliencePipelineProvider<HttpResponseMessage>
     {
         builder.Services
+            .AddSingleton<ResiliencePipelineRegistry<OcelotResiliencePipelineKey>>()
             .AddSingleton(errorMapping)
             .AddSingleton<IPollyQoSResiliencePipelineProvider<HttpResponseMessage>, T>()
             .AddSingleton(delegatingHandler);

--- a/src/Ocelot.Provider.Polly/OcelotResiliencePipelineKey.cs
+++ b/src/Ocelot.Provider.Polly/OcelotResiliencePipelineKey.cs
@@ -1,0 +1,12 @@
+using Polly.Registry;
+
+namespace Ocelot.Provider.Polly;
+
+/// <summary>
+/// Object used to identify a resilience pipeline in <see cref="ResiliencePipelineRegistry{OcelotResiliencePipelineKey}"/>.
+/// </summary>
+/// <value>
+/// Object used to identify a resilience pipeline in <see cref="ResiliencePipelineRegistry{OcelotResiliencePipelineKey}"/>
+/// </value>
+/// <param name="Key">The key for the resilience pipeline.</param>
+public record OcelotResiliencePipelineKey(string Key);

--- a/src/Ocelot/Configuration/QoSOptions.cs
+++ b/src/Ocelot/Configuration/QoSOptions.cs
@@ -32,10 +32,41 @@ namespace Ocelot.Configuration
             TimeoutValue = timeoutValue;
         }
 
+        /// <summary>
+        /// How long the circuit should stay open before resetting in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// If using Polly version 8 or above, this value must be 500 (0.5 sec) or greater.
+        /// </remarks>
+        /// <value>
+        /// How long the circuit should stay open before resetting in milliseconds
+        /// </value>
         public int DurationOfBreak { get; }
+
+        /// <summary>
+        /// How many times a circuit can fail before being set to open.
+        /// </summary>
+        /// <remarks>
+        /// If using Polly version 8 or above, this value must be 2 or greater.
+        /// </remarks>
+        /// <value>
+        /// How many times a circuit can fail before being set to open
+        /// </value>
         public int ExceptionsAllowedBeforeBreaking { get; }
+
         public string Key { get; }
+
+        /// <summary>
+        /// Value for TimeoutStrategy in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// If using Polly version 8 or above, this value must be 1000 (1 sec) or greater.
+        /// </remarks>
+        /// <value>
+        /// Value for TimeoutStrategy in milliseconds
+        /// </value>
         public int TimeoutValue { get; }
+
         public bool UseQos => ExceptionsAllowedBeforeBreaking > 0 || TimeoutValue > 0;
     }
 }

--- a/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
+++ b/test/Ocelot.AcceptanceTests/PollyQoSTests.cs
@@ -56,7 +56,7 @@ namespace Ocelot.AcceptanceTests
             var port = PortFinder.GetRandomPort();
             var configuration = FileConfigurationFactory(port, new QoSOptions(0, 0, 1000, null), HttpMethods.Post);
 
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 201, string.Empty, 1000))
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", 201, string.Empty, 2100))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunningWithPolly())
                 .And(x => _steps.GivenThePostHasContent("postContent"))

--- a/test/Ocelot.UnitTests/Polly/PollyQoSResiliencePipelineProviderTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyQoSResiliencePipelineProviderTests.cs
@@ -4,6 +4,7 @@ using Ocelot.Logging;
 using Ocelot.Provider.Polly;
 
 using Polly.CircuitBreaker;
+using Polly.Registry;
 using Polly.Testing;
 using Polly.Timeout;
 
@@ -16,7 +17,7 @@ namespace Ocelot.UnitTests.Polly
         {
             var options = new QoSOptionsBuilder()
                 .WithTimeoutValue(1000) // 1s, minimum required by Polly
-                .WithExceptionsAllowedBeforeBreaking(1)
+                .WithExceptionsAllowedBeforeBreaking(2)
                 .WithDurationOfBreak(500) // 0.5s, minimum required by Polly
                 .Build();
 
@@ -25,7 +26,8 @@ namespace Ocelot.UnitTests.Polly
                 .Build();
 
             var loggerFactoryMock = new Mock<IOcelotLoggerFactory>();
-            var pollyQoSResiliencePipelineProvider = new PollyQoSResiliencePipelineProvider(loggerFactoryMock.Object);
+            var resiliencePipelineRegistry = new ResiliencePipelineRegistry<OcelotResiliencePipelineKey>();
+            var pollyQoSResiliencePipelineProvider = new PollyQoSResiliencePipelineProvider(loggerFactoryMock.Object, resiliencePipelineRegistry);
             var resiliencePipeline = pollyQoSResiliencePipelineProvider.GetResiliencePipeline(route);
             resiliencePipeline.ShouldNotBeNull();
         }
@@ -40,6 +42,10 @@ namespace Ocelot.UnitTests.Polly
             var resiliencePipeline1 = pollyQoSResiliencePipelineProvider.GetResiliencePipeline(route1);
             var resiliencePipeline2 = pollyQoSResiliencePipelineProvider.GetResiliencePipeline(route2);
             resiliencePipeline1.ShouldBe(resiliencePipeline2);
+
+            var resiliencePipeline3 = pollyQoSResiliencePipelineProvider.GetResiliencePipeline(route1);
+            resiliencePipeline3.ShouldBe(resiliencePipeline1);
+            resiliencePipeline3.ShouldBe(resiliencePipeline2);
         }
 
         [Fact]
@@ -212,10 +218,12 @@ namespace Ocelot.UnitTests.Polly
         private static PollyQoSResiliencePipelineProvider PollyQoSResiliencePipelineProviderFactory()
         {
             var loggerFactoryMock = new Mock<IOcelotLoggerFactory>();
-            loggerFactoryMock.Setup(x => x.CreateLogger<PollyQoSResiliencePipelineProvider>())
+            loggerFactoryMock
+                .Setup(x => x.CreateLogger<PollyQoSResiliencePipelineProvider>())
                 .Returns(new Mock<IOcelotLogger>().Object);
+            var resiliencePipelineRegistry = new ResiliencePipelineRegistry<OcelotResiliencePipelineKey>();
 
-            var pollyQoSResiliencePipelineProvider = new PollyQoSResiliencePipelineProvider(loggerFactoryMock.Object);
+            var pollyQoSResiliencePipelineProvider = new PollyQoSResiliencePipelineProvider(loggerFactoryMock.Object, resiliencePipelineRegistry);
             return pollyQoSResiliencePipelineProvider;
         }
 


### PR DESCRIPTION
Fixes / New Feature #

Use `ResiliencePipelineRegistry`  in `PollyQoSResiliencePipelineProvider`. This new implementation replaces the previous dictionary-based approach for managing cache for resilience pipelines.

## Proposed Changes

  - switched `Dictionary<string, ResiliencePipeline<HttpResponseMessage>>` to `ResiliencePipelineRegistry` for caching in `PollyQoSResiliencePipelineProvider`
  - adjusted tests
