### PR TITLE
Startup time benchmarking

### DIFF
--- a/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
+++ b/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Ocelot.Configuration.File;
+using Ocelot.DependencyInjection;
+using Ocelot.Middleware;
+using Ocelot.Testing;
+namespace Ocelot.Benchmarks
+{
+    [Config(typeof(HeavyRoutesStartupBenchmark))]
+    public class HeavyRoutesStartupBenchmark : ManualConfig
+    {
+        private IWebHost _ocelot;
+
+        public HeavyRoutesStartupBenchmark()
+        {
+            AddColumn(StatisticColumn.AllStatistics);
+            AddDiagnoser(MemoryDiagnoser.Default);
+            AddValidator(BaselineValidator.FailOnError);
+        }
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            //Setting up for more than 600 routes in different files
+            CreateOcelotConfigFile(0, 100, "ocelot.json");
+            CreateOcelotConfigFile(101, 500, "ocelot.second.json");
+        }
+        
+        [Benchmark]
+        public void StartOcelotWithLargeConfigurations()
+        {
+            OcelotStartup($"http://localhost:{TcpPortFinder.FindAvailablePort()}");
+        }
+
+        [GlobalCleanup]
+        public async void Cleanup()
+        {
+            // Stop the web host after benchmarking
+            await _ocelot.StopAsync();
+        }
+
+        /// <summary>
+        /// To replicate large number of routes.
+        /// </summary>
+        /// <param name="start">Starting digit to create downstream/upstream files.</param>
+        /// <param name="end">Ending digit to create downstream/upstream files.</param>
+        /// <param name="fileName">Ocelot files names.</param>
+        private static void CreateOcelotConfigFile(int start, int end, string fileName)
+        {
+            var routes = new List<FileRoute>();
+
+            for (int i = start; i < end; i++)
+            {
+                routes.Add(new()
+                {
+                    DownstreamPathTemplate = $"/downstream{i}",
+                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                            {
+                                new()
+                                {
+                                    Host = "localhost",
+                                    Port = 51879,
+                                },
+                            },
+                    DownstreamScheme = "http",
+                    UpstreamPathTemplate = $"/upstream{i}",
+                    UpstreamHttpMethod = new List<string> { "Get" },
+                });
+            }
+
+            var configuration = new FileConfiguration { Routes = routes };
+            GivenThereIsAConfiguration(configuration, fileName);
+        }
+
+        private void OcelotStartup(string url)
+        {
+            _ocelot = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(url)
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    config
+                        .SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
+                        .AddJsonFile("appsettings.json", true, true)
+                        .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true)
+                        .AddJsonFile("ocelot.json", false, false)
+                        .AddJsonFile("ocelot.second.json", false, false)
+                        .AddEnvironmentVariables();
+                })
+                .ConfigureServices(s =>
+                {
+                    s.AddOcelot();
+                })
+                .ConfigureLogging((hostingContext, logging) =>
+                {
+                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                })
+                .UseIISIntegration()
+                .Configure(app =>
+                {
+                    app.UseOcelot().Wait();
+                })
+                .Build();
+
+            _ocelot.Start();
+        }
+
+        public static void GivenThereIsAConfiguration(FileConfiguration fileConfiguration, string fileName)
+        {
+            var configurationPath = Path.Combine(AppContext.BaseDirectory, fileName);
+
+            var jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration);
+
+            if (File.Exists(configurationPath))
+            {
+                File.Delete(configurationPath);
+            }
+
+            File.WriteAllText(configurationPath, jsonConfiguration);
+        }
+    }
+}

--- a/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
+++ b/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
@@ -37,7 +37,7 @@ namespace Ocelot.Benchmarks
         }
 
         [Benchmark]
-        public void StartOcelotWithLargeConfigurations()
+        public void StartOcelotWithAddingNewConfigFile()
         {
             //Adding new file
             CreateOcelotConfigFile(startFileCount, endFileCount, $"ocelot{8}.json");
@@ -45,7 +45,7 @@ namespace Ocelot.Benchmarks
         }
 
         [Benchmark]
-        public void StartOcelotWithOverrideFile()
+        public void StartOcelotWithOverridingExistingFile()
         {   
             //Overriding with old file
             CreateOcelotConfigFile(0, 90, $"ocelot{8}.json");

--- a/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
+++ b/test/Ocelot.Benchmarks/HeavyRoutesStartupBenchmark.cs
@@ -5,142 +5,137 @@ using Newtonsoft.Json;
 using Ocelot.Configuration.File;
 using Ocelot.DependencyInjection;
 using Ocelot.Middleware;
-using Ocelot.Testing;
-namespace Ocelot.Benchmarks
+
+namespace Ocelot.Benchmarks;
+
+[Config(typeof(HeavyRoutesStartupBenchmark))]
+public class HeavyRoutesStartupBenchmark : ManualConfig
 {
-    [Config(typeof(HeavyRoutesStartupBenchmark))]
-    public class HeavyRoutesStartupBenchmark : ManualConfig
+    private IWebHost _ocelot;
+
+    //7 files with 80+ routes
+    int startFileCount = 0;
+
+    //7 files with 80+ routes
+    int endFileCount = 90;
+    public HeavyRoutesStartupBenchmark()
     {
-        private IWebHost _ocelot;
+        AddColumn(StatisticColumn.AllStatistics);
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddValidator(BaselineValidator.FailOnError);
+    }
 
-        //7 files with 80+ routes
-        int startFileCount = 0;
-
-        //7 files with 80+ routes
-        int endFileCount = 90;
-        public HeavyRoutesStartupBenchmark()
+    [GlobalSetup]
+    public void SetUp()
+    {
+        for (int i = 1; i <= 7; i++)
         {
-            AddColumn(StatisticColumn.AllStatistics);
-            AddDiagnoser(MemoryDiagnoser.Default);
-            AddValidator(BaselineValidator.FailOnError);
+            CreateOcelotConfigFile(startFileCount, endFileCount, $"ocelot{i}.json");
+            startFileCount = endFileCount + 1;
+            endFileCount += 90;
         }
+    }
 
-        [GlobalSetup]
-        public void SetUp()
+    [Benchmark]
+    public async Task StartOcelotWithAddingNewConfigFile()
+    {
+        //Adding new file
+        CreateOcelotConfigFile(startFileCount, endFileCount, $"ocelot{8}.json");
+        await OcelotStartupAsync($"http://localhost:{TcpPortFinder.FindAvailablePort()}");
+    }
+
+    [Benchmark]
+    public async Task StartOcelotWithOverridingExistingFile()
+    {   
+        //Overriding with old file
+        CreateOcelotConfigFile(0, 90, $"ocelot{8}.json");
+        await OcelotStartupAsync($"http://localhost:{TcpPortFinder.FindAvailablePort()}");
+    }
+
+    [GlobalCleanup]
+    public async void Cleanup()
+    {
+        // Stop the web host after benchmarking
+        await _ocelot.StopAsync();
+    }
+
+    /// <summary>
+    /// To replicate large number of routes.
+    /// </summary>
+    /// <param name="start">Starting digit to create downstream/upstream files.</param>
+    /// <param name="end">Ending digit to create downstream/upstream files.</param>
+    /// <param name="fileName">Ocelot files names.</param>
+    private static void CreateOcelotConfigFile(int start, int end, string fileName)
+    {
+        var routes = new List<FileRoute>();
+
+        for (int i = start; i < end; i++)
         {
-            for (int i = 1; i <= 7; i++)
+            routes.Add(new()
             {
-                CreateOcelotConfigFile(startFileCount, endFileCount, $"ocelot{i}.json");
-                startFileCount = endFileCount + 1;
-                endFileCount += 90;
-            }
-        }
-
-        [Benchmark]
-        public void StartOcelotWithAddingNewConfigFile()
-        {
-            //Adding new file
-            CreateOcelotConfigFile(startFileCount, endFileCount, $"ocelot{8}.json");
-            OcelotStartup($"http://localhost:{TcpPortFinder.FindAvailablePort()}");
-        }
-
-        [Benchmark]
-        public void StartOcelotWithOverridingExistingFile()
-        {   
-            //Overriding with old file
-            CreateOcelotConfigFile(0, 90, $"ocelot{8}.json");
-            OcelotStartup($"http://localhost:{TcpPortFinder.FindAvailablePort()}");
-        }
-
-        [GlobalCleanup]
-        public async void Cleanup()
-        {
-            // Stop the web host after benchmarking
-            await _ocelot.StopAsync();
-        }
-
-        /// <summary>
-        /// To replicate large number of routes.
-        /// </summary>
-        /// <param name="start">Starting digit to create downstream/upstream files.</param>
-        /// <param name="end">Ending digit to create downstream/upstream files.</param>
-        /// <param name="fileName">Ocelot files names.</param>
-        private static void CreateOcelotConfigFile(int start, int end, string fileName)
-        {
-            var routes = new List<FileRoute>();
-
-            for (int i = start; i < end; i++)
-            {
-                routes.Add(new()
-                {
-                    DownstreamPathTemplate = $"/downstream{i}",
-                    DownstreamHostAndPorts = new List<FileHostAndPort>
+                DownstreamPathTemplate = $"/downstream{i}",
+                DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
                             {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 51879,
-                                },
+                                Host = "localhost",
+                                Port = 51879,
                             },
-                    DownstreamScheme = "http",
-                    UpstreamPathTemplate = $"/upstream{i}",
-                    UpstreamHttpMethod = new List<string> { "Get" },
-                });
-            }
-
-            var configuration = new FileConfiguration { Routes = routes };
-            GivenThereIsAConfiguration(configuration, fileName);
+                        },
+                DownstreamScheme = "http",
+                UpstreamPathTemplate = $"/upstream{i}",
+                UpstreamHttpMethod = new List<string> { "Get" },
+            });
         }
 
-        private void OcelotStartup(string url)
-        {
-            _ocelot = new WebHostBuilder()
-                .UseKestrel()
-                .UseUrls(url)
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .ConfigureAppConfiguration((hostingContext, config) =>
-                {
-                    for (int i = 1; i <= 8; i++)
-                    {
-                        config.AddJsonFile($"ocelot{i}.json", false, false);
-                    }
+        var configuration = new FileConfiguration { Routes = routes };
+        GivenThereIsAConfiguration(configuration, fileName);
+    }
 
-                    config
-                        .SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
-                        .AddJsonFile("appsettings.json", true, true)
-                        .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true)
-                        .AddEnvironmentVariables();
-                })
-                .ConfigureServices(s =>
-                {
-                    s.AddOcelot();
-                })
-                .ConfigureLogging((hostingContext, logging) =>
-                {
-                    logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
-                })
-                .UseIISIntegration()
-                .Configure(app =>
-                {
-                    app.UseOcelot().Wait();
-                })
-                .Build();
-
-            _ocelot.Start();
-        }
-
-        public static void GivenThereIsAConfiguration(FileConfiguration fileConfiguration, string fileName)
-        {
-            var configurationPath = Path.Combine(AppContext.BaseDirectory, fileName);
-
-            var jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration);
-
-            if (File.Exists(configurationPath))
+    private Task OcelotStartupAsync(string url)
+    {
+        _ocelot = TestHostBuilder.Create()
+            .UseKestrel()
+            .UseUrls(url)
+            .UseContentRoot(Directory.GetCurrentDirectory())
+            .ConfigureAppConfiguration((hostingContext, config) =>
             {
-                File.Delete(configurationPath);
-            }
+                for (int i = 1; i <= 8; i++)
+                {
+                    config.AddJsonFile($"ocelot{i}.json", false, false);
+                }
 
-            File.WriteAllText(configurationPath, jsonConfiguration);
+                config
+                    .SetBasePath(hostingContext.HostingEnvironment.ContentRootPath)
+                    .AddJsonFile("appsettings.json", true, true)
+                    .AddJsonFile($"appsettings.{hostingContext.HostingEnvironment.EnvironmentName}.json", true, true)
+                    .AddEnvironmentVariables();
+            })
+            .ConfigureServices(s =>
+            {
+                s.AddOcelot();
+            })
+            .ConfigureLogging((hostingContext, logging) =>
+            {
+                logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+            })
+            .UseIISIntegration()
+            .Configure(async app => await app.UseOcelot())
+            .Build();
+        return _ocelot.StartAsync();
+    }
+
+    public static void GivenThereIsAConfiguration(FileConfiguration fileConfiguration, string fileName)
+    {
+        var configurationPath = Path.Combine(AppContext.BaseDirectory, fileName);
+
+        var jsonConfiguration = JsonConvert.SerializeObject(fileConfiguration);
+
+        if (File.Exists(configurationPath))
+        {
+            File.Delete(configurationPath);
         }
+
+        File.WriteAllText(configurationPath, jsonConfiguration);
     }
 }

--- a/test/Ocelot.Benchmarks/Program.cs
+++ b/test/Ocelot.Benchmarks/Program.cs
@@ -17,6 +17,7 @@ public class Program
                 typeof(MsLoggerBenchmarks),
                 typeof(PayloadBenchmarks),
                 typeof(ResponseBenchmarks),
+                typeof(HeavyRoutesStartupBenchmark),
             });
         switcher.Run(args);
     }

--- a/test/Ocelot.Testing/TcpPortFinder.cs
+++ b/test/Ocelot.Testing/TcpPortFinder.cs
@@ -1,0 +1,23 @@
+﻿using System.Net.Sockets;
+using System.Net;
+
+namespace Ocelot.Testing
+{
+    public class TcpPortFinder
+    {
+        public static int FindAvailablePort()
+        {
+            TcpListener? listener = null;
+            try
+            {
+                listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                return ((IPEndPoint)listener.LocalEndpoint).Port;
+            }
+            finally
+            {
+                listener?.Stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Fixes #1526 
- #1526 
- #1857

Adding benchmark for startup. 
We can replicate issue or verify with this PR

Unable to replicate application down with 600 dummy routes.

## Proposed Changes
  - Add `HeavyRoutesStartupBenchmark` benchmark
  - Current benchmarking is done for 600+ dummy routes across 2 files, more file and more dummy routes can be extended easily.