### PR TITLE
Logging bug in `HttpRequesterMiddleware`

### DIFF
--- a/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
+++ b/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
@@ -39,12 +39,17 @@ namespace Ocelot.Requester.Middleware
 
         private void CreateLogBasedOnResponse(Response<HttpResponseMessage> response)
         {
-            var message= () =>$"{(int)response.Data.StatusCode} ({response.Data.ReasonPhrase}) status code, request uri: {response.Data.RequestMessage?.RequestUri}";
-            if (response.Data?.StatusCode < HttpStatusCode.BadRequest)
+            var status = response.Data?.StatusCode ?? HttpStatusCode.Processing;
+            var reason = response.Data?.ReasonPhrase ?? "unknown";
+            var uri = response.Data?.RequestMessage?.RequestUri?.ToString() ?? string.Empty;
+
+            string message() => $"{(int)status} ({reason}) status code of request URI: {uri}.";
+
+            if (status < HttpStatusCode.BadRequest)
             {
                 Logger.LogInformation(message);
             }
-            else if (response.Data?.StatusCode >= HttpStatusCode.BadRequest)
+            else if (status >= HttpStatusCode.BadRequest)
             {
                 Logger.LogWarning(message);
             }

--- a/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
+++ b/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
@@ -39,15 +39,14 @@ namespace Ocelot.Requester.Middleware
 
         private void CreateLogBasedOnResponse(Response<HttpResponseMessage> response)
         {
-            if (response.Data?.StatusCode <= HttpStatusCode.BadRequest)
+            var message= () =>$"{(int)response.Data.StatusCode} ({response.Data.ReasonPhrase}) status code, request uri: {response.Data.RequestMessage?.RequestUri}";
+            if (response.Data?.StatusCode < HttpStatusCode.BadRequest)
             {
-                Logger.LogInformation(() =>
-                    $"{(int)response.Data.StatusCode} ({response.Data.ReasonPhrase}) status code, request uri: {response.Data.RequestMessage?.RequestUri}");
+                Logger.LogInformation(message);
             }
             else if (response.Data?.StatusCode >= HttpStatusCode.BadRequest)
             {
-                Logger.LogWarning(
-                    () => $"{(int)response.Data.StatusCode} ({response.Data.ReasonPhrase}) status code, request uri: {response.Data.RequestMessage?.RequestUri}");
+                Logger.LogWarning(message);
             }
         }
     }

--- a/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
+++ b/src/Ocelot/Requester/Middleware/HttpRequesterMiddleware.cs
@@ -49,7 +49,7 @@ namespace Ocelot.Requester.Middleware
             {
                 Logger.LogInformation(message);
             }
-            else if (status >= HttpStatusCode.BadRequest)
+            else
             {
                 Logger.LogWarning(message);
             }


### PR DESCRIPTION
`BadRequest` should be logged as debug!

### Update by Maintainer on Feb 27, 2024
`BadRequest` should be logged as **warning** via `LogWarning` method.
