### PR TITLE
#1844 More open customization of Polly use

### DIFF
--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -45,15 +45,15 @@ public static class OcelotBuilderExtensions
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, delegatingHandler, ErrorMapping);
+        AddPolly<T>(builder, delegatingHandler, DefaultErrorMapping);
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, GetDelegatingHandler, ErrorMapping);
+        AddPolly<T>(builder, GetDelegatingHandler, DefaultErrorMapping);
 
     public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
     {
-        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, ErrorMapping);
+        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, DefaultErrorMapping);
     }
 
     private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -16,6 +16,9 @@ namespace Ocelot.Provider.Polly;
 
 public static class OcelotBuilderExtensions
 {
+    /// <summary>
+    /// Default mapping of Polly <see cref="Exception"/>s to <see cref="Error"/> objects.
+    /// </summary>
     public static readonly Dictionary<Type, Func<Exception, Error>> DefaultErrorMapping = new Dictionary<Type, Func<Exception, Error>>
     {
         {typeof(TaskCanceledException), CreateRequestTimedOutError},
@@ -27,16 +30,16 @@ public static class OcelotBuilderExtensions
     private static Error CreateRequestTimedOutError(Exception e) => new RequestTimedOutError(e);
 
     /// <summary>
-    /// Add Polly QoS provider to Ocelot
+    /// Adds Polly QoS provider to Ocelot by custom delegate and with custom error mapping.
     /// </summary>
-    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
-    /// <param name="builder"></param>
-    /// <param name="delegatingHandler">Your customized delegating handler (to manage QOS behavior by yourself)</param>
-    /// <param name="errorMapping">Unused</param>
-    /// <returns></returns>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QoS behavior by yourself).</param>
+    /// <param name="errorMapping">Your customized error mapping.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
             QosDelegatingHandlerDelegate delegatingHandler,
-            IDictionary<Type, Func<Exception, Error>> errorMapping)
+            Dictionary<Type, Func<Exception, Error>> errorMapping)
             where T : class, IPollyQoSProvider<HttpResponseMessage>
     {
         builder.Services
@@ -48,47 +51,67 @@ public static class OcelotBuilderExtensions
     }
 
     /// <summary>
-    /// Add Polly QoS provider to Ocelot
+    /// Adds Polly QoS provider to Ocelot with custom error mapping, but default <see cref="DelegatingHandler"/> is used.
     /// </summary>
-    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
-    /// <param name="builder"></param>
-    /// <param name="errorMapping">Unused</param>
-    /// <returns></returns>
-    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, IDictionary<Type, Func<Exception, Error>> errorMapping)
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="errorMapping">Your customized error mapping.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, GetDelegatingHandler, errorMapping);
+        AddPolly<T>(builder, DefaultDelegatingHandler, errorMapping);
 
     /// <summary>
-    /// Add Polly QoS provider to Ocelot with default error mapping
+    /// Adds Polly QoS provider to Ocelot with custom <see cref="DelegatingHandler"/> delegate, but default error mapping is used.
     /// </summary>
-    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
-    /// <param name="builder"></param>
-    /// <param name="delegatingHandler">Your customized delegating handler (to manage QOS behavior by yourself)</param>
-    /// <returns></returns>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QoS behavior by yourself).</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
         AddPolly<T>(builder, delegatingHandler, DefaultErrorMapping);
 
     /// <summary>
-    /// Add Polly QoS provider to Ocelot default QOS Delegating Handler
+    /// Adds Polly QoS provider to Ocelot by defaults.
     /// </summary>
-    /// <typeparam name="T">QOS Provider to use with default QOS Provider</typeparam>
-    /// <param name="builder"></param>
-    /// <returns></returns>
+    /// <remarks>
+    /// Defaults:
+    /// <list type="bullet">
+    ///   <item><see cref="DefaultDelegatingHandler"/></item>
+    ///   <item><see cref="DefaultErrorMapping"/></item>
+    /// </list>
+    /// </remarks>
+    /// <typeparam name="T">QoS provider to use (by default use <see cref="PollyQoSProvider"/>).</typeparam>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
-        AddPolly<T>(builder, GetDelegatingHandler, DefaultErrorMapping);
+        AddPolly<T>(builder, DefaultDelegatingHandler, DefaultErrorMapping);
 
     /// <summary>
-    /// Add Polly QoS provider to Ocelot with default QOS Provider and default QOS Delegating Handler
+    /// Adds Polly QoS provider to Ocelot by defaults with default QoS provider.
     /// </summary>
-   /// <param name="builder"></param>
-    /// <returns></returns>
-    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
-    {
-        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, DefaultErrorMapping);
-    }
+    /// <remarks>
+    /// Defaults:
+    /// <list type="bullet">
+    ///   <item><see cref="PollyQoSProvider"/></item>
+    ///   <item><see cref="DefaultDelegatingHandler"/></item>
+    ///   <item><see cref="DefaultErrorMapping"/></item>
+    /// </list>
+    /// </remarks>
+    /// <param name="builder">Ocelot builder to extend.</param>
+    /// <returns>The reference to the same extended <see cref="IOcelotBuilder"/> object.</returns>
+    public static IOcelotBuilder AddPolly(this IOcelotBuilder builder) =>
+        AddPolly<PollyQoSProvider>(builder, DefaultDelegatingHandler, DefaultErrorMapping);
 
-    private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
+    /// <summary>
+    /// Creates default delegating handler based on the <see cref="PollyPoliciesDelegatingHandler"/> type.
+    /// </summary>
+    /// <param name="route">The downstream route to apply the handler for.</param>
+    /// <param name="contextAccessor">The context accessor of the route.</param>
+    /// <param name="loggerFactory">The factory of logger.</param>
+    /// <returns>A <see cref="DelegatingHandler"/> object, but concreate type is the <see cref="PollyPoliciesDelegatingHandler"/> class.</returns>
+    public static DelegatingHandler DefaultDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)
         => new PollyPoliciesDelegatingHandler(route, contextAccessor, loggerFactory);
 }

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-
 using Ocelot.Configuration;
 using Ocelot.DependencyInjection;
 using Ocelot.Errors;
@@ -8,7 +7,6 @@ using Ocelot.Errors.QoS;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Ocelot.Requester;
-
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -16,14 +16,15 @@ namespace Ocelot.Provider.Polly;
 
 public static class OcelotBuilderExtensions
 {
-    private static readonly Dictionary<Type, Func<Exception, Error>> ErrorMapping = new Dictionary<Type, Func<Exception, Error>>
+    public static readonly Dictionary<Type, Func<Exception, Error>> DefaultErrorMapping = new Dictionary<Type, Func<Exception, Error>>
     {
-        {typeof(TaskCanceledException), e => new RequestTimedOutError(e)},
-        {typeof(TimeoutRejectedException), e => new RequestTimedOutError(e)},
-        {typeof(BrokenCircuitException), e => new RequestTimedOutError(e)},
-        {typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e)}
+        {typeof(TaskCanceledException), CreateRequestTimedOutError},
+        {typeof(TimeoutRejectedException), CreateRequestTimedOutError},
+        {typeof(BrokenCircuitException), CreateRequestTimedOutError},
+        {typeof(BrokenCircuitException<HttpResponseMessage>), CreateRequestTimedOutError},
     };
 
+    private static Error CreateRequestTimedOutError(Exception e) => new RequestTimedOutError(e);
 
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
             QosDelegatingHandlerDelegate delegatingHandler,

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+
 using Ocelot.Configuration;
 using Ocelot.DependencyInjection;
 using Ocelot.Errors;
@@ -7,6 +8,7 @@ using Ocelot.Errors.QoS;
 using Ocelot.Logging;
 using Ocelot.Provider.Polly.Interfaces;
 using Ocelot.Requester;
+
 using Polly.CircuitBreaker;
 using Polly.Timeout;
 
@@ -14,10 +16,19 @@ namespace Ocelot.Provider.Polly;
 
 public static class OcelotBuilderExtensions
 {
+    private static readonly Dictionary<Type, Func<Exception, Error>> ErrorMapping = new Dictionary<Type, Func<Exception, Error>>
+    {
+        {typeof(TaskCanceledException), e => new RequestTimedOutError(e)},
+        {typeof(TimeoutRejectedException), e => new RequestTimedOutError(e)},
+        {typeof(BrokenCircuitException), e => new RequestTimedOutError(e)},
+        {typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e)}
+    };
+
+
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
-        QosDelegatingHandlerDelegate delegatingHandler,
-        Dictionary<Type, Func<Exception, Error>> errorMapping)
-        where T : class, IPollyQoSProvider<HttpResponseMessage>
+            QosDelegatingHandlerDelegate delegatingHandler,
+            Dictionary<Type, Func<Exception, Error>> errorMapping)
+            where T : class, IPollyQoSProvider<HttpResponseMessage>
     {
         builder.Services
             .AddSingleton(errorMapping)
@@ -26,17 +37,22 @@ public static class OcelotBuilderExtensions
 
         return builder;
     }
+    
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, GetDelegatingHandler, errorMapping);
+
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, delegatingHandler, ErrorMapping);
+
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
+        where T : class, IPollyQoSProvider<HttpResponseMessage> =>
+        AddPolly<T>(builder, GetDelegatingHandler, ErrorMapping);
 
     public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
     {
-        var errorMapping = new Dictionary<Type, Func<Exception, Error>>
-        {
-            { typeof(TaskCanceledException), e => new RequestTimedOutError(e) },
-            { typeof(TimeoutRejectedException), e => new RequestTimedOutError(e) },
-            { typeof(BrokenCircuitException), e => new RequestTimedOutError(e) },
-            { typeof(BrokenCircuitException<HttpResponseMessage>), e => new RequestTimedOutError(e) },
-        };
-        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, errorMapping);
+        return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, ErrorMapping);
     }
 
     private static DelegatingHandler GetDelegatingHandler(DownstreamRoute route, IHttpContextAccessor contextAccessor, IOcelotLoggerFactory loggerFactory)

--- a/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
+++ b/src/Ocelot.Provider.Polly/OcelotBuilderExtensions.cs
@@ -26,9 +26,17 @@ public static class OcelotBuilderExtensions
 
     private static Error CreateRequestTimedOutError(Exception e) => new RequestTimedOutError(e);
 
+    /// <summary>
+    /// Add Polly QoS provider to Ocelot
+    /// </summary>
+    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
+    /// <param name="builder"></param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QOS behavior by yourself)</param>
+    /// <param name="errorMapping">Unused</param>
+    /// <returns></returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder,
             QosDelegatingHandlerDelegate delegatingHandler,
-            Dictionary<Type, Func<Exception, Error>> errorMapping)
+            IDictionary<Type, Func<Exception, Error>> errorMapping)
             where T : class, IPollyQoSProvider<HttpResponseMessage>
     {
         builder.Services
@@ -38,19 +46,44 @@ public static class OcelotBuilderExtensions
 
         return builder;
     }
-    
-    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
+
+    /// <summary>
+    /// Add Polly QoS provider to Ocelot
+    /// </summary>
+    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
+    /// <param name="builder"></param>
+    /// <param name="errorMapping">Unused</param>
+    /// <returns></returns>
+    public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, IDictionary<Type, Func<Exception, Error>> errorMapping)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
         AddPolly<T>(builder, GetDelegatingHandler, errorMapping);
 
+    /// <summary>
+    /// Add Polly QoS provider to Ocelot with default error mapping
+    /// </summary>
+    /// <typeparam name="T">QOS Provider to use (by default use PollyQoSProvider)</typeparam>
+    /// <param name="builder"></param>
+    /// <param name="delegatingHandler">Your customized delegating handler (to manage QOS behavior by yourself)</param>
+    /// <returns></returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
         AddPolly<T>(builder, delegatingHandler, DefaultErrorMapping);
 
+    /// <summary>
+    /// Add Polly QoS provider to Ocelot default QOS Delegating Handler
+    /// </summary>
+    /// <typeparam name="T">QOS Provider to use with default QOS Provider</typeparam>
+    /// <param name="builder"></param>
+    /// <returns></returns>
     public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
         where T : class, IPollyQoSProvider<HttpResponseMessage> =>
         AddPolly<T>(builder, GetDelegatingHandler, DefaultErrorMapping);
 
+    /// <summary>
+    /// Add Polly QoS provider to Ocelot with default QOS Provider and default QOS Delegating Handler
+    /// </summary>
+   /// <param name="builder"></param>
+    /// <returns></returns>
     public static IOcelotBuilder AddPolly(this IOcelotBuilder builder)
     {
         return AddPolly<PollyQoSProvider>(builder, GetDelegatingHandler, DefaultErrorMapping);


### PR DESCRIPTION
In certain contexts, we need to be able to fully tune the way Polly is used for timeouts and circuit-breakers, but not only that.
With this in mind, I'm proposing in this PR to open up the use of AddPolly by adding :

```csharp
public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, Dictionary<Type, Func<Exception, Error>> errorMapping)
     where T : class, IPollyQoSProvider<HttpResponseMessage> =>
     AddPolly<T>(builder, GetDelegatingHandler, errorMapping);

 public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder, QosDelegatingHandlerDelegate delegatingHandler)
     where T : class, IPollyQoSProvider<HttpResponseMessage> =>
     AddPolly<T>(builder, delegatingHandler, ErrorMapping);

 public static IOcelotBuilder AddPolly<T>(this IOcelotBuilder builder)
     where T : class, IPollyQoSProvider<HttpResponseMessage> =>
     AddPolly<T>(builder, GetDelegatingHandler, ErrorMapping);
```
Thanks to this, we will be able to use our own implementations of `IPollyQoSProvider<HttpResponseMessage>`, `QosDelegatingHandlerDelegate`  and  `Dictionary<Type, Func<Exception, Error>>`
