### PR TITLE
#2039 Buffer request body and copy the body to downstreams during multiplexing

### DIFF
--- a/docs/features/requestaggregation.rst
+++ b/docs/features/requestaggregation.rst
@@ -217,9 +217,12 @@ Below is an example of an aggregator that you could implement for your solution:
 Gotchas
 -------
 
-You cannot use Routes with specific **RequestIdKeys** as this would be crazy complicated to track.
+* You cannot use Routes with specific **RequestIdKeys** as this would be crazy complicated to track.
+* Aggregation only supports the ``GET`` HTTP verb.
+* Aggregation allows for the forwarding of ``HttpRequest.Body`` to downstream services by duplicating the body data.
+  Form data and attached files should also be forwarded.
+  It is essential to always specify the ``Content-Length`` header in requests to upstream; otherwise, Ocelot will log warnings like *"Aggregation does not support body copy without Content-Length header!"*.
 
-Aggregation only supports the ``GET`` HTTP verb.
 
 """"
 

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -215,7 +215,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
         {
             Request =
             {
-                Body = await CopyBufferToTargetRequestAsync(source),
+                Body = await CloneRequestBodyAsync(source),
                 ContentLength = from.ContentLength,
                 ContentType = from.ContentType,
                 Host = from.Host,
@@ -257,7 +257,7 @@ public class MultiplexingMiddleware : OcelotMiddleware
         return aggregator.Aggregate(route, httpContext, contexts);
     }
 
-    protected virtual async Task<Stream> CopyBufferToTargetRequestAsync(HttpContext source)
+    protected virtual async Task<Stream> CloneRequestBodyAsync(HttpContext source)
     {
         source.Request.EnableBuffering();
         if (source.Request.Body.Position == 0)

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -269,6 +269,10 @@ public class MultiplexingMiddleware : OcelotMiddleware
                 targetBuffer.Position = 0;
                 request.Body.Position = 0;
             }
+            else
+            {
+                Logger.LogWarning("Aggregation does not support body copy without Content-Length header!");
+            }
 
             return targetBuffer;
         }

--- a/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
+++ b/src/Ocelot/Multiplexer/MultiplexingMiddleware.cs
@@ -260,26 +260,24 @@ public class MultiplexingMiddleware : OcelotMiddleware
     protected virtual async Task<Stream> CloneRequestBodyAsync(HttpRequest request, CancellationToken aborted)
     {
         request.EnableBuffering();
-        if (request.Body.Position == 0)
-        {
-            var targetBuffer = new MemoryStream();
-            if (request.ContentLength is not null)
-            {
-                await request.Body.CopyToAsync(targetBuffer, (int)request.ContentLength, aborted);
-                targetBuffer.Position = 0;
-                request.Body.Position = 0;
-            }
-            else
-            {
-                Logger.LogWarning("Aggregation does not support body copy without Content-Length header!");
-            }
-
-            return targetBuffer;
-        }
-        else
+        if (request.Body.Position != 0)
         {
             Logger.LogWarning("Ocelot does not support body copy without stream in initial position 0");
             return request.Body;
         }
+
+        var targetBuffer = new MemoryStream();
+        if (request.ContentLength is not null)
+        {
+            await request.Body.CopyToAsync(targetBuffer, (int)request.ContentLength, aborted);
+            targetBuffer.Position = 0;
+            request.Body.Position = 0;
+        }
+        else
+        {
+            Logger.LogWarning("Aggregation does not support body copy without Content-Length header!");
+        }
+
+        return targetBuffer;
     }
 }

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -639,8 +639,8 @@ namespace Ocelot.AcceptanceTests
                 new KeyValuePair<string, string>("param2", "from-form-REPLACESTRING"),
             };
 
-            var sub1ResponseContent = @"""[key:param1=value1&param2=from-form-s1]""";
-            var sub2ResponseContent = @"""[key:param1=value1&param2=from-form-s2]""";
+            var sub1ResponseContent = "\"[key:param1=value1&param2=from-form-s1]\"";
+            var sub2ResponseContent = "\"[key:param1=value1&param2=from-form-s2]\"";
             var expected = $"{{\"Service1\":{sub1ResponseContent},\"Service2\":{sub2ResponseContent}}}";
 
             this.Given(x => x.GivenServiceIsRunning(0, port1, "/Sub1", 200, (IFormCollection reqForm) => FormatFormCollection(reqForm).Replace("REPLACESTRING", "s1")))
@@ -655,16 +655,17 @@ namespace Ocelot.AcceptanceTests
 
         private static string FormatFormCollection(IFormCollection reqForm)
         {
-            var sb = new StringBuilder();
-            sb.Append("\"");
+            var sb = new StringBuilder()
+                .Append('"');
 
             foreach (var kvp in reqForm)
             {
                 sb.Append($"[{kvp.Key}:{kvp.Value}]");
             }
 
-            sb.Append("\"");
-            return sb.ToString();
+            return sb
+                .Append('"')
+                .ToString();
         }
 
         private void GivenServiceIsRunning(string baseUrl, int statusCode, string responseBody)
@@ -770,12 +771,14 @@ namespace Ocelot.AcceptanceTests
         private static new FileConfiguration GivenConfiguration(params FileRoute[] routes)
         {
             var obj = Steps.GivenConfiguration(routes);
-            obj.Aggregates.Add(new()
-            {
-                UpstreamPathTemplate = "/",
-                UpstreamHost = "localhost",
-                RouteKeys = routes.Select(r => r.Key).ToList(), // [ "Laura", "Tom" ],
-            });
+            obj.Aggregates.Add(
+                new()
+                {
+                    UpstreamPathTemplate = "/",
+                    UpstreamHost = "localhost",
+                    RouteKeys = routes.Select(r => r.Key).ToList(), // [ "Laura", "Tom" ],
+                }
+            );
             return obj;
         }
     }

--- a/test/Ocelot.AcceptanceTests/AggregateTests.cs
+++ b/test/Ocelot.AcceptanceTests/AggregateTests.cs
@@ -598,6 +598,81 @@ namespace Ocelot.AcceptanceTests
             }
         }
 
+        [Fact]
+        [Trait("Bug", "2039")]
+        public void Should_return_response_200_with_body_sent_on_multiple_services()
+        {
+            var port1 = PortFinder.GetRandomPort();
+            var port2 = PortFinder.GetRandomPort();
+            var configuration = new FileConfiguration
+            {
+                Routes = new()
+                {
+                    new FileRoute
+                    {
+                        DownstreamPathTemplate = "/Sub1",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new()
+                        {
+                            new FileHostAndPort
+                            {
+                                Host = "localhost",
+                                Port = port1,
+                            },
+                        },
+                        UpstreamPathTemplate = "/Service1",
+                        UpstreamHttpMethod = new() { "Get" },
+                        Key = "Service1",
+                    },
+                    new FileRoute
+                    {
+                        DownstreamPathTemplate = "/Sub2",
+                        DownstreamScheme = "http",
+                        DownstreamHostAndPorts = new()
+                        {
+                            new FileHostAndPort
+                            {
+                                Host = "localhost",
+                                Port = port2,
+                            },
+                        },
+                        UpstreamPathTemplate = "/Service2",
+                        UpstreamHttpMethod = new() { "Get" },
+                        Key = "Service2",
+                    },
+                },
+                Aggregates = new()
+                {
+                    new FileAggregateRoute
+                    {
+                        UpstreamPathTemplate = "/",
+                        UpstreamHost = "localhost",
+                        RouteKeys = new ()
+                        {
+                            "Service1",
+                            "Service2",
+                        },
+                    },
+                },
+            };
+
+            var requestBody = @"{""id"":1,""response"":""fromBody-#REPLACESTRING#""}";
+
+            var sub1ResponseContent = @"{""id"":1,""response"":""fromBody-s1""}";
+            var sub2ResponseContent = @"{""id"":1,""response"":""fromBody-s2""}";
+
+            var expected = "{\"Service1\":" + sub1ResponseContent + ",\"Service2\":" + sub2ResponseContent + "}";
+
+            this.Given(x => x.GivenServiceIsRunning(0, port1, "/Sub1", 200, reqBody => reqBody.Replace("#REPLACESTRING#", "s1")))
+                .Given(x => x.GivenServiceIsRunning(1, port2, "/Sub2", 200, reqBody => reqBody.Replace("#REPLACESTRING#", "s2")))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlWithBodyOnTheApiGateway("/", requestBody))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+                .And(x => ThenTheResponseBodyShouldBe(expected))
+                .BDDfy();
+        }
+
         private void GivenServiceIsRunning(string baseUrl, int statusCode, string responseBody)
         {
             _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, async context =>
@@ -622,6 +697,28 @@ namespace Ocelot.AcceptanceTests
                 else
                 {
                     context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync(responseBody);
+                }
+            });
+        }
+
+        private void GivenServiceIsRunning(int index, int port, string basePath, int statusCode, Func<string, string> responseFromBody)
+        {
+            var baseUrl = $"{Uri.UriSchemeHttp}://localhost:{port}";
+            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
+            {
+                _downstreamPaths[index] = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value : context.Request.Path.Value;
+
+                if (_downstreamPaths[index] != basePath)
+                {
+                    context.Response.StatusCode = statusCode;
+                    await context.Response.WriteAsync("downstream path didn't match base path");
+                }
+                else
+                {
+                    context.Response.StatusCode = statusCode;
+                    var requestBody = await new StreamReader(context.Request.Body).ReadToEndAsync();
+                    var responseBody = responseFromBody(requestBody);
                     await context.Response.WriteAsync(responseBody);
                 }
             });

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -826,6 +826,20 @@ public class Steps : IDisposable
         _response = _ocelotClient.SendAsync(request).Result;
     }
 
+    public void WhenIGetUrlWithFormOnTheApiGateway(string url, string name, IEnumerable<KeyValuePair<string, string>> values)
+    {
+        var content = new MultipartFormDataContent();
+        var dataContent = new FormUrlEncodedContent(values);
+        content.Add(dataContent, name);
+        content.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, url)
+        {
+            Content = content,
+        };
+        _response = _ocelotClient.SendAsync(request).Result;
+    }
+
     public void WhenICancelTheRequest()
     {
         _ocelotClient.CancelPendingRequests();

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -191,7 +191,7 @@ public class Steps : IDisposable
                 Console.WriteLine(e);
             }
         }
-     }
+    }
 
     public void ThenTheResponseBodyHeaderIs(string key, string value)
     {
@@ -815,6 +815,15 @@ public class Steps : IDisposable
     public void WhenIGetUrlOnTheApiGatewayAndDontWait(string url)
     {
         _ocelotClient.GetAsync(url);
+    }
+
+    public void WhenIGetUrlWithBodyOnTheApiGateway(string url, string body)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url)
+        {
+            Content = new StringContent(body),
+        };
+        _response = _ocelotClient.SendAsync(request).Result;
     }
 
     public void WhenICancelTheRequest()

--- a/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
@@ -233,7 +233,8 @@ namespace Ocelot.UnitTests.Multiplexing
             // Assert
             mock.Protected().Verify<Task<Stream>>("CloneRequestBodyAsync",
                 numberOfRoutes > 1 ? Times.Exactly(numberOfRoutes) : Times.Never(),
-                ItExpr.IsAny<HttpContext>());
+                ItExpr.IsAny<HttpRequest>(),
+                ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]

--- a/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Multiplexing/MultiplexingMiddlewareTests.cs
@@ -219,41 +219,41 @@ namespace Ocelot.UnitTests.Multiplexing
         [InlineData(3)]
         [InlineData(4)]
         [Trait("Bug", "2039")]
-        public async Task Should_Call_CopyBufferToTargetRequestAsync_EachTime_ForMultipleRequests(int numberOfRoutes)
+        public async Task Should_Call_CloneRequestBodyAsync_Each_Time_Per_Requests(int numberOfRoutes)
         {
             var mock = MockMiddlewareFactory(null, null);
 
             _middleware = mock.Object;
 
             // Arrange
-            GivenUser("test", "Invoke", nameof(Should_Call_CopyBufferToTargetRequestAsync_EachTime_ForMultipleRequests));
+            GivenUser("test", "Invoke", nameof(Should_Call_CloneRequestBodyAsync_Each_Time_Per_Requests));
             GivenTheFollowing(GivenDefaultRoute(numberOfRoutes));
 
             // Act
             await WhenIMultiplex();
 
             // Assert
-            mock.Protected().Verify<Task<Stream>>("CopyBufferToTargetRequestAsync", Times.Exactly(numberOfRoutes),
+            mock.Protected().Verify<Task<Stream>>("CloneRequestBodyAsync", Times.Exactly(numberOfRoutes),
                 ItExpr.IsAny<HttpContext>());
         }
 
         [Fact]
         [Trait("Bug", "2039")]
-        public async Task Should_Not_Call_CopyBufferToTargetRequestAsync_With_One_Route()
+        public async Task Should_Not_Call_CloneRequestBodyAsync_With_One_Route()
         {
             var mock = MockMiddlewareFactory(null, null);
 
             _middleware = mock.Object;
 
             // Arrange
-            GivenUser("test", "Invoke", nameof(Should_Call_CopyBufferToTargetRequestAsync_EachTime_ForMultipleRequests));
+            GivenUser("test", "Invoke", nameof(Should_Not_Call_CloneRequestBodyAsync_With_One_Route));
             GivenTheFollowing(GivenDefaultRoute(1));
 
             // Act
             await WhenIMultiplex();
 
             // Assert
-            mock.Protected().Verify<Task<Stream>>("CopyBufferToTargetRequestAsync", Times.Never(),
+            mock.Protected().Verify<Task<Stream>>("CloneRequestBodyAsync", Times.Never(),
                 ItExpr.IsAny<HttpContext>());
         }
 


### PR DESCRIPTION
## Closes #2039 
- #2039 

Buffers the body of the request when multiplexing multiple routes and copy the buffered body to the downstreams.

I took consideration of all your feedbacks from the previous PR, don't hesitate to tell me if something's off, either in the code or in the process.

I looked at the benchmark tests but I'm not sure on how to integrate this correctly.

## Proposed Changes

  - Smartly enables ASP.NET buffering for body copy
  - Copy the buffer to the downstream requests through a `MemoryStream`
  - Fixes broken tests due to `CreateThreadContext` name and parameter changes
  - Unit tests on `CloneRequestBodyAsync` (called n times when n > 1, not called for 1)
  - Acceptance test of body copy for multiple services