### PR TITLE
#2031 Don't validate placeholders in templates

### DIFF
--- a/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
@@ -12,7 +12,7 @@ namespace Ocelot.Configuration.Validator
     /// </summary>
     public partial class FileConfigurationFluentValidator : AbstractValidator<FileConfiguration>, IConfigurationValidator
     {
-        private const string ServiceFabric = "ServiceFabric";
+        private const string Servicefabric = "servicefabric";
         private readonly List<ServiceDiscoveryFinderDelegate> _serviceDiscoveryFinderDelegates;
 
         public FileConfigurationFluentValidator(IServiceProvider provider, RouteFluentValidator routeFluentValidator, FileGlobalConfigurationFluentValidator fileGlobalConfigurationFluentValidator)
@@ -61,24 +61,19 @@ namespace Ocelot.Configuration.Validator
             RuleForEach(configuration => configuration.Aggregates)
                 .Must((config, aggregateRoute) => DoesNotContainRoutesWithSpecificRequestIdKeys(aggregateRoute, config.Routes))
                 .WithMessage((_, aggregateRoute) => $"{nameof(aggregateRoute)} {aggregateRoute.UpstreamPathTemplate} contains Route with specific RequestIdKey, this is not possible with Aggregates");
-
-            // Service Fabric service discovery features
-            RuleForEach(configuration => configuration.Routes)
-                .Must(ServiceFabricPlaceholdersInServiceName)
-                .WithMessage(ServiceFabricPlaceholdersInServiceNameMessage);
         }
 
         private bool HaveServiceDiscoveryProviderRegistered(FileRoute route, FileServiceDiscoveryProvider serviceDiscoveryProvider)
         {
             return string.IsNullOrEmpty(route.ServiceName) ||
-                   ServiceFabric.Equals(serviceDiscoveryProvider?.Type, StringComparison.InvariantCultureIgnoreCase) ||
+                   serviceDiscoveryProvider?.Type?.ToLower() == Servicefabric ||
                    _serviceDiscoveryFinderDelegates.Any();
         }
 
         private bool HaveServiceDiscoveryProviderRegistered(FileServiceDiscoveryProvider serviceDiscoveryProvider)
         {
             return serviceDiscoveryProvider == null ||
-                ServiceFabric.Equals(serviceDiscoveryProvider.Type, StringComparison.InvariantCultureIgnoreCase) ||
+                Servicefabric.Equals(serviceDiscoveryProvider.Type, StringComparison.InvariantCultureIgnoreCase) ||
                 string.IsNullOrEmpty(serviceDiscoveryProvider.Type) || _serviceDiscoveryFinderDelegates.Any();
         }
 
@@ -119,26 +114,6 @@ namespace Ocelot.Configuration.Validator
                 .Select(m => m.Value).ToList();
             return placeholders.Count == placeholders.Distinct().Count();
         }
-
-        private static bool ServiceFabricPlaceholdersInServiceName(FileConfiguration configuration, FileRoute route)
-        {
-            if (!ServiceFabric.Equals(configuration?.GlobalConfiguration?.ServiceDiscoveryProvider?.Type, StringComparison.InvariantCultureIgnoreCase) ||
-                string.IsNullOrEmpty(route?.ServiceName) ||
-                !PlaceholderRegex().IsMatch(route.ServiceName))
-            {
-                return true;
-            }
-
-            var firstPlaceholders = PlaceholderRegex().Matches(route.UpstreamPathTemplate)
-                .Select(m => m.Value).ToList();
-            var secondPlaceholders = PlaceholderRegex().Matches(route.ServiceName + route.DownstreamPathTemplate)
-                .Select(m => m.Value).ToList();
-            return firstPlaceholders.All(secondPlaceholders.Contains)
-                && secondPlaceholders.All(firstPlaceholders.Contains);
-        }
-
-        private string ServiceFabricPlaceholdersInServiceNameMessage(FileConfiguration configuration, FileRoute route)
-            => $"SD Provider: {configuration?.GlobalConfiguration?.ServiceDiscoveryProvider?.Type ?? "?"}; Placeholders in ServiceName feature has invalid configuration! {nameof(route.UpstreamPathTemplate)} '{route.UpstreamPathTemplate}' doesn't contain the same placeholders in both {nameof(route.DownstreamPathTemplate)} '{route.DownstreamPathTemplate}' and {nameof(route.ServiceName)} '{route.ServiceName}', or vice versa!";
 
         private static bool DoesNotContainRoutesWithSpecificRequestIdKeys(FileAggregateRoute fileAggregateRoute,
             IEnumerable<FileRoute> routes)

--- a/test/Ocelot.AcceptanceTests/ServiceFabricTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceFabricTests.cs
@@ -173,54 +173,6 @@ namespace Ocelot.AcceptanceTests
                 .BDDfy();
         }
 
-        [Fact]
-        [Trait("PR", "722, 2032")]
-        [Trait("Feat", "721")]
-        public void should_throw_exception_when_config_is_invalid_for_ServiceFabricPlaceholdersInServiceName_rule()
-        {
-            // Arrange
-            var port = PortFinder.GetRandomPort();
-            var invalidConfig = new FileConfiguration
-            {
-                Routes =
-                [
-                    new()
-                    {
-                        DownstreamPathTemplate = "/{all}",
-                        DownstreamScheme = "http",
-                        UpstreamPathTemplate = "/api/{version}/{all}",
-                        UpstreamHttpMethod = ["Get"],
-                        ServiceName = "Service_{invalid}/Api", // invalid placeholder is not defined in upstream
-                    },
-                ],
-                GlobalConfiguration = new FileGlobalConfiguration
-                {
-                    ServiceDiscoveryProvider = new()
-                    {
-                        Host = "localhost",
-                        Port = port,
-                        Type = "ServiceFabric",
-                    },
-                },
-            };
-            _steps.GivenThereIsAConfiguration(invalidConfig);
-
-            // Act
-            Exception exception = null;
-            try
-            {
-                _steps.GivenOcelotIsRunning();
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-            }
-
-            // Assert
-            exception.ShouldNotBeNull();
-            exception.Message.ShouldBe("One or more errors occurred. (Unable to start Ocelot, errors are: SD Provider: ServiceFabric; Placeholders in ServiceName feature has invalid configuration! UpstreamPathTemplate '/api/{version}/{all}' doesn't contain the same placeholders in both DownstreamPathTemplate '/{all}' and ServiceName 'Service_{invalid}/Api', or vice versa!)");
-        }
-
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody, string expectedQueryString)
         {
             _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>

--- a/test/Ocelot.AcceptanceTests/ServiceFabricTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceFabricTests.cs
@@ -173,6 +173,54 @@ namespace Ocelot.AcceptanceTests
                 .BDDfy();
         }
 
+        [Fact]
+        [Trait("PR", "722, 2032")]
+        [Trait("Feat", "721")]
+        public void should_throw_exception_when_config_is_invalid_for_ServiceFabricPlaceholdersInServiceName_rule()
+        {
+            // Arrange
+            var port = PortFinder.GetRandomPort();
+            var invalidConfig = new FileConfiguration
+            {
+                Routes =
+                [
+                    new()
+                    {
+                        DownstreamPathTemplate = "/{all}",
+                        DownstreamScheme = "http",
+                        UpstreamPathTemplate = "/api/{version}/{all}",
+                        UpstreamHttpMethod = ["Get"],
+                        ServiceName = "Service_{invalid}/Api", // invalid placeholder is not defined in upstream
+                    },
+                ],
+                GlobalConfiguration = new FileGlobalConfiguration
+                {
+                    ServiceDiscoveryProvider = new()
+                    {
+                        Host = "localhost",
+                        Port = port,
+                        Type = "ServiceFabric",
+                    },
+                },
+            };
+            _steps.GivenThereIsAConfiguration(invalidConfig);
+
+            // Act
+            Exception exception = null;
+            try
+            {
+                _steps.GivenOcelotIsRunning();
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // Assert
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldBe("One or more errors occurred. (Unable to start Ocelot, errors are: SD Provider: ServiceFabric; Placeholders in ServiceName feature has invalid configuration! UpstreamPathTemplate '/api/{version}/{all}' doesn't contain the same placeholders in both DownstreamPathTemplate '/{all}' and ServiceName 'Service_{invalid}/Api', or vice versa!)");
+        }
+
         private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, int statusCode, string responseBody, string expectedQueryString)
         {
             _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>

--- a/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Validation/FileConfigurationFluentValidatorTests.cs
@@ -753,32 +753,12 @@ namespace Ocelot.UnitTests.Configuration.Validation
         [InlineData("/foo/{bar}/foo", "/yahoo/foo/{bar}")] // valid
         [InlineData("/foo/{bar}/{foo}", "/yahoo/{foo}/{bar}")] // valid
         [InlineData("/foo/{bar}/{bar}", "/yahoo/foo/{bar}", "UpstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder")] // invalid
-        [InlineData("/foo/{bar}/{bar}", "/yahoo/{foo}/{bar}", "UpstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder", "DownstreamPathTemplate '/yahoo/{foo}/{bar}' doesn't contain the same placeholders in UpstreamPathTemplate '/foo/{bar}/{bar}'")] // invalid
+        [InlineData("/foo/{bar}/{bar}", "/yahoo/{foo}/{bar}", "UpstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder")] // invalid
         [InlineData("/yahoo/foo/{bar}", "/foo/{bar}/foo")] // valid
         [InlineData("/yahoo/{foo}/{bar}", "/foo/{bar}/{foo}")] // valid
         [InlineData("/yahoo/foo/{bar}", "/foo/{bar}/{bar}", "DownstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder")] // invalid
-        [InlineData("/yahoo/{foo}/{bar}", "/foo/{bar}/{bar}", "DownstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder", "UpstreamPathTemplate '/yahoo/{foo}/{bar}' doesn't contain the same placeholders in DownstreamPathTemplate '/foo/{bar}/{bar}'")] // invalid
+        [InlineData("/yahoo/{foo}/{bar}", "/foo/{bar}/{bar}", "DownstreamPathTemplate '/foo/{bar}/{bar}' has duplicated placeholder")] // invalid
         public void IsPlaceholderNotDuplicatedIn_RuleForFileRoute_PathTemplatePlaceholdersAreValidated(string upstream, string downstream, params string[] expected)
-        {
-            // Arrange
-            var route = GivenDefaultRoute(upstream, downstream);
-            GivenAConfiguration(route);
-
-            // Act
-            WhenIValidateTheConfiguration();
-
-            // Assert
-            ThenThereAreErrors(expected.Length > 0);
-            ThenTheErrorMessagesAre(expected);
-        }
-
-        [Theory]
-        [Trait("PR", "1927")]
-        [InlineData("/foo/{bar}/{foo}", "/yahoo/{foo}/{bar}")] // valid
-        [InlineData("/foo/{bar}/{yahoo}", "/yahoo/{foo}/{bar}", "UpstreamPathTemplate '/foo/{bar}/{yahoo}' doesn't contain the same placeholders in DownstreamPathTemplate '/yahoo/{foo}/{bar}'", "DownstreamPathTemplate '/yahoo/{foo}/{bar}' doesn't contain the same placeholders in UpstreamPathTemplate '/foo/{bar}/{yahoo}'")] // invalid
-        [InlineData("/yahoo/{foo}/{bar}", "/foo/{bar}/{foo}")] // valid
-        [InlineData("/yahoo/{foo}/{bar}", "/foo/{bar}/{yahoo}", "UpstreamPathTemplate '/yahoo/{foo}/{bar}' doesn't contain the same placeholders in DownstreamPathTemplate '/foo/{bar}/{yahoo}'", "DownstreamPathTemplate '/foo/{bar}/{yahoo}' doesn't contain the same placeholders in UpstreamPathTemplate '/yahoo/{foo}/{bar}'")] // invalid
-        public void IsPlaceholderDefinedInBothTemplates_RuleForFileRoute_PathTemplatePlaceholdersAreValidated(string upstream, string downstream, params string[] expected)
         {
             // Arrange
             var route = GivenDefaultRoute(upstream, downstream);


### PR DESCRIPTION
## Fixes #2031 
- #2031 

## Follow up
- #683 
- #1927 

## Proposed Changes
  - Removed validation rules for path templates: `IsUpstreamPlaceholderDefinedInDownstream` and `IsDownstreamPlaceholderDefinedInUpstream`
  - Refactor validation rule for Service Fabric service discovery feature [Placeholders in Service Name](https://ocelot.readthedocs.io/en/latest/features/servicefabric.html#placeholders-in-service-name) as `ServiceFabricPlaceholdersInServiceName` rule
  - Updated all related tests
