### PR TITLE
#849 #1496 Extend the route key format used for load balancing making it unique

### DIFF
--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -24,33 +24,18 @@ namespace Ocelot.Configuration.Creator
                 Append(upstreamHttpMethod, ',');
             }
 
-            Append(fileRoute.UpstreamHost);
             Append(fileRoute.UpstreamPathTemplate);
-
-            if (!string.IsNullOrEmpty(fileRoute.ServiceName))
-            {
-                Append(fileRoute.ServiceNamespace);
-                Append(fileRoute.ServiceName);
-            }
-            else
-            {
-                foreach (var downstreamHostAndPorts in fileRoute.DownstreamHostAndPorts)
-                {
-                    Append(downstreamHostAndPorts.Host);
-                    Append(downstreamHostAndPorts.Port.ToString(), ':');
-                }
-            }
+            Append(fileRoute.UpstreamHost);
+            Append(fileRoute.ServiceNamespace);
+            Append(fileRoute.ServiceName);
+            Append(fileRoute.LoadBalancerOptions.Type);
+            Append(fileRoute.LoadBalancerOptions.Key);
 
             return keyBuilder.ToString();
 
             // Helper function for appending a part to the key, automatically inserts a separator as needed
             void Append(string next, char separator = '|')
             {
-                if (string.IsNullOrEmpty(next))
-                {
-                    return;
-                }
-
                 if (keyBuilder.Length > 0)
                 {
                     keyBuilder.Append(separator);

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -18,18 +18,24 @@ namespace Ocelot.Configuration.Creator
                 return $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}";
             }
 
+            // Build the key from the route's properties using the format:
+            // UpstreamHttpMethod|UpstreamPathTemplate|UpstreamHost|ServiceNamespace|ServiceName|LoadBalancerType|LoadBalancerKey
             var keyBuilder = new StringBuilder();
+
+            // UpstreamHttpMethod and UpstreamPathTemplate are required
             foreach (var upstreamHttpMethod in fileRoute.UpstreamHttpMethod)
             {
                 Append(upstreamHttpMethod, ',');
             }
 
             Append(fileRoute.UpstreamPathTemplate);
-            Append(fileRoute.UpstreamHost);
-            Append(fileRoute.ServiceNamespace);
-            Append(fileRoute.ServiceName);
-            Append(fileRoute.LoadBalancerOptions.Type);
-            Append(fileRoute.LoadBalancerOptions.Key);
+
+            // Other properties are optional, use constants for missing values to aid debugging
+            Append(CoalesceNullOrWhiteSpace(fileRoute.UpstreamHost, "no-host"));
+            Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceNamespace, "no-svc-ns"));
+            Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceName, "no-svc-name"));
+            Append(CoalesceNullOrWhiteSpace(fileRoute.LoadBalancerOptions.Type, "no-lb-type"));
+            Append(CoalesceNullOrWhiteSpace(fileRoute.LoadBalancerOptions.Key, "no-lb-key"));
 
             return keyBuilder.ToString();
 
@@ -43,6 +49,8 @@ namespace Ocelot.Configuration.Creator
 
                 keyBuilder.Append(next);
             }
+
+            string CoalesceNullOrWhiteSpace(string first, string second) => string.IsNullOrWhiteSpace(first) ? second : first;
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -43,13 +43,14 @@ namespace Ocelot.Configuration.Creator
 
             return keyBuilder.ToString();
 
-            // Helper method for appending a part to the key, automatically inserts a separator as needed
+            // Helper function for appending a part to the key, automatically inserts a separator as needed
             void Append(string next, char separator = '|')
             {
                 if (string.IsNullOrEmpty(next))
                 {
                     return;
                 }
+
                 if (keyBuilder.Length > 0)
                 {
                     keyBuilder.Append(separator);

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -5,13 +5,54 @@ namespace Ocelot.Configuration.Creator
 {
     public class RouteKeyCreator : IRouteKeyCreator
     {
-        public string Create(FileRoute fileRoute) => IsStickySession(fileRoute)
-            ? $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}"
-            : $"{fileRoute.UpstreamPathTemplate}|{string.Join(',', fileRoute.UpstreamHttpMethod)}|{string.Join(',', fileRoute.DownstreamHostAndPorts.Select(x => $"{x.Host}:{x.Port}"))}";
+        public string Create(FileRoute fileRoute)
+        {
+            var isStickySession = fileRoute.LoadBalancerOptions is
+            {
+                Type: nameof(CookieStickySessions),
+                Key.Length: > 0
+            };
 
-        private static bool IsStickySession(FileRoute fileRoute) =>
-            !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Type)
-            && !string.IsNullOrEmpty(fileRoute.LoadBalancerOptions.Key)
-            && fileRoute.LoadBalancerOptions.Type == nameof(CookieStickySessions);
+            if (isStickySession)
+            {
+                return $"{nameof(CookieStickySessions)}:{fileRoute.LoadBalancerOptions.Key}";
+            }
+
+            var keyBuilder = new StringBuilder();
+            foreach (var upstreamHttpMethod in fileRoute.UpstreamHttpMethod)
+            {
+                Append(upstreamHttpMethod, ',');
+            }
+
+            Append(fileRoute.UpstreamHost);
+            Append(fileRoute.UpstreamPathTemplate);
+
+            if (!string.IsNullOrEmpty(fileRoute.ServiceName))
+            {
+                Append(fileRoute.ServiceNamespace);
+                Append(fileRoute.ServiceName);
+            }
+            else
+            {
+                foreach (var downstreamHostAndPorts in fileRoute.DownstreamHostAndPorts)
+                {
+                    Append(downstreamHostAndPorts.Host);
+                    Append(downstreamHostAndPorts.Port.ToString(), ':');
+                }
+            }
+
+            return keyBuilder.ToString();
+
+            // Helper method for appending a part to the key, automatically inserts a separator as needed
+            void Append(string next, char separator = '|')
+            {
+                if (keyBuilder.Length > 0)
+                {
+                    keyBuilder.Append(separator);
+                }
+
+                keyBuilder.Append(next);
+            }
+        }
     }
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -24,23 +24,23 @@ namespace Ocelot.Configuration.Creator
 
             // UpstreamHttpMethod and UpstreamPathTemplate are required
             var upstreamHttpMethods = Csv(fileRoute.UpstreamHttpMethod);
-            Append(upstreamHttpMethods);
-            Append(fileRoute.UpstreamPathTemplate);
+            Append(keyBuilder, upstreamHttpMethods);
+            Append(keyBuilder, fileRoute.UpstreamPathTemplate);
 
             // Other properties are optional, replace undefined values with defaults to aid debugging
-            Append(CoalesceNullOrWhiteSpace(fileRoute.UpstreamHost, "no-host"));
+            Append(keyBuilder, Coalesce(fileRoute.UpstreamHost, "no-host"));
 
             var downstreamHostAndPorts = Csv(fileRoute.DownstreamHostAndPorts.Select(downstream => $"{downstream.Host}:{downstream.Port}"));
-            Append(CoalesceNullOrWhiteSpace(downstreamHostAndPorts, "no-host-and-port"));
-            Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceNamespace, "no-svc-ns"));
-            Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceName, "no-svc-name"));
-            Append(CoalesceNullOrWhiteSpace(fileRoute.LoadBalancerOptions.Type, "no-lb-type"));
-            Append(CoalesceNullOrWhiteSpace(fileRoute.LoadBalancerOptions.Key, "no-lb-key"));
+            Append(keyBuilder, Coalesce(downstreamHostAndPorts, "no-host-and-port"));
+            Append(keyBuilder, Coalesce(fileRoute.ServiceNamespace, "no-svc-ns"));
+            Append(keyBuilder, Coalesce(fileRoute.ServiceName, "no-svc-name"));
+            Append(keyBuilder, Coalesce(fileRoute.LoadBalancerOptions.Type, "no-lb-type"));
+            Append(keyBuilder, Coalesce(fileRoute.LoadBalancerOptions.Key, "no-lb-key"));
 
             return keyBuilder.ToString();
 
             // Helper function to append a string to the keyBuilder, separated by a pipe
-            void Append(string next)
+            static void Append(StringBuilder keyBuilder, string next)
             {
                 if (keyBuilder.Length > 0)
                 {
@@ -51,10 +51,10 @@ namespace Ocelot.Configuration.Creator
             }
 
             // Helper function to convert multiple strings into a comma-separated string
-            string Csv(IEnumerable<string> values) => string.Join(',', values);
+            static string Csv(IEnumerable<string> values) => string.Join(',', values);
 
             // Helper function to return the first non-null-or-whitespace string
-            string CoalesceNullOrWhiteSpace(string first, string second) => string.IsNullOrWhiteSpace(first) ? second : first;
+            static string Coalesce(string first, string second) => string.IsNullOrWhiteSpace(first) ? second : first;
         }
     }
 }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -19,7 +19,7 @@ namespace Ocelot.Configuration.Creator
             }
 
             // Build the key from the route's properties using the format:
-            // UpstreamHttpMethod|UpstreamPathTemplate|UpstreamHost|ServiceNamespace|ServiceName|LoadBalancerType|LoadBalancerKey
+            // UpstreamHttpMethod|UpstreamPathTemplate|UpstreamHost|DownstreamHostAndPorts|ServiceNamespace|ServiceName|LoadBalancerType|LoadBalancerKey
             var keyBuilder = new StringBuilder();
 
             // UpstreamHttpMethod and UpstreamPathTemplate are required

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -46,6 +46,10 @@ namespace Ocelot.Configuration.Creator
             // Helper method for appending a part to the key, automatically inserts a separator as needed
             void Append(string next, char separator = '|')
             {
+                if (string.IsNullOrEmpty(next))
+                {
+                    return;
+                }
                 if (keyBuilder.Length > 0)
                 {
                     keyBuilder.Append(separator);

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -5,6 +5,17 @@ namespace Ocelot.Configuration.Creator;
 
 public class RouteKeyCreator : IRouteKeyCreator
 {
+    /// <summary>
+    /// Creates the unique <see langword="string"/> key based on the route properties for load balancing etc.
+    /// </summary>
+    /// <remarks>
+    /// Key template:
+    /// <list type="bullet">
+    /// <item>UpstreamHttpMethod|UpstreamPathTemplate|UpstreamHost|DownstreamHostAndPorts|ServiceNamespace|ServiceName|LoadBalancerType|LoadBalancerKey</item>
+    /// </list>
+    /// </remarks>
+    /// <param name="fileRoute">The route object.</param>
+    /// <returns>A <see langword="string"/> object containing the key.</returns>
     public string Create(FileRoute fileRoute)
     {
         var isStickySession = fileRoute.LoadBalancerOptions is
@@ -21,8 +32,6 @@ public class RouteKeyCreator : IRouteKeyCreator
         var upstreamHttpMethods = Csv(fileRoute.UpstreamHttpMethod);
         var downstreamHostAndPorts = Csv(fileRoute.DownstreamHostAndPorts.Select(downstream => $"{downstream.Host}:{downstream.Port}"));
 
-        // Build the key from the route's properties using the format:
-        // UpstreamHttpMethod|UpstreamPathTemplate|UpstreamHost|DownstreamHostAndPorts|ServiceNamespace|ServiceName|LoadBalancerType|LoadBalancerKey
         var keyBuilder = new StringBuilder()
 
             // UpstreamHttpMethod and UpstreamPathTemplate are required

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -23,15 +23,15 @@ namespace Ocelot.Configuration.Creator
             var keyBuilder = new StringBuilder();
 
             // UpstreamHttpMethod and UpstreamPathTemplate are required
-            foreach (var upstreamHttpMethod in fileRoute.UpstreamHttpMethod)
-            {
-                Append(upstreamHttpMethod, ',');
-            }
-
+            var upstreamHttpMethods = Csv(fileRoute.UpstreamHttpMethod);
+            Append(upstreamHttpMethods);
             Append(fileRoute.UpstreamPathTemplate);
 
-            // Other properties are optional, use constants for missing values to aid debugging
+            // Other properties are optional, replace undefined values with defaults to aid debugging
             Append(CoalesceNullOrWhiteSpace(fileRoute.UpstreamHost, "no-host"));
+
+            var downstreamHostAndPorts = Csv(fileRoute.DownstreamHostAndPorts.Select(downstream => $"{downstream.Host}:{downstream.Port}"));
+            Append(CoalesceNullOrWhiteSpace(downstreamHostAndPorts, "no-host-and-port"));
             Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceNamespace, "no-svc-ns"));
             Append(CoalesceNullOrWhiteSpace(fileRoute.ServiceName, "no-svc-name"));
             Append(CoalesceNullOrWhiteSpace(fileRoute.LoadBalancerOptions.Type, "no-lb-type"));
@@ -39,17 +39,21 @@ namespace Ocelot.Configuration.Creator
 
             return keyBuilder.ToString();
 
-            // Helper function for appending a part to the key, automatically inserts a separator as needed
-            void Append(string next, char separator = '|')
+            // Helper function to append a string to the keyBuilder, separated by a pipe
+            void Append(string next)
             {
                 if (keyBuilder.Length > 0)
                 {
-                    keyBuilder.Append(separator);
+                    keyBuilder.Append('|');
                 }
 
                 keyBuilder.Append(next);
             }
 
+            // Helper function to convert multiple strings into a comma-separated string
+            string Csv(IEnumerable<string> values) => string.Join(',', values);
+
+            // Helper function to return the first non-null-or-whitespace string
             string CoalesceNullOrWhiteSpace(string first, string second) => string.IsNullOrWhiteSpace(first) ? second : first;
         }
     }

--- a/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RouteKeyCreator.cs
@@ -45,7 +45,7 @@ public class RouteKeyCreator : IRouteKeyCreator
             .AppendNext(Coalesce(fileRoute.ServiceNamespace, "no-svc-ns"))
             .AppendNext(Coalesce(fileRoute.ServiceName, "no-svc-name"))
             .AppendNext(Coalesce(fileRoute.LoadBalancerOptions.Type, "no-lb-type"))
-            .AppendNext(Coalesce(fileRoute.LoadBalancerOptions.Key, "no-lb-ke"));
+            .AppendNext(Coalesce(fileRoute.LoadBalancerOptions.Key, "no-lb-key"));
 
         return keyBuilder.ToString();
     }

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -18,44 +18,40 @@ namespace Ocelot.LoadBalancer.LoadBalancers
         {
             try
             {
-                Response<ILoadBalancer> result;
-
                 if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
                 {
                     // TODO Fix ugly reflection issue of dymanic detection in favor of static type property
                     if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
                     {
-                        result = _factory.Get(route, config);
-                        if (result.IsError)
-                        {
-                            return new ErrorResponse<ILoadBalancer>(result.Errors);
-                        }
-
-                        loadBalancer = result.Data;
-                        AddLoadBalancer(route.LoadBalancerKey, loadBalancer);
+                        return GetResponse(route, config);
                     }
 
                     return new OkResponse<ILoadBalancer>(loadBalancer);
                 }
 
-                result = _factory.Get(route, config);
-
-                if (result.IsError)
-                {
-                    return new ErrorResponse<ILoadBalancer>(result.Errors);
-                }
-
-                loadBalancer = result.Data;
-                AddLoadBalancer(route.LoadBalancerKey, loadBalancer);
-                return new OkResponse<ILoadBalancer>(loadBalancer);
+                return GetResponse(route, config);
             }
             catch (Exception ex)
             {
-                return new ErrorResponse<ILoadBalancer>(new List<Errors.Error>
-                {
-                    new UnableToFindLoadBalancerError($"unabe to find load balancer for {route.LoadBalancerKey} exception is {ex}"),
-                });
+                return new ErrorResponse<ILoadBalancer>(
+                [
+                    new UnableToFindLoadBalancerError($"Unable to find load balancer for '{route.LoadBalancerKey}'. Exception: {ex};"),
+                ]);
             }
+        }
+
+        private Response<ILoadBalancer> GetResponse(DownstreamRoute route, ServiceProviderConfiguration config)
+        {
+            var result = _factory.Get(route, config);
+
+            if (result.IsError)
+            {
+                return new ErrorResponse<ILoadBalancer>(result.Errors);
+            }
+
+            var loadBalancer = result.Data;
+            AddLoadBalancer(route.LoadBalancerKey, loadBalancer);
+            return new OkResponse<ILoadBalancer>(loadBalancer);
         }
 
         private void AddLoadBalancer(string key, ILoadBalancer loadBalancer)

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -16,29 +16,14 @@ namespace Ocelot.LoadBalancer.LoadBalancers
 
         public Response<ILoadBalancer> Get(DownstreamRoute route, ServiceProviderConfiguration config)
         {
+            if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
+            {
+                return new OkResponse<ILoadBalancer>(loadBalancer);
+            }
+
             try
             {
-                Response<ILoadBalancer> result;
-
-                if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
-                {
-                    if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
-                    {
-                        result = _factory.Get(route, config);
-                        if (result.IsError)
-                        {
-                            return new ErrorResponse<ILoadBalancer>(result.Errors);
-                        }
-
-                        loadBalancer = result.Data;
-                        AddLoadBalancer(route.LoadBalancerKey, loadBalancer);
-                    }
-
-                    return new OkResponse<ILoadBalancer>(loadBalancer);
-                }
-
-                result = _factory.Get(route, config);
-
+                var result = _factory.Get(route, config);
                 if (result.IsError)
                 {
                     return new ErrorResponse<ILoadBalancer>(result.Errors);

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -18,12 +18,27 @@ namespace Ocelot.LoadBalancer.LoadBalancers
         {
             try
             {
+                Response<ILoadBalancer> result;
+
                 if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
                 {
+                    if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
+                    {
+                        result = _factory.Get(route, config);
+                        if (result.IsError)
+                        {
+                            return new ErrorResponse<ILoadBalancer>(result.Errors);
+                        }
+
+                        loadBalancer = result.Data;
+                        AddLoadBalancer(route.LoadBalancerKey, loadBalancer);
+                    }
+
                     return new OkResponse<ILoadBalancer>(loadBalancer);
                 }
 
-                var result = _factory.Get(route, config);
+                result = _factory.Get(route, config);
+
                 if (result.IsError)
                 {
                     return new ErrorResponse<ILoadBalancer>(result.Errors);

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -22,6 +22,7 @@ namespace Ocelot.LoadBalancer.LoadBalancers
 
                 if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
                 {
+                    // TODO Fix ugly reflection issue of dymanic detection in favor of static type property
                     if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
                     {
                         result = _factory.Get(route, config);

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -16,13 +16,13 @@ namespace Ocelot.LoadBalancer.LoadBalancers
 
         public Response<ILoadBalancer> Get(DownstreamRoute route, ServiceProviderConfiguration config)
         {
-            if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
-            {
-                return new OkResponse<ILoadBalancer>(loadBalancer);
-            }
-
             try
             {
+                if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
+                {
+                    return new OkResponse<ILoadBalancer>(loadBalancer);
+                }
+
                 var result = _factory.Get(route, config);
                 if (result.IsError)
                 {

--- a/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
+++ b/src/Ocelot/LoadBalancer/LoadBalancers/LoadBalancerHouse.cs
@@ -22,8 +22,6 @@ namespace Ocelot.LoadBalancer.LoadBalancers
 
                 if (_loadBalancers.TryGetValue(route.LoadBalancerKey, out var loadBalancer))
                 {
-                    loadBalancer = _loadBalancers[route.LoadBalancerKey];
-
                     if (route.LoadBalancerOptions.Type != loadBalancer.GetType().Name)
                     {
                         result = _factory.Get(route, config);

--- a/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
@@ -550,8 +550,8 @@ namespace Ocelot.AcceptanceTests
 
             // Ocelot request for http://us-shop/ should find 'product-us' in Consul, call /products and return "Phone chargers with US plug"
             // Ocelot request for http://eu-shop/ should find 'product-eu' in Consul, call /products and return "Phone chargers with EU plug"
-            this.Given(x => x._serviceHandler.GivenThereIsAServiceRunningOn(downstreamServiceUrlUS, "/products", OkResponse("/products", responseBodyUS)))
-                .And(x => x._serviceHandler2.GivenThereIsAServiceRunningOn(downstreamServiceUrlEU, "/products", OkResponse("/products", responseBodyEU)))
+            this.Given(x => x._serviceHandler.GivenThereIsAServiceRunningOn(downstreamServiceUrlUS, "/products", MapGet("/products", responseBodyUS)))
+                .And(x => x._serviceHandler2.GivenThereIsAServiceRunningOn(downstreamServiceUrlEU, "/products", MapGet("/products", responseBodyEU)))
                 .And(x => x.GivenThereIsAFakeConsulServiceDiscoveryProvider(fakeConsulServiceDiscoveryUrl))
                 .And(x => x.GivenTheServicesAreRegisteredWithConsul(serviceEntryUS, serviceEntryEU))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
@@ -718,7 +718,7 @@ namespace Ocelot.AcceptanceTests
             });
         }
 
-        private RequestDelegate OkResponse(string path, string responseBody) => async context =>
+        private RequestDelegate MapGet(string path, string responseBody) => async context =>
         {
             var downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
             if (downstreamPath == path)

--- a/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscoveryTests.cs
@@ -548,8 +548,8 @@ namespace Ocelot.AcceptanceTests
                 },
             };
 
-            // Scenario 1: GET request for http://us-shop/ (Host: us-shop) to Ocelot should look up 'product-us' in Consul, call its /products and return "Phone chargers with US plug"
-            // Scenario 2: GET request for http://eu-shop/ (Host: eu-shop) to Ocelot should look up 'product-eu' in Consul, call its /products and return "Phone chargers with EU plug"
+            // Ocelot request for http://us-shop/ should find 'product-us' in Consul, call /products and return "Phone chargers with US plug"
+            // Ocelot request for http://eu-shop/ should find 'product-eu' in Consul, call /products and return "Phone chargers with EU plug"
             this.Given(x => x._serviceHandler.GivenThereIsAServiceRunningOn(downstreamServiceUrlUS, "/products", OkResponse("/products", responseBodyUS)))
                 .And(x => x._serviceHandler2.GivenThereIsAServiceRunningOn(downstreamServiceUrlEU, "/products", OkResponse("/products", responseBodyEU)))
                 .And(x => x.GivenThereIsAFakeConsulServiceDiscoveryProvider(fakeConsulServiceDiscoveryUrl))

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -269,9 +269,14 @@ public class Steps : IDisposable
         _ocelotClient = _ocelotServer.CreateClient();
     }
 
-    public void GivenOcelotIsRunningWithConsul()
+    public void GivenOcelotIsRunningWithConsul(params string[] urlsToListenOn)
     {
         _webHostBuilder = new WebHostBuilder();
+
+        if (urlsToListenOn?.Length > 0)
+        {
+            _webHostBuilder.UseUrls(urlsToListenOn);
+        }
 
         _webHostBuilder
             .ConfigureAppConfiguration((hostingContext, config) =>

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -29,7 +29,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs($"{nameof(CookieStickySessions)}:{route.LoadBalancerOptions.Key}"))
+                .Then(_ => ThenTheResultIs("CookieStickySessions:testy"))
                 .BDDfy();
         }
 
@@ -39,9 +39,9 @@ namespace Ocelot.UnitTests.Configuration
             var route = new FileRoute
             {
                 UpstreamPathTemplate = "/api/product",
-                UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
-                DownstreamHostAndPorts = new List<FileHostAndPort>
-                {
+                UpstreamHttpMethod = ["GET", "POST", "PUT"],
+                DownstreamHostAndPorts =
+                [
                     new()
                     {
                         Host = "localhost",
@@ -52,12 +52,12 @@ namespace Ocelot.UnitTests.Configuration
                         Host = "localhost",
                         Port = 4430,
                     },
-                },
+                ],
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|localhost:8080|localhost:4430"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||||"))
                 .BDDfy();
         }
 
@@ -68,9 +68,9 @@ namespace Ocelot.UnitTests.Configuration
             {
                 UpstreamHost = "my-upstream-host",
                 UpstreamPathTemplate = "/api/product",
-                UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
-                DownstreamHostAndPorts = new List<FileHostAndPort>
-                {
+                UpstreamHttpMethod = ["GET", "POST", "PUT"],
+                DownstreamHostAndPorts =
+                [
                     new()
                     {
                         Host = "localhost",
@@ -81,12 +81,12 @@ namespace Ocelot.UnitTests.Configuration
                         Host = "localhost",
                         Port = 4430,
                     },
-                },
+                ],
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|my-upstream-host|/api/product|localhost:8080|localhost:4430"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-upstream-host||||"))
                 .BDDfy();
         }
 
@@ -96,13 +96,34 @@ namespace Ocelot.UnitTests.Configuration
             var route = new FileRoute
             {
                 UpstreamPathTemplate = "/api/product",
-                UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
+                UpstreamHttpMethod = ["GET", "POST", "PUT"],
                 ServiceName = "my-service-name",
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-service-name"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||my-service-name||"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_re_route_key_with_load_balancer_options()
+        {
+            var route = new FileRoute
+            {
+                UpstreamPathTemplate = "/api/product",
+                UpstreamHttpMethod = ["GET", "POST", "PUT"],
+                ServiceName = "my-service-name",
+                LoadBalancerOptions = new FileLoadBalancerOptions
+                {
+                    Type = nameof(LeastConnection),
+                    Key = "testy",
+                },
+            };
+
+            this.Given(_ => GivenThe(route))
+                .When(_ => WhenICreate())
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||my-service-name|LeastConnection|testy"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -102,7 +102,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product|my-service-name"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product||my-service-name"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -57,7 +57,52 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs($"{route.UpstreamPathTemplate}|{string.Join(',', route.UpstreamHttpMethod)}|{string.Join(',', route.DownstreamHostAndPorts.Select(x => $"{x.Host}:{x.Port}"))}"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product|localhost:123|localhost:123"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_re_route_key_with_upstream_host()
+        {
+            var route = new FileRoute
+            {
+                UpstreamHost = "my-upstream-host",
+                UpstreamPathTemplate = "/api/product",
+                UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
+                DownstreamHostAndPorts = new List<FileHostAndPort>
+                {
+                    new()
+                    {
+                        Host = "localhost",
+                        Port = 123,
+                    },
+                    new()
+                    {
+                        Host = "localhost",
+                        Port = 123,
+                    },
+                },
+            };
+
+            this.Given(_ => GivenThe(route))
+                .When(_ => WhenICreate())
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|my-upstream-host|/api/product|localhost:123|localhost:123"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_return_re_route_key_with_service_name()
+        {
+            var route = new FileRoute
+            {
+                UpstreamPathTemplate = "/api/product",
+                UpstreamHttpMethod = new List<string> { "GET", "POST", "PUT" },
+                ServiceName = "my-service-name",
+            };
+
+            this.Given(_ => GivenThe(route))
+                .When(_ => WhenICreate())
+                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product|my-service-name"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -16,7 +16,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_return_sticky_session_key()
+        public void Should_return_sticky_session_key()
         {
             var route = new FileRoute
             {
@@ -34,7 +34,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_return_re_route_key()
+        public void Should_return_route_key()
         {
             var route = new FileRoute
             {
@@ -42,16 +42,8 @@ namespace Ocelot.UnitTests.Configuration
                 UpstreamHttpMethod = ["GET", "POST", "PUT"],
                 DownstreamHostAndPorts =
                 [
-                    new()
-                    {
-                        Host = "localhost",
-                        Port = 8080,
-                    },
-                    new()
-                    {
-                        Host = "localhost",
-                        Port = 4430,
-                    },
+                    new("localhost", 8080),
+                    new("localhost", 4430),
                 ],
             };
 
@@ -62,7 +54,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_return_re_route_key_with_upstream_host()
+        public void Should_return_route_key_with_upstream_host()
         {
             var route = new FileRoute
             {
@@ -71,16 +63,8 @@ namespace Ocelot.UnitTests.Configuration
                 UpstreamHttpMethod = ["GET", "POST", "PUT"],
                 DownstreamHostAndPorts =
                 [
-                    new()
-                    {
-                        Host = "localhost",
-                        Port = 8080,
-                    },
-                    new()
-                    {
-                        Host = "localhost",
-                        Port = 4430,
-                    },
+                    new("localhost", 8080),
+                    new("localhost", 4430),
                 ],
             };
 
@@ -91,7 +75,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_return_re_route_key_with_svc_name()
+        public void Should_return_route_key_with_svc_name()
         {
             var route = new FileRoute
             {
@@ -107,7 +91,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_return_re_route_key_with_load_balancer_options()
+        public void Should_return_route_key_with_load_balancer_options()
         {
             var route = new FileRoute
             {

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -57,7 +57,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||||"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
@@ -66,7 +66,7 @@ namespace Ocelot.UnitTests.Configuration
         {
             var route = new FileRoute
             {
-                UpstreamHost = "my-upstream-host",
+                UpstreamHost = "my-host",
                 UpstreamPathTemplate = "/api/product",
                 UpstreamHttpMethod = ["GET", "POST", "PUT"],
                 DownstreamHostAndPorts =
@@ -86,23 +86,23 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-upstream-host||||"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-host|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
         [Fact]
-        public void should_return_re_route_key_with_service_name()
+        public void should_return_re_route_key_with_svc_name()
         {
             var route = new FileRoute
             {
                 UpstreamPathTemplate = "/api/product",
                 UpstreamHttpMethod = ["GET", "POST", "PUT"],
-                ServiceName = "my-service-name",
+                ServiceName = "products-service",
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||my-service-name||"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|products-service|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
@@ -113,7 +113,7 @@ namespace Ocelot.UnitTests.Configuration
             {
                 UpstreamPathTemplate = "/api/product",
                 UpstreamHttpMethod = ["GET", "POST", "PUT"],
-                ServiceName = "my-service-name",
+                ServiceName = "products-service",
                 LoadBalancerOptions = new FileLoadBalancerOptions
                 {
                     Type = nameof(LeastConnection),
@@ -123,7 +123,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|||my-service-name|LeastConnection|testy"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|products-service|LeastConnection|testy"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -45,19 +45,19 @@ namespace Ocelot.UnitTests.Configuration
                     new()
                     {
                         Host = "localhost",
-                        Port = 123,
+                        Port = 8080,
                     },
                     new()
                     {
                         Host = "localhost",
-                        Port = 123,
+                        Port = 4430,
                     },
                 },
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product|localhost:123|localhost:123"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|localhost:8080|localhost:4430"))
                 .BDDfy();
         }
 
@@ -74,19 +74,19 @@ namespace Ocelot.UnitTests.Configuration
                     new()
                     {
                         Host = "localhost",
-                        Port = 123,
+                        Port = 8080,
                     },
                     new()
                     {
                         Host = "localhost",
-                        Port = 123,
+                        Port = 4430,
                     },
                 },
             };
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|my-upstream-host|/api/product|localhost:123|localhost:123"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|my-upstream-host|/api/product|localhost:8080|localhost:4430"))
                 .BDDfy();
         }
 
@@ -102,7 +102,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT||/api/product||my-service-name"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-service-name"))
                 .BDDfy();
         }
 

--- a/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RouteKeyCreatorTests.cs
@@ -57,7 +57,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|localhost:8080,localhost:4430|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
@@ -86,7 +86,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-host|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|my-host|localhost:8080,localhost:4430|no-svc-ns|no-svc-name|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
@@ -102,7 +102,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|products-service|no-lb-type|no-lb-key"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-host-and-port|no-svc-ns|products-service|no-lb-type|no-lb-key"))
                 .BDDfy();
         }
 
@@ -123,7 +123,7 @@ namespace Ocelot.UnitTests.Configuration
 
             this.Given(_ => GivenThe(route))
                 .When(_ => WhenICreate())
-                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-svc-ns|products-service|LeastConnection|testy"))
+                .Then(_ => ThenTheResultIs("GET,POST,PUT|/api/product|no-host|no-host-and-port|no-svc-ns|products-service|LeastConnection|testy"))
                 .BDDfy();
         }
 


### PR DESCRIPTION
## Fixes #849 #1496 
- #849
- #1496 

## Proposed Changes
  - Make the `RouteKeyCreator` aware of `UpstreamHost` routing
  - Make the `RouteKeyCreator` aware of ServiceDiscovery with `ServiceName` and `ServiceNamespace`

Multiple routes with identical `UpstreamMethod` and `UpstreamPath`, but different `UpstreamHost` and `ServiceName` or `DownstreamHostAndPort` will now be load-balanced correctly.
