### PR TITLE
Avoid content if original request has no content and avoid Transfer-Encoding: chunked if Content-Length is known

### DIFF
--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+
 using Ocelot.Configuration;
 using Ocelot.DependencyInjection;
 using Ocelot.Errors;
@@ -7,6 +8,7 @@ using Ocelot.Errors.QoS;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Ocelot.Requester;
+
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 
@@ -14,10 +16,31 @@ namespace Ocelot.Provider.Polly;
 
 public static class OcelotBuilderExtensions
 {
+    /// <summary>
+    /// Default mapping of Polly <see cref="Exception"/>s to <see cref="Error"/> objects.
+    /// </summary>
+    public static readonly Dictionary<Type, Func<Exception, Error>> DefaultErrorMapping = new Dictionary<Type, Func<Exception, Error>>
+    {
+        {typeof(TaskCanceledException), CreateRequestTimedOutError},
+        {typeof(TimeoutRejectedException), CreateRequestTimedOutError},
+        {typeof(BrokenCircuitException), CreateRequestTimedOutError},
+        {typeof(BrokenCircuitException<HttpResponseMessage>), CreateRequestTimedOutError},
+    };
+
+    private static Error CreateRequestTimedOutError(Exception e) => new RequestTimedOutError(e);
+
+    /// <summary>
+    /// Adds Polly QoS provider to Ocelot by custom delegate and with custom error mapping.
+    /// </summary>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QoS behavior by yourself).</param>
+    /// <param name="errorMapping">Your customized error mapping.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
-        QosDelegatingHandlerDelegate delegatingHandler,
-        Dictionary<Type, Func<Exception, Error>> errorMapping)
-        where T : class, IPollyQoSProvider<HttpResponseMessage>
+            QosDelegatingHandlerDelegate delegatingHandler,
+            Dictionary<Type, Func<Exception, Error>> errorMapping)
+            where T : class, IPollyQoSProvider<HttpResponseMessage>
     {
         builder.Services
             .AddSingleton(errorMapping)
@@ -27,18 +50,68 @@ public static class OcelotBuilderExtensions
         return builder;
     }
 
-    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
-    {
-        var errorMapping = new Dictionary<Type, Func<Exception, Error>>
-        {
-            { typeof(TaskCanceledException), e => new RequestTimedOutError(e) },
-            { typeof(TimeoutRejectedException), e => new RequestTimedOutError(e) },
-            { typeof(BrokenCircuitException), e => new RequestTimedOutError(e) },
-            { typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e) },
-        };
-        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, errorMapping);
-    }
+    /// <summary>
+    /// Adds Polly QoS provider to Ocelot with custom error mapping, but default <see cref="DelegatingHandler"/> is used.
+    /// </summary>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="errorMapping">Your customized error mapping.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, DefaultDelegatingHandler, errorMapping);
 
-    private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
+    /// <summary>
+    /// Adds Polly QoS provider to Ocelot with custom <see cref="DelegatingHandler"/> delegate, but default error mapping is used.
+    /// </summary>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QoS behavior by yourself).</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, delegatingHandler, DefaultErrorMapping);
+
+    /// <summary>
+    /// Adds Polly QoS provider to Ocelot by defaults.
+    /// </summary>
+    /// <remarks>
+    /// Defaults:
+    /// <list type="bullet">
+    ///   <item><see cref="DefaultDelegatingHandler"/></item>
+    ///   <item><see cref="DefaultErrorMapping"/></item>
+    /// </list>
+    /// </remarks>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, DefaultDelegatingHandler, DefaultErrorMapping);
+
+    /// <summary>
+    /// Adds Polly QoS provider to Ocelot by defaults with default QoS provider.
+    /// </summary>
+    /// <remarks>
+    /// Defaults:
+    /// <list type="bullet">
+    ///   <item><see cref="PollyQoSProvider"/></item>
+    ///   <item><see cref="DefaultDelegatingHandler"/></item>
+    ///   <item><see cref="DefaultErrorMapping"/></item>
+    /// </list>
+    /// </remarks>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder) =>
+        AddPolly<PollyQoSProvider>(builder, DefaultDelegatingHandler, DefaultErrorMapping);
+
+    /// <summary>
+    /// Creates default delegating handler based on the <see cref="PollyPoliciesDelegatingHandler"/> type.
+    /// </summary>
+    /// <param name="route">The downstream route to apply the handler for.</param>
+    /// <param name="contextAccessor">The context accessor of the route.</param>
+    /// <param name="loggerFactory">The factory of logger.</param>
+    /// <returns>A <see cref="DelegatingHandler"/> object, but concreate type is the <see cref="PollyPoliciesDelegatingHandler"/> class.</returns>
+    public static DelegatingHandler DefaultDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
         => new PollyPoliciesDelegatingHandler(route, contextAccessor, loggerFactory);
 }

--- a/src/Ocelot/Request/Mapper/EmptyHttpContent.cs
+++ b/src/Ocelot/Request/Mapper/EmptyHttpContent.cs
@@ -1,0 +1,15 @@
+﻿namespace Ocelot.Request.Mapper;
+
+public class EmptyHttpContent : HttpContent
+{
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+    {
+        return Task.CompletedTask;
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = 0;
+        return true;
+    }
+}

--- a/src/Ocelot/Request/Mapper/RequestMapper.cs
+++ b/src/Ocelot/Request/Mapper/RequestMapper.cs
@@ -27,14 +27,22 @@ public class RequestMapper : IRequestMapper
 
     private static HttpContent MapContent(HttpRequest request)
     {
+        HttpContent content;
+
         // no content if we have no body or if the request has no content according to RFC 2616 section 4.3
         if (request.Body == null
-            || (!request.ContentLength.HasValue && !request.Headers.TransferEncoding.Equals("chunked")))
+            || (!request.ContentLength.HasValue && StringValues.IsNullOrEmpty(request.Headers.TransferEncoding)))
         {
             return null;
         }
-
-        var content = new StreamHttpContent(request.HttpContext);
+        else if (request.ContentLength.HasValue && request.ContentLength == 0)
+        {
+            content = new EmptyHttpContent();
+        }
+        else
+        {
+            content = new StreamHttpContent(request.HttpContext);
+        }
 
         AddContentHeaders(request, content);
 

--- a/src/Ocelot/Request/Mapper/StreamHttpContent.cs
+++ b/src/Ocelot/Request/Mapper/StreamHttpContent.cs
@@ -8,25 +8,24 @@ public class StreamHttpContent : HttpContent
     private const int DefaultBufferSize = 65536;
     public const long UnknownLength = -1;
     private readonly HttpContext _context;
+    private readonly long _contentLength;
 
     public StreamHttpContent(HttpContext context)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
+        _contentLength = context.Request.ContentLength ?? -1;
     }
 
-    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context,
-        CancellationToken cancellationToken)
-        => await CopyAsync(_context.Request.Body, stream, Headers.ContentLength ?? UnknownLength, false,
-            cancellationToken);
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken)
+        => await CopyAsync(_context.Request.Body, stream, _contentLength, false, cancellationToken);
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        => await CopyAsync(_context.Request.Body, stream, Headers.ContentLength ?? UnknownLength, false,
-            CancellationToken.None);
+        => await CopyAsync(_context.Request.Body, stream, _contentLength, false, CancellationToken.None);
 
     protected override bool TryComputeLength(out long length)
     {
-        length = -1;
-        return false;
+        length = _contentLength;
+        return length >= 0;
     }
 
     // This is used internally by HttpContent.ReadAsStreamAsync(...)

--- a/test/Ocelot.AcceptanceTests/MapRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/MapRequestTests.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+
+namespace Ocelot.AcceptanceTests
+{
+    public class MapRequestTests : IDisposable
+    {
+        private readonly ServiceHandler _serviceHandler;
+        private readonly Steps _steps;
+
+        private class ChunkedContent : HttpContent
+        {
+            private readonly string[] _chunks;
+
+            public ChunkedContent(params string[] chunks)
+            {
+                _chunks = chunks;
+            }
+
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                foreach (var chunk in _chunks)
+                {
+                    var bytes = Encoding.Default.GetBytes(chunk);
+                    await stream.WriteAsync(bytes, 0, bytes.Length);
+                }
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = -1;
+                return false;
+            }
+        }
+
+        public MapRequestTests()
+        {
+            _serviceHandler = new ServiceHandler();
+            _steps = new Steps();
+        }
+        
+        [Fact]
+        public void should_map_request_without_content()
+        {
+            var port = PortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                {
+                    new()
+                    {
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
+                            {
+                                Host = "localhost",
+                                Port = port,
+                            },
+                        },
+                        UpstreamPathTemplate = "/",
+                        UpstreamHttpMethod = new List<string> { "Get" },
+                    },
+                },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe(";;"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_map_request_with_content_length()
+        {
+            var port = PortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                {
+                    new()
+                    {
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
+                            {
+                                Host = "localhost",
+                                Port = port,
+                            },
+                        },
+                        UpstreamPathTemplate = "/",
+                        UpstreamHttpMethod = new List<string> { "Post" },
+                    },
+                },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/", new StringContent("This is some content")))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("20;;This is some content"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_map_request_with_empty_content()
+        {
+            var port = PortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                {
+                    new()
+                    {
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
+                            {
+                                Host = "localhost",
+                                Port = port,
+                            },
+                        },
+                        UpstreamPathTemplate = "/",
+                        UpstreamHttpMethod = new List<string> { "Post" },
+                    },
+                },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/", new StringContent("")))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe("0;;"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_map_request_with_chunked_content()
+        {
+            var port = PortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                {
+                    new()
+                    {
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
+                            {
+                                Host = "localhost",
+                                Port = port,
+                            },
+                        },
+                        UpstreamPathTemplate = "/",
+                        UpstreamHttpMethod = new List<string> { "Post" },
+                    },
+                },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/", new ChunkedContent("This ", "is some content")))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe(";chunked;This is some content"))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_map_request_with_empty_chunked_content()
+        {
+            var port = PortFinder.GetRandomPort();
+
+            var configuration = new FileConfiguration
+            {
+                Routes = new List<FileRoute>
+                {
+                    new()
+                    {
+                        DownstreamPathTemplate = "/",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new List<FileHostAndPort>
+                        {
+                            new()
+                            {
+                                Host = "localhost",
+                                Port = port,
+                            },
+                        },
+                        UpstreamPathTemplate = "/",
+                        UpstreamHttpMethod = new List<string> { "Post" },
+                    },
+                },
+            };
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", 200))
+                .And(x => _steps.GivenThereIsAConfiguration(configuration))
+                .And(x => _steps.GivenOcelotIsRunning())
+                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/", new ChunkedContent()))
+                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => _steps.ThenTheResponseBodyShouldBe(";chunked;"))
+                .BDDfy();
+        }
+
+        private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode)
+        {
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                var request = context.Request;
+                var response = context.Response;
+
+                await response.WriteAsync(request.ContentLength + ";" + request.Headers.TransferEncoding + ";");
+                await request.Body.CopyToAsync(response.Body);
+            });
+        }
+
+        public void Dispose()
+        {
+            _serviceHandler?.Dispose();
+            _steps?.Dispose();
+        }
+    }
+}

--- a/test/Ocelot.UnitTests/Request/Mapper/RequestMapperTests.cs
+++ b/test/Ocelot.UnitTests/Request/Mapper/RequestMapperTests.cs
@@ -393,6 +393,7 @@ public class RequestMapperTests
 
     private void GivenTheInputRequestHasContent(string content)
     {
+        _inputRequest.ContentLength = content.Length;
         _inputRequest.Body = new MemoryStream(Encoding.UTF8.GetBytes(content));
     }
 


### PR DESCRIPTION
With the changes in Ocelot [23.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0) the `RequestMapper` sets the Property `Content` using the new `StreamHttpContent`. Because the **Content-Length** is not computed in `StreamHttpContent` the header **Transfer-Encoding**: chunked will be set on all upstream requests even if there is no content in the downstream request (e.g. on GET requests). This causes issues when the upstream is an IIS working as reverse proxy (using ARR), in that case all GET requests are failing with status code 502.7 inside ARR.

Additionally in some cases the **Content-Length** is required by the upstream server, it will send status code 411 if it is missing, behind Ocelot all request will fail with status code 411, as the **Content-Length** was not transferred to the upstream server and instead **Transfer-Encoding**: chunked is sent to the upstream server.

Both issue are addressed with this PR.