### PR TITLE
Notes about Merging Configuration Files feature in `configuration.rst`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,5 +417,4 @@ test/Ocelot.AcceptanceTests/ocelot.json
 # Read the Docs
 # https://ocelot.readthedocs.io
 _build/
-_static/
 _templates/

--- a/docs/_static/overrides.css
+++ b/docs/_static/overrides.css
@@ -1,0 +1,3 @@
+blockquote {
+    font-size: smaller;
+}

--- a/docs/_static/overrides.css
+++ b/docs/_static/overrides.css
@@ -1,3 +1,6 @@
 blockquote {
-    font-size: smaller;
+    font-size: 0.9em;
+}
+aside.footnote-list {
+    font-size: 0.9em;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,3 +27,4 @@ html_theme = 'alabaster'
 
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_static_path
 html_static_path = ['_static']
+html_css_files = ['overrides.css']

--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -123,9 +123,16 @@ If you want to set the **GlobalConfiguration** property, you must have a file ca
 The way Ocelot merges the files is basically load them, loop over them, add any **Routes**, add any **AggregateRoutes** and if the file is called ``ocelot.global.json`` add the **GlobalConfiguration** aswell as any **Routes** or **AggregateRoutes**.
 Ocelot will then save the merged configuration to a file called `ocelot.json`_ and this will be used as the source of truth while Ocelot is running.
 
-At the moment there is no validation at this stage it only happens when Ocelot validates the final merged configuration.
-This is something to be aware of when you are investigating problems. 
-We would advise always checking what is in `ocelot.json`_ file if you have any problems.
+  **Note 1**: Currently, validation occurs only during the final merging of configurations in Ocelot.
+  It's essential to be aware of this when troubleshooting issues.
+  We recommend thoroughly inspecting the contents of the ``ocelot.json`` file if you encounter any problems.
+
+  **Note 2**: The Merging feature is operational only during the application's startup.
+  Consequently, the merged configuration in ``ocelot.json`` remains static post-merging and startup.
+  It's important to be aware that the ``ConfigureAppConfiguration`` method is invoked solely during the startup of an ASP.NET web application.
+  Once the Ocelot application has started, you cannot call the ``AddOcelot`` method, nor can you employ the merging feature within ``AddOcelot``.
+  If you still require on-the-fly updating of the primary configuration file, ``ocelot.json``, please refer to the :ref:`config-react-to-changes` section.
+  Additionally, note that merging partial configuration files (such as ``ocelot.*.json``) on the fly using :doc:`../features/administration` API is not currently implemented.
 
 Keep files in a folder
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -335,6 +342,8 @@ As a team, we highly recommend following these instructions when developing your
 * **Production environments**. **Do not use self-signed certificates at all!**
   System administrators or DevOps engineers must create real valid certificates being signed by hosting or cloud providers.
   **Switch off the feature for all routes!** Remove the **DangerousAcceptAnyServerCertificateValidator** property for all routes in production version of `ocelot.json`_ file!
+
+.. _config-react-to-changes:
 
 React to Configuration Changes
 ------------------------------


### PR DESCRIPTION
## Closes #2042 
- #2042 

## Proposed Changes
  - Notes 1 and 2 have been added with user guidelines for [the feature](https://ocelot.readthedocs.io/en/latest/features/configuration.html#merging-configuration-files) usage.
  - Added static reStructuredText CSS overrides
