### PR TITLE
Release 23.3.4 artifacts | +semver: patch

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,16 +1,6 @@
-Technical release, version {0}
-
-### Breaking changes
-
-- The `ILoadBalancer` interface: The `Lease` method was renamed to `LeaseAsync`.
-  Interface FQN: `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer`
-  Method FQN:  `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer.LeaseAsync`
-- TO BE Written
-
-
-## 🔥Hot fixing v[23.3](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0) (version 23.3.4) aka [Blue Olympic Balumbes](https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518) release
+## 🔥 Hot fixing v[23.3](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0) (version {0}) aka [Blue Olympic Balumbes](https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518) release
 > Codenamed: **[Blue Olympic Fiend](https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518)**
-> Read the Docs: [Ocelot 23.3](https://ocelot.readthedocs.io/en/23.3.4/)
+> Read the Docs: [Ocelot 23.3](https://ocelot.readthedocs.io/en/{0}/)
 > Hot fixed versions: [23.3.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0), [23.3.3](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.3)
 > Milestone: [v23.3 Hotfixes](https://github.com/ThreeMammals/Ocelot/milestone/8)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,3 +6,36 @@ Technical release, version {0}
   Interface FQN: `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer`
   Method FQN:  `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer.LeaseAsync`
 - TO BE Written
+
+
+## 🔥Hot fixing v[23.3](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0) (version 23.3.4) aka [Blue Olympic Balumbes](https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518) release
+> Codenamed: **[Blue Olympic Fiend](https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518)**
+> Read the Docs: [Ocelot 23.3](https://ocelot.readthedocs.io/en/23.3.4/)
+> Hot fixed versions: [23.3.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0), [23.3.3](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.3)
+> Milestone: [v23.3 Hotfixes](https://github.com/ThreeMammals/Ocelot/milestone/8)
+
+❤️ A heartfelt "Thank You" to [Roman Shevchik](https://github.com/antikorol) and [Massimiliano Innocenti](https://github.com/minnocenti901) for their contributions in testing and reporting the [Service Discovery](https://github.com/ThreeMammals/Ocelot/labels/Service%20Discovery) issues, #2110 and #2119, respectively!
+
+### ℹ️ About
+This release delivers a number of bug fixes for the predecessor's [23.3.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0) release, which is full of new features but was not tested well. All bugs were combined into the [v23.3 Hotfixes](https://github.com/ThreeMammals/Ocelot/milestone/8) milestone.
+
+Following the substantial refactoring of [Service Discovery](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/servicediscovery.rst) providers in the [23.3.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0) release, the community identified and we have acknowledged several [critical service discovery defects](https://github.com/ThreeMammals/Ocelot/issues?q=is%3Aissue+milestone%3A%22v23.3+Hotfixes%22+label%3A%22Service+Discovery%22) with providers such as [Kube](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/kubernetes.rst) and [Consul](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/servicediscovery.rst#consul). The `Kube` provider, while somewhat unstable, remained operational; however, the `Consul` provider was entirely non-functional.
+
+📓 If your projects rely on the [Service Discovery](https://ocelot.readthedocs.io/en/latest/features/servicediscovery.html) feature and cannot function without it, please upgrade to this version to utilize the full list of features of version [23.3.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0).
+
+### 🧑‍💻 Technical Information
+A comprehensive explanation of the technical details would span several pages; therefore, it is advisable for fans of Ocelot to review all pertinent technical information within the issue descriptions associated with [the milestone](https://github.com/ThreeMammals/Ocelot/milestone/8).
+Our team has implemented some **Breaking Changes** which we urge you to review carefully (details follow).
+
+### ⚠️ Breaking Changes
+Listed by priority:
+- `ILoadBalancer` interface alteration: Method `Lease` is now `LeaseAsync`.
+  Interface FQN: `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer`
+  Method FQN: `Ocelot.LoadBalancer.LoadBalancers.ILoadBalancer.LeaseAsync`
+- `DefaultConsulServiceBuilder` constructor modification: The first parameter's type has been changed from `Func<ConsulRegistryConfiguration>` to `IHttpContextAccessor`.
+  Class FQN: `Ocelot.Provider.Consul.DefaultConsulServiceBuilder`
+  Constructor signature: `public DefaultConsulServiceBuilder(IHttpContextAccessor contextAccessor, IConsulClientFactory clientFactory, IOcelotLoggerFactory loggerFactory)`
+- Adjustments to `Lease` type: The `Lease` has been restructured from a class to a structure and elevated in the namespace hierarchy.
+  Struct FQN: `Ocelot.LoadBalancer.Lease`
+
+📓 Should your [custom solutions](https://ocelot.readthedocs.io/en/latest/search.html?q=custom) involve overriding default Ocelot classes and their behavior, redevelopment or at least recompilation of the solution, followed by deployment, will be necessary.

--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 #tool nuget:?package=ReportGenerator&version=5.2.4
 #addin nuget:?package=Newtonsoft.Json&version=13.0.3
 #addin nuget:?package=System.Text.Encodings.Web&version=8.0.0
-#addin nuget:?package=Cake.Coveralls&version=1.1.0
+#addin nuget:?package=Cake.Coveralls&version=4.0.0
 
 #r "Spectre.Console"
 using Spectre.Console

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,23 +58,31 @@ We **do** follow development process which is described in :doc:`../building/rel
 Patches
 -------
 
-- `23.3.3`_: Technical release with DevOps patch.
-- `23.3.4`_: Hot fixing version `23.3.0`_, codenamed `Blue Olympic Balumbes <https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518>`_ release,
-  with codename decoding links:
+- `23.3.3`_, on Jun 11, 2024. Technical release with DevOps patch.
+- `23.3.4`_, on Oct 3, 2024. Hot fixing version `23.3.0`_, codenamed `Blue Olympic Balumbes <https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518>`_ release.
+
+  :htm:`<details><summary>Codename decoding links</summary>`
 
   - **for men** :htm:`&rarr;` naked `Blue Olympic Fiend <https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518>`_ 
   - **for women** :htm:`&rarr;` not a well-dressed woman sings at the opening ceremony, so "Not `Celine Dion <https://www.celinedion.com/>`_" 
   - **for black men** :htm:`&rarr;` don't care about White movements, so enjoy `Black Men's Basketball Final <https://www.youtube.com/watch?v=Xci7dzk-bFk>`_ in `Paris 2024 <https://www.youtube.com/hashtag/paris2024>`_:
     be proud of Stephen Curry, "just give me a ball" boy, as an absolute rockstar, made `shot 1 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=832s>`_, `shot 2 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1052s>`_, `shot 3 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1087s>`_  and final `shot 4 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1216s>`_.
 
+  :htm:`</details>`
+
 Release Notes
 -------------
 
 | Release Tag: `23.3.0`_
-| Release Codename: `Twilight Texas <https://www.timeanddate.com/eclipse/solar/2024-april-8>`_, with codename decoding links:
-  :htm:`&rarr;` `for men <https://www.timeanddate.com/eclipse/map/2024-april-8>`_
-  :htm:`&rarr;` `for women <https://www.goodreads.com/series/50439-twilight-texas>`_
-  :htm:`&rarr;` `for black men <https://rollingout.com/2024/06/03/eclipse-darkness-busta-rhymes-twista/>`_
+| Release Codename: `Twilight Texas <https://www.timeanddate.com/eclipse/solar/2024-april-8>`_
+
+  :htm:`<details><summary>Codename decoding links</summary>`
+
+  - `for men <https://www.timeanddate.com/eclipse/map/2024-april-8>`_
+  - `for women <https://www.goodreads.com/series/50439-twilight-texas>`_
+  - `for black men <https://rollingout.com/2024/06/03/eclipse-darkness-busta-rhymes-twista/>`_
+
+  :htm:`</details>`
 
 What's new?
 ^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,11 @@
 .. _@thiagoloureiro: https://github.com/thiagoloureiro
 .. _@bbenameur: https://github.com/bbenameur
 
-.. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
-.. _23.3.0: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _23.2.0: https://github.com/ThreeMammals/Ocelot/releases/tag/23.2.0
+.. _23.3.0: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
+.. _23.3.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.3
+.. _23.3.4: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.4
+.. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.4
 
 .. _954: https://github.com/ThreeMammals/Ocelot/issues/954
 .. _957: https://github.com/ThreeMammals/Ocelot/issues/957
@@ -53,12 +55,24 @@ The main features are :doc:`../features/configuration` and :doc:`../features/rou
 
 We **do** follow development process which is described in :doc:`../building/releaseprocess`.
 
+Patches
+-------
+
+- `23.3.3`_: Technical release with DevOps patch.
+- `23.3.4`_: Hot fixing version `23.3.0`_, codenamed `Blue Olympic Balumbes <https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518>`_ release,
+  with codename decoding links:
+
+  - **for men** :htm:`&rarr;` naked `Blue Olympic Fiend <https://www.youtube.com/live/j-Ou-ggS718?si=fPPwmOwjYEZq70H9&t=9518>`_ 
+  - **for women** :htm:`&rarr;` not a well-dressed woman sings at the opening ceremony, so "Not `Celine Dion <https://www.celinedion.com/>`_" 
+  - **for black men** :htm:`&rarr;` don't care about White movements, so enjoy `Black Men's Basketball Final <https://www.youtube.com/watch?v=Xci7dzk-bFk>`_ in `Paris 2024 <https://www.youtube.com/hashtag/paris2024>`_:
+    be proud of Stephen Curry, "just give me a ball" boy, as an absolute rockstar, made `shot 1 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=832s>`_, `shot 2 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1052s>`_, `shot 3 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1087s>`_  and final `shot 4 <https://www.youtube.com/watch?v=Xci7dzk-bFk&t=1216s>`_.
+
 Release Notes
 -------------
 
 | Release Tag: `23.3.0`_
-| Release Codename: **Twilight Texas**
-  :htm:`&rarr;` `for men <https://www.timeanddate.com/eclipse/solar/2024-april-8>`_
+| Release Codename: `Twilight Texas <https://www.timeanddate.com/eclipse/solar/2024-april-8>`_, with codename decoding links:
+  :htm:`&rarr;` `for men <https://www.timeanddate.com/eclipse/map/2024-april-8>`_
   :htm:`&rarr;` `for women <https://www.goodreads.com/series/50439-twilight-texas>`_
   :htm:`&rarr;` `for black men <https://rollingout.com/2024/06/03/eclipse-darkness-busta-rhymes-twista/>`_
 
@@ -133,8 +147,8 @@ Ocelot extra packages
     If both `Circuit Breaker`_ and `Timeout`_ have :ref:`qos-configuration` with their respective properties in the ``QoSOptions`` of the route JSON, then the :ref:`qos-circuit-breaker-strategy` will take precedence in the constructed resilience pipeline.
     For more details, refer to PR `2086`_.
 
-Stabilization aka bug fixing
-""""""""""""""""""""""""""""
+Stabilization (bug fixing)
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fixed `2034`_ in PR `2045`_ by `@raman-m`_
 - Fixed `2039`_ in PR `2050`_ by `@PaulARoy`_
@@ -146,8 +160,8 @@ Stabilization aka bug fixing
 
 See `all bugs <https://github.com/ThreeMammals/Ocelot/issues?q=is%3Aissue+milestone%3ASpring%2724+is%3Aclosed+label%3Abug>`_ of the `Spring'24 <https://github.com/ThreeMammals/Ocelot/milestone/6>`_ milestone
 
-Documentation for version `23.3`_
-"""""""""""""""""""""""""""""""""
+Documentation Summary
+^^^^^^^^^^^^^^^^^^^^^
 
 - :doc:`../features/caching`: New :ref:`cch-enablecontenthashing-option` and :ref:`cch-global-configuration` sections
 - :doc:`../features/configuration`: New :ref:`config-version-policy` and :ref:`config-route-metadata` sections

--- a/samples/OpenTracing/Ocelot.Samples.OpenTracing.csproj
+++ b/samples/OpenTracing/Ocelot.Samples.OpenTracing.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Jaeger" Version="1.0.3" />
-    
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Ocelot.Tracing.OpenTracing\Ocelot.Tracing.OpenTracing.csproj" />
@@ -23,7 +22,7 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="appsettings.Development.json">

--- a/src/Ocelot.Administration/Ocelot.Administration.csproj
+++ b/src/Ocelot.Administration/Ocelot.Administration.csproj
@@ -31,28 +31,28 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.33" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.20" />
     <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Cache.CacheManager/Ocelot.Cache.CacheManager.csproj
+++ b/src/Ocelot.Cache.CacheManager/Ocelot.Cache.CacheManager.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CacheManager.Core" Version="2.0.0-beta-1629" />
@@ -39,7 +39,7 @@
     <PackageReference Include="CacheManager.Microsoft.Extensions.Logging" Version="2.0.0-beta-1629" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
@@ -47,12 +47,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.11" />
+    <PackageReference Include="Microsoft.NETCore.Platforms" Version="6.0.13" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
@@ -60,7 +60,7 @@
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="8.0.0-preview.7.23375.6" />

--- a/src/Ocelot.Provider.Consul/Ocelot.Provider.Consul.csproj
+++ b/src/Ocelot.Provider.Consul/Ocelot.Provider.Consul.csproj
@@ -30,12 +30,12 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Consul" Version="1.7.14.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="Consul" Version="1.7.14.4" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Provider.Eureka/Ocelot.Provider.Eureka.csproj
+++ b/src/Ocelot.Provider.Eureka/Ocelot.Provider.Eureka.csproj
@@ -33,11 +33,11 @@
   <ItemGroup>
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="3.2.8" />
     <PackageReference Include="Steeltoe.Discovery.Eureka" Version="3.2.8" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
+++ b/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
@@ -29,9 +29,9 @@
     <Compile Remove="KubeApiClientFactory.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="KubeClient" Version="2.5.8" />
-    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="2.5.8" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="KubeClient" Version="2.5.10" />
+    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="2.5.10" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -39,6 +39,6 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Provider.Polly/Ocelot.Provider.Polly.csproj
+++ b/src/Ocelot.Provider.Polly/Ocelot.Provider.Polly.csproj
@@ -31,12 +31,12 @@
     <ProjectReference Include="..\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Polly" Version="8.4.0" />
+    <PackageReference Include="Polly" Version="8.4.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Provider.Polly/OcelotResiliencePipelineKey.cs
+++ b/src/Ocelot.Provider.Polly/OcelotResiliencePipelineKey.cs
@@ -5,8 +5,5 @@ namespace Ocelot.Provider.Polly;
 /// <summary>
 /// Object used to identify a resilience pipeline in <see cref="ResiliencePipelineRegistry{OcelotResiliencePipelineKey}"/>.
 /// </summary>
-/// <value>
-/// Object used to identify a resilience pipeline in <see cref="ResiliencePipelineRegistry{OcelotResiliencePipelineKey}"/>
-/// </value>
 /// <param name="Key">The key for the resilience pipeline.</param>
 public record OcelotResiliencePipelineKey(string Key);

--- a/src/Ocelot.Tracing.Butterfly/Ocelot.Tracing.Butterfly.csproj
+++ b/src/Ocelot.Tracing.Butterfly/Ocelot.Tracing.Butterfly.csproj
@@ -33,11 +33,11 @@
   <ItemGroup>
     <PackageReference Include="Butterfly.Client" Version="0.0.8" />
     <PackageReference Include="Butterfly.Client.AspNetCore" Version="0.0.8" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocelot.Tracing.OpenTracing/Ocelot.Tracing.OpenTracing.csproj
+++ b/src/Ocelot.Tracing.OpenTracing/Ocelot.Tracing.OpenTracing.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Ocelot/Configuration/Validator/RouteFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/RouteFluentValidator.cs
@@ -27,7 +27,7 @@ namespace Ocelot.Configuration.Validator
             When(route => !string.IsNullOrEmpty(route.DownstreamPathTemplate), () =>
             {
                 RuleFor(route => route.DownstreamPathTemplate)
-                    .Must(path => path.StartsWith("/"))
+                    .Must(path => path.StartsWith('/'))
                     .WithMessage("{PropertyName} {PropertyValue} doesnt start with forward slash");
 
                 RuleFor(route => route.DownstreamPathTemplate)
@@ -46,7 +46,7 @@ namespace Ocelot.Configuration.Validator
                     .WithMessage("{PropertyName} {PropertyValue} contains double forward slash, Ocelot does not support this at the moment. Please raise an issue in GitHib if you need this feature.");
 
                 RuleFor(route => route.UpstreamPathTemplate)
-                    .Must(path => path.StartsWith("/"))
+                    .Must(path => path.StartsWith('/'))
                     .WithMessage("{PropertyName} {PropertyValue} doesnt start with forward slash");
 
                 RuleFor(route => route.UpstreamPathTemplate)

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -313,7 +313,6 @@ namespace Ocelot.DependencyInjection
             return this;
         }
 
-
         /// <summary>For local implementation purposes, so it MUST NOT be public!..</summary>
         private IServiceProvider _serviceProvider; // TODO Reuse ActivatorUtilities factories?
 

--- a/src/Ocelot/Ocelot.csproj
+++ b/src/Ocelot/Ocelot.csproj
@@ -29,32 +29,32 @@
   </PropertyGroup>
   <!-- Project dependencies -->
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="11.8.0" />
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="IPAddressRange" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="6.0.33" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.33" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="7.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="7.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.20" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />

--- a/src/Ocelot/RateLimiting/RateLimiting.cs
+++ b/src/Ocelot/RateLimiting/RateLimiting.cs
@@ -65,15 +65,18 @@ public class RateLimiting : IRateLimiting
     public virtual RateLimitCounter Count(RateLimitCounter? entry, RateLimitRule rule)
     {
         var now = DateTime.UtcNow;
-        if (!entry.HasValue) // no entry, start counting
+        if (!entry.HasValue)
         {
+            // no entry, start counting
             return new RateLimitCounter(now, null, 1); // current request is the 1st one
         }
 
         var counter = entry.Value;
         var total = counter.TotalRequests + 1; // increment request count
         var startedAt = counter.StartedAt;
-        if (startedAt + ToTimespan(rule.Period) >= now) // counting Period is active
+
+        // Counting Period is active
+        if (startedAt + ToTimespan(rule.Period) >= now)
         {
             var exceededAt = total >= rule.Limit && !counter.ExceededAt.HasValue // current request number equals to the limit
                 ? now // the exceeding moment is now, the next request will fail but the current one doesn't
@@ -144,7 +147,9 @@ public class RateLimiting : IRateLimiting
             ? defaultSeconds // allow values which are greater or equal to 1 second
             : rule.PeriodTimespan; // good value
         var now = DateTime.UtcNow;
-        if (counter.StartedAt + ToTimespan(rule.Period) >= now) // counting Period is active
+
+        // Counting Period is active
+        if (counter.StartedAt + ToTimespan(rule.Period) >= now)
         {
             return counter.TotalRequests < rule.Limit
                 ? 0.0D // happy path, no need to retry, current request is valid
@@ -153,8 +158,8 @@ public class RateLimiting : IRateLimiting
                     : periodTimespan; // exceeding not yet detected -> let's ban for whole period
         }
 
-        if (counter.ExceededAt.HasValue && // limit exceeding was happen
-            counter.ExceededAt + TimeSpan.FromSeconds(periodTimespan) >= now) // ban PeriodTimespan is active
+        // Limit exceeding was happen && ban PeriodTimespan is active
+        if (counter.ExceededAt.HasValue && counter.ExceededAt + TimeSpan.FromSeconds(periodTimespan) >= now)
         {
             var startedAt = counter.ExceededAt.Value; // ban period was started at
             double secondsPast = (now - startedAt).TotalSeconds;

--- a/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+++ b/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
@@ -45,36 +45,36 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Serilog" Version="3.1.1" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     <PackageReference Include="Butterfly.Client.AspNetCore" Version="0.0.8" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="OpenTracing" Version="0.12.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
-    <PackageReference Include="Consul" Version="1.7.14.1" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="Consul" Version="1.7.14.4" />
     <PackageReference Include="CacheManager.Microsoft.Extensions.Logging" Version="2.0.0-beta-1629" />
     <PackageReference Include="CacheManager.Serialization.Json" Version="2.0.0-beta-1629" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="3.2.8" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
@@ -87,7 +87,7 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
@@ -100,18 +100,18 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.Benchmarks/Ocelot.Benchmarks.csproj
+++ b/test/Ocelot.Benchmarks/Ocelot.Benchmarks.csproj
@@ -21,24 +21,24 @@
     <ProjectReference Include="..\..\src\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.11" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-	<!-- Conditionally obtain references for the net 6.0 target -->
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-	</ItemGroup>
-	<!-- Conditionally obtain references for the net 7.0 target -->
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
-	</ItemGroup>
-	<!-- Conditionally obtain references for the net 8.0 target -->
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-		<PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />
-	</ItemGroup>
+  <!-- Conditionally obtain references for the net 6.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+  </ItemGroup>
+  <!-- Conditionally obtain references for the net 7.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+  </ItemGroup>
+  <!-- Conditionally obtain references for the net 8.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.IntegrationTests/AdministrationTests.cs
+++ b/test/Ocelot.IntegrationTests/AdministrationTests.cs
@@ -48,12 +48,10 @@ namespace Ocelot.IntegrationTests
         public void Should_return_response_401_with_call_re_routes_controller()
         {
             var configuration = new FileConfiguration();
-
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunning();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized);
         }
 
         //this seems to be be answer https://github.com/IdentityServer/IdentityServer4/issues/4914
@@ -61,14 +59,12 @@ namespace Ocelot.IntegrationTests
         public void Should_return_response_200_with_call_re_routes_controller()
         {
             var configuration = new FileConfiguration();
-
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -87,13 +83,12 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunningWithNoWebHostBuilder(_ocelotBaseUrl))
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunningWithNoWebHostBuilder(_ocelotBaseUrl);
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -109,14 +104,13 @@ namespace Ocelot.IntegrationTests
                     .AddJsonOptions(options => { options.JsonSerializerOptions.WriteIndented = true; });
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotUsingBuilderIsRunning(customBuilder))
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .Then(x => ThenTheResultHaveMultiLineIndentedJson())
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotUsingBuilderIsRunning(customBuilder);
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenTheResultHaveMultiLineIndentedJson();
         }
 
         [Fact]
@@ -124,15 +118,13 @@ namespace Ocelot.IntegrationTests
         {
             var configuration = new FileConfiguration();
             var port = PortFinder.GetRandomPort();
-
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenIdentityServerSigningEnvironmentalVariablesAreSet())
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenAnotherOcelotIsRunning($"http://localhost:{port}"))
-                .When(x => WhenIGetUrlOnTheSecondOcelot("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenIdentityServerSigningEnvironmentalVariablesAreSet();
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenAnotherOcelotIsRunning($"http://localhost:{port}");
+            WhenIGetUrlOnTheSecondOcelot("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
         }
 
         [Fact]
@@ -194,14 +186,13 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenTheResponseShouldBe(configuration))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenTheResponseShouldBe(configuration);
         }
 
         [Fact]
@@ -283,18 +274,17 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(initialConfiguration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .When(x => WhenIPostOnTheApiGateway("/administration/configuration", updatedConfiguration))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenTheResponseShouldBe(updatedConfiguration))
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .And(x => ThenTheResponseShouldBe(updatedConfiguration))
-                .And(_ => ThenTheConfigurationIsSavedCorrectly(updatedConfiguration))
-                .BDDfy();
+            GivenThereIsAConfiguration(initialConfiguration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            WhenIPostOnTheApiGateway("/administration/configuration", updatedConfiguration);
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenTheResponseShouldBe(updatedConfiguration);
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheResponseShouldBe(updatedConfiguration);
+            ThenTheConfigurationIsSavedCorrectly(updatedConfiguration);
         }
 
         [Fact]
@@ -323,18 +313,17 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIPostOnTheApiGateway("/administration/configuration", configuration))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => TheChangeTokenShouldBeActive())
-                .And(x => ThenTheResponseShouldBe(configuration))
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .And(x => ThenTheResponseShouldBe(configuration))
-                .And(_ => ThenTheConfigurationIsSavedCorrectly(configuration))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIPostOnTheApiGateway("/administration/configuration", configuration);
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            TheChangeTokenShouldBeActive();
+            ThenTheResponseShouldBe(configuration);
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheResponseShouldBe(configuration);
+            ThenTheConfigurationIsSavedCorrectly(configuration);
         }
 
         private void TheChangeTokenShouldBeActive()
@@ -406,25 +395,24 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(initialConfiguration))
-                .And(x => GivenThereIsAFooServiceRunningOn($"http://localhost:{fooPort}"))
-                .And(x => GivenThereIsABarServiceRunningOn($"http://localhost:{barPort}"))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => WhenIGetUrlOnTheApiGateway("/foo"))
-                .Then(x => ThenTheResponseBodyShouldBe("foo"))
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIPostOnTheApiGateway("/administration/configuration", updatedConfiguration))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenTheResponseShouldBe(updatedConfiguration))
-                .And(x => WhenIGetUrlOnTheApiGateway("/foo"))
-                .Then(x => ThenTheResponseBodyShouldBe("bar"))
-                .When(x => WhenIPostOnTheApiGateway("/administration/configuration", initialConfiguration))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenTheResponseShouldBe(initialConfiguration))
-                .And(x => WhenIGetUrlOnTheApiGateway("/foo"))
-                .Then(x => ThenTheResponseBodyShouldBe("foo"))
-                .BDDfy();
+            GivenThereIsAConfiguration(initialConfiguration);
+            GivenThereIsAFooServiceRunningOn($"http://localhost:{fooPort}");
+            GivenThereIsABarServiceRunningOn($"http://localhost:{barPort}");
+            GivenOcelotIsRunning();
+            WhenIGetUrlOnTheApiGateway("/foo");
+            ThenTheResponseBodyShouldBe("foo");
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIPostOnTheApiGateway("/administration/configuration", updatedConfiguration);
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenTheResponseShouldBe(updatedConfiguration);
+            WhenIGetUrlOnTheApiGateway("/foo");
+            ThenTheResponseBodyShouldBe("bar");
+            WhenIPostOnTheApiGateway("/administration/configuration", initialConfiguration);
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenTheResponseShouldBe(initialConfiguration);
+            WhenIGetUrlOnTheApiGateway("/foo");
+            ThenTheResponseBodyShouldBe("foo");
         }
 
         [Fact]
@@ -477,14 +465,12 @@ namespace Ocelot.IntegrationTests
             };
 
             var regionToClear = "gettest";
-
-            this.Given(x => GivenThereIsAConfiguration(initialConfiguration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIDeleteOnTheApiGateway($"/administration/outputcache/{regionToClear}"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NoContent))
-                .BDDfy();
+            GivenThereIsAConfiguration(initialConfiguration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIDeleteOnTheApiGateway($"/administration/outputcache/{regionToClear}");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.NoContent);
         }
 
         [Fact]
@@ -505,14 +491,13 @@ namespace Ocelot.IntegrationTests
                 };
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenThereIsAnIdentityServerOn(identityServerRootUrl, "api"))
-                .And(x => GivenOcelotIsRunningWithIdentityServerSettings(options))
-                .And(x => GivenIHaveAToken(identityServerRootUrl))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIGetUrlOnTheApiGateway("/administration/configuration"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenThereIsAnIdentityServerOn(identityServerRootUrl, "api");
+            GivenOcelotIsRunningWithIdentityServerSettings(options);
+            GivenIHaveAToken(identityServerRootUrl);
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIGetUrlOnTheApiGateway("/administration/configuration");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
         }
 
         private void GivenIHaveAToken(string url)

--- a/test/Ocelot.IntegrationTests/CacheManagerTests.cs
+++ b/test/Ocelot.IntegrationTests/CacheManagerTests.cs
@@ -83,13 +83,12 @@ namespace Ocelot.IntegrationTests
 
             var regionToClear = "gettest";
 
-            this.Given(x => GivenThereIsAConfiguration(initialConfiguration))
-                .And(x => GivenOcelotIsRunning())
-                .And(x => GivenIHaveAnOcelotToken("/administration"))
-                .And(x => GivenIHaveAddedATokenToMyRequest())
-                .When(x => WhenIDeleteOnTheApiGateway($"/administration/outputcache/{regionToClear}"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NoContent))
-                .BDDfy();
+            GivenThereIsAConfiguration(initialConfiguration);
+            GivenOcelotIsRunning();
+            GivenIHaveAnOcelotToken("/administration");
+            GivenIHaveAddedATokenToMyRequest();
+            WhenIDeleteOnTheApiGateway($"/administration/outputcache/{regionToClear}");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.NoContent);
         }
 
         private void GivenIHaveAddedATokenToMyRequest()

--- a/test/Ocelot.IntegrationTests/HeaderTests.cs
+++ b/test/Ocelot.IntegrationTests/HeaderTests.cs
@@ -30,7 +30,7 @@ namespace Ocelot.IntegrationTests
         }
 
         [Fact]
-        public void Should_pass_remote_ip_address_if_as_x_forwarded_for_header()
+        public async Task Should_pass_remote_ip_address_if_as_x_forwarded_for_header()
         {
             var port = PortFinder.GetRandomPort();
             var configuration = new FileConfiguration
@@ -63,13 +63,12 @@ namespace Ocelot.IntegrationTests
                 },
             };
 
-            this.Given(x => GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "X-Forwarded-For"))
-                .And(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenXForwardedForIsSet())
-                .BDDfy();
+            GivenThereIsAServiceRunningOn($"http://localhost:{port}", 200, "X-Forwarded-For");
+            GivenThereIsAConfiguration(configuration);
+            GivenOcelotIsRunning();
+            await WhenIGetUrlOnTheApiGateway("/");
+            ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+            ThenXForwardedForIsSet();
         }
 
         private void GivenThereIsAServiceRunningOn(string url, int statusCode, string headerKey)

--- a/test/Ocelot.IntegrationTests/Ocelot.IntegrationTests.csproj
+++ b/test/Ocelot.IntegrationTests/Ocelot.IntegrationTests.csproj
@@ -36,27 +36,27 @@
     <ProjectReference Include="..\Ocelot.Testing\Ocelot.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.25" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
@@ -67,7 +67,7 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.Data.SQLite" Version="7.0.14" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
@@ -78,9 +78,9 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
@@ -88,6 +88,6 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
+++ b/test/Ocelot.IntegrationTests/ThreadSafeHeadersTests.cs
@@ -55,12 +55,11 @@ namespace Ocelot.IntegrationTests
                     },
             };
 
-            this.Given(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenThereIsAServiceRunningOn($"http://localhost:{port}"))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGatewayMultipleTimesWithDifferentHeaderValues("/", 300))
-                .Then(x => ThenTheSameHeaderValuesAreReturnedByTheDownstreamService())
-                .BDDfy();
+            GivenThereIsAConfiguration(configuration);
+            GivenThereIsAServiceRunningOn($"http://localhost:{port}");
+            GivenOcelotIsRunning();
+            WhenIGetUrlOnTheApiGatewayMultipleTimesWithDifferentHeaderValues("/", 300);
+            ThenTheSameHeaderValuesAreReturnedByTheDownstreamService();
         }
 
         private void GivenThereIsAServiceRunningOn(string url)

--- a/test/Ocelot.IntegrationTests/Usings.cs
+++ b/test/Ocelot.IntegrationTests/Usings.cs
@@ -11,5 +11,4 @@ global using System.Threading.Tasks;
 global using Ocelot;
 global using Ocelot.Testing;
 global using Shouldly;
-global using TestStack.BDDfy;
 global using Xunit;

--- a/test/Ocelot.ManualTest/Ocelot.ManualTest.csproj
+++ b/test/Ocelot.ManualTest/Ocelot.ManualTest.csproj
@@ -32,7 +32,7 @@
     <ProjectReference Include="..\..\src\Ocelot\Ocelot.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
@@ -59,7 +59,7 @@
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
@@ -67,6 +67,6 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+++ b/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
@@ -49,38 +49,38 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="Polly.Testing" Version="8.3.1" />
-    <PackageReference Include="xunit" Version="2.6.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0-pre.35">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
     <PackageReference Include="Butterfly.Client.AspNetCore" Version="0.0.8" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="3.2.8" />
-    <PackageReference Include="Consul" Version="1.7.14.1" />
+    <PackageReference Include="Consul" Version="1.7.14.4" />
     <PackageReference Include="CacheManager.Core" Version="2.0.0-beta-1629" />
     <PackageReference Include="CacheManager.Microsoft.Extensions.Configuration" Version="2.0.0-beta-1629" />
     <PackageReference Include="CacheManager.Microsoft.Extensions.Logging" Version="2.0.0-beta-1629" />
-    <PackageReference Include="Polly" Version="8.4.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="Polly.Testing" Version="8.4.2" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.33" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
@@ -92,7 +92,7 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 7.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
@@ -104,14 +104,17 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.UnitTests/Polly/PollyResiliencePipelineDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/Polly/PollyResiliencePipelineDelegatingHandlerTests.cs
@@ -33,7 +33,7 @@ public class PollyResiliencePipelineDelegatingHandlerTests
     }
 
     [Fact]
-    public async void SendAsync_OnePolicy()
+    public async Task SendAsync_OnePolicy()
     {
         // Arrange
         var fakeResponse = new HttpResponseMessage(HttpStatusCode.NoContent);


### PR DESCRIPTION
## Successor
- #2162 

## Predecessor
- #2088 

## Proposed Changes

- All NuGet packages have been updated, with the exception of the `Serilog.*` packs (in the acceptance testing project).

- The BDDfy testing framework has been removed from the integration testing project due to a compilation version mismatch following the package updates. The `TestStack.BDDfy` version [v4.3.2](https://github.com/TestStack/TestStack.BDDfy/releases) is no longer supported as of September 2016.

- Detailed release notes have been written and are available.

- Implemented a minor yet significant update of the `Cake.Coveralls` package to version [4.0.0](https://github.com/cake-contrib/Cake.Coveralls/releases/tag/4.0.0) in `build.cake`, following a contribution to the repository via https://github.com/cake-contrib/Cake.Coveralls/pull/124, addressing bug https://github.com/cake-contrib/Cake.Coveralls/issues/123. Consequently, the build log no longer shows the outdated compatibility warning 😍. This update paves the way for future enhancements to the Coveralls logic, streamlining DevOps practices, and enabling the "Coverage Status badge" in the README.md ([currently commented out](https://github.com/ThreeMammals/Ocelot/blob/develop/README.md?plain=1#L5)), setting the stage for the development of the [Quality Gates](https://ocelot.readthedocs.io/en/latest/building/releaseprocess.html#quality-gates) process.

- Addressed several troublesome warnings and messages in the compilation log.
