### PR TITLE
#2165 Global configuration `SecurityOptions`

### DIFF
--- a/src/Ocelot/Configuration/Creator/ISecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ISecurityOptionsCreator.cs
@@ -4,6 +4,6 @@ namespace Ocelot.Configuration.Creator
 {
     public interface ISecurityOptionsCreator
     {
-        SecurityOptions Create(FileSecurityOptions securityOptions);
+        SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration);
     }
 }

--- a/src/Ocelot/Configuration/Creator/ISecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/ISecurityOptionsCreator.cs
@@ -1,9 +1,8 @@
 ﻿using Ocelot.Configuration.File;
 
-namespace Ocelot.Configuration.Creator
+namespace Ocelot.Configuration.Creator;
+
+public interface ISecurityOptionsCreator
 {
-    public interface ISecurityOptionsCreator
-    {
-        SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration);
-    }
+    SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration global);
 }

--- a/src/Ocelot/Configuration/Creator/RoutesCreator.cs
+++ b/src/Ocelot/Configuration/Creator/RoutesCreator.cs
@@ -108,7 +108,7 @@ namespace Ocelot.Configuration.Creator
 
             var lbOptions = _loadBalancerOptionsCreator.Create(fileRoute.LoadBalancerOptions);
 
-            var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions);
+            var securityOptions = _securityOptionsCreator.Create(fileRoute.SecurityOptions, globalConfiguration);
 
             var downstreamHttpVersion = _versionCreator.Create(fileRoute.DownstreamHttpVersion);
 

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -22,26 +22,16 @@ namespace Ocelot.Configuration.Creator
 
             if (securityOptions.ExcludeAllowedFromBlocked)
             {
-                ipBlockedList = ipBlockedList.Except(ipAllowedList).ToList();
+                ipBlockedList = ipBlockedList.Except(ipAllowedList).ToArray();
             }
 
             return new SecurityOptions(ipAllowedList, ipBlockedList);
         }
 
-        private static List<string> SetIpAddressList(List<string> ipValueList)
-        {
-            var ipList = new List<string>();
-
-            foreach (var ipValue in ipValueList)
-            {
-                if (IPAddressRange.TryParse(ipValue, out var ipAddressRange))
-                {
-                    var ips = ipAddressRange.Select<IPAddress, string>(x => x.ToString());
-                    ipList.AddRange(ips);
-                }
-            }
-
-            return ipList;
+        private static string[] SetIpAddressList(IList<string> ipValueList)
+            => ipValueList
+                .Where(ipValue => IPAddressRange.TryParse(ipValue, out _))
+                .SelectMany(ipValue => IPAddressRange.Parse(ipValue).Select<IPAddress, string>(ip => ip.ToString()))
+                .ToArray();
         }
-    }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -22,16 +22,26 @@ namespace Ocelot.Configuration.Creator
 
             if (securityOptions.ExcludeAllowedFromBlocked)
             {
-                ipBlockedList = ipBlockedList.Except(ipAllowedList).ToArray();
+                ipBlockedList = ipBlockedList.Except(ipAllowedList).ToList();
             }
 
             return new SecurityOptions(ipAllowedList, ipBlockedList);
         }
 
-        private static string[] SetIpAddressList(IList<string> ipValueList)
-            => ipValueList
-                .Where(ipValue => IPAddressRange.TryParse(ipValue, out _))
-                .SelectMany(ipValue => IPAddressRange.Parse(ipValue).Select<IPAddress, string>(ip => ip.ToString()))
-                .ToArray();
+        private static List<string> SetIpAddressList(List<string> ipValueList)
+        {
+            var ipList = new List<string>();
+
+            foreach (var ipValue in ipValueList)
+            {
+                if (IPAddressRange.TryParse(ipValue, out var ipAddressRange))
+                {
+                    var ips = ipAddressRange.Select<IPAddress, string>(x => x.ToString());
+                    ipList.AddRange(ips);
+                }
+            }
+
+            return ipList;
         }
+    }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -5,7 +5,7 @@ namespace Ocelot.Configuration.Creator
 {
     public class SecurityOptionsCreator : ISecurityOptionsCreator
     {
-        public SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration) 
+        public SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration)
             => Create(securityOptions.IsFullFilled() ? securityOptions : globalConfiguration.SecurityOptions);
 
         private static SecurityOptions Create(FileSecurityOptions securityOptions)
@@ -21,10 +21,16 @@ namespace Ocelot.Configuration.Creator
             return new SecurityOptions(ipAllowedList, ipBlockedList);
         }
 
-        private static string[] SetIpAddressList(List<string> ipValueList)
-            => ipValueList
-                .Where(ipValue => IPAddressRange.TryParse(ipValue, out _))
-                .SelectMany(ipValue => IPAddressRange.Parse(ipValue).Select<IPAddress, string>(ip => ip.ToString()))
-                .ToArray();
+        private static string[] SetIpAddressList(List<string> ipValues) => ipValues.SelectMany(Parse).ToArray();
+
+        private static string[] Parse(string ipValue)
+        {
+            if (IPAddressRange.TryParse(ipValue, out var range))
+            {
+                return range.Select<IPAddress, string>(ip => ip.ToString()).ToArray();
+            }
+
+            return Array.Empty<string>();
         }
+    }
 }

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -5,15 +5,8 @@ namespace Ocelot.Configuration.Creator
 {
     public class SecurityOptionsCreator : ISecurityOptionsCreator
     {
-        public SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration)
-        {
-            if (securityOptions.IsFullFilled())
-            {
-                return Create(securityOptions);
-            }
-
-            return Create(globalConfiguration.SecurityOptions);
-        }
+        public SecurityOptions Create(FileSecurityOptions securityOptions, FileGlobalConfiguration globalConfiguration) 
+            => Create(securityOptions.IsFullFilled() ? securityOptions : globalConfiguration.SecurityOptions);
 
         private static SecurityOptions Create(FileSecurityOptions securityOptions)
         {

--- a/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
+++ b/src/Ocelot/Configuration/Creator/SecurityOptionsCreator.cs
@@ -21,7 +21,7 @@ namespace Ocelot.Configuration.Creator
             return new SecurityOptions(ipAllowedList, ipBlockedList);
         }
 
-        private static string[] SetIpAddressList(IList<string> ipValueList)
+        private static string[] SetIpAddressList(List<string> ipValueList)
             => ipValueList
                 .Where(ipValue => IPAddressRange.TryParse(ipValue, out _))
                 .SelectMany(ipValue => IPAddressRange.Parse(ipValue).Select<IPAddress, string>(ip => ip.ToString()))

--- a/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
+++ b/src/Ocelot/Configuration/File/FileGlobalConfiguration.cs
@@ -13,6 +13,7 @@ namespace Ocelot.Configuration.File
             HttpHandlerOptions = new FileHttpHandlerOptions();
             CacheOptions = new FileCacheOptions();
             MetadataOptions = new FileMetadataOptions();
+            SecurityOptions = new FileSecurityOptions();
         }
 
         public string RequestIdKey { get; set; }
@@ -48,5 +49,7 @@ namespace Ocelot.Configuration.File
         public FileCacheOptions CacheOptions { get; set; }
 
         public FileMetadataOptions MetadataOptions { get; set; }
+
+        public FileSecurityOptions SecurityOptions { get; set; }
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -1,57 +1,51 @@
-namespace Ocelot.Configuration.File
+namespace Ocelot.Configuration.File;
+
+public class FileSecurityOptions
 {
-    public class FileSecurityOptions
+    public FileSecurityOptions()
     {
-        public FileSecurityOptions()
-        {
-            IPAllowedList = new List<string>();
-            IPBlockedList = new List<string>();
-            ExcludeAllowedFromBlocked = false;
-        }
-
-        public FileSecurityOptions(FileSecurityOptions from)
-        {
-            IPAllowedList = new(from.IPAllowedList);
-            IPBlockedList = new(from.IPBlockedList);
-            ExcludeAllowedFromBlocked = from.ExcludeAllowedFromBlocked;
-        }
-
-        public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
-            : this()
-        {
-            if (!string.IsNullOrEmpty(allowedIPs))
-            {
-                IPAllowedList.Add(allowedIPs);
-            }
-
-            if (!string.IsNullOrEmpty(blockedIPs))
-            {
-                IPBlockedList.Add(blockedIPs);
-            }
-
-            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
-        }
-
-        public FileSecurityOptions(IEnumerable<string> allowedIPs = null, IEnumerable<string> blockedIPs = null, bool? excludeAllowedFromBlocked = null)
-            : this()
-        {
-            IPAllowedList.AddRange(allowedIPs ?? Enumerable.Empty<string>());
-            IPBlockedList.AddRange(blockedIPs ?? Enumerable.Empty<string>());
-            ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
-        }
-
-        public List<string> IPAllowedList { get; set; }
-        public List<string> IPBlockedList { get; set; }
-
-        /// <summary>
-        /// Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.
-        /// </summary>
-        /// <value>
-        /// Default value: false.
-        /// </value>        
-        public bool ExcludeAllowedFromBlocked { get; set; }
-
-        public bool IsFullFilled()
-            => this.IPAllowedList.Count > 0 || this.IPBlockedList.Count > 0;
+        IPAllowedList = new();
+        IPBlockedList = new();
+        ExcludeAllowedFromBlocked = false;
     }
+
+    public FileSecurityOptions(FileSecurityOptions from)
+    {
+        IPAllowedList = new(from.IPAllowedList);
+        IPBlockedList = new(from.IPBlockedList);
+        ExcludeAllowedFromBlocked = from.ExcludeAllowedFromBlocked;
+    }
+
+    public FileSecurityOptions(string allowedIPs = null, string blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+        : this()
+    {
+        if (!string.IsNullOrEmpty(allowedIPs))
+        {
+            IPAllowedList.Add(allowedIPs);
+        }
+
+        if (!string.IsNullOrEmpty(blockedIPs))
+        {
+            IPBlockedList.Add(blockedIPs);
+        }
+
+        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
+    }
+
+    public FileSecurityOptions(IEnumerable<string> allowedIPs = null, IEnumerable<string> blockedIPs = null, bool? excludeAllowedFromBlocked = null)
+        : this()
+    {
+        IPAllowedList.AddRange(allowedIPs ?? Enumerable.Empty<string>());
+        IPBlockedList.AddRange(blockedIPs ?? Enumerable.Empty<string>());
+        ExcludeAllowedFromBlocked = excludeAllowedFromBlocked ?? false;
+    }
+
+    public List<string> IPAllowedList { get; set; }
+    public List<string> IPBlockedList { get; set; }
+
+    /// <summary>Provides the ability to specify a wide range of blocked IP addresses and allow a subrange of IP addresses.</summary>
+    /// <value>A <see cref="bool"/> value, defaults to <see langword="false"/>.</value>        
+    public bool ExcludeAllowedFromBlocked { get; set; }
+
+    public bool IsEmpty() => IPAllowedList.Count == 0 && IPBlockedList.Count == 0;
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptions.cs
@@ -50,5 +50,8 @@ namespace Ocelot.Configuration.File
         /// Default value: false.
         /// </value>        
         public bool ExcludeAllowedFromBlocked { get; set; }
+
+        public bool IsFullFilled()
+            => this.IPAllowedList.Count > 0 || this.IPBlockedList.Count > 0;
     }
 }

--- a/src/Ocelot/Configuration/File/FileSecurityOptionsExtensions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptionsExtensions.cs
@@ -1,0 +1,8 @@
+﻿namespace Ocelot.Configuration.File
+{
+    internal static class FileSecurityOptionsExtensions
+    {
+        internal static bool IsFullFilled(this FileSecurityOptions fileSecurityOptions) 
+            => fileSecurityOptions.IPAllowedList.Count > 0 || fileSecurityOptions.IPBlockedList.Count > 0;
+    }
+}

--- a/src/Ocelot/Configuration/File/FileSecurityOptionsExtensions.cs
+++ b/src/Ocelot/Configuration/File/FileSecurityOptionsExtensions.cs
@@ -1,8 +1,0 @@
-﻿namespace Ocelot.Configuration.File
-{
-    internal static class FileSecurityOptionsExtensions
-    {
-        internal static bool IsFullFilled(this FileSecurityOptions fileSecurityOptions) 
-            => fileSecurityOptions.IPAllowedList.Count > 0 || fileSecurityOptions.IPBlockedList.Count > 0;
-    }
-}

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -4,8 +4,8 @@
     {
         public SecurityOptions()
         {
-            IPAllowedList = new List<string>();
-            IPBlockedList = new List<string>();
+            IPAllowedList = new();
+            IPBlockedList = new();
         }
 
         public SecurityOptions(string allowed = null, string blocked = null)
@@ -13,22 +13,22 @@
         {
             if (!string.IsNullOrEmpty(allowed))
             {
-                IPAllowedList = IPAllowedList.Append(allowed).ToList();
+                IPAllowedList.Add(allowed);
             }
 
             if (!string.IsNullOrEmpty(blocked))
             {
-                IPBlockedList = IPBlockedList.Append(blocked).ToList();
+                IPBlockedList.Add(blocked);
             }
         }
 
-        public SecurityOptions(IList<string> allowedList = null, IList<string> blockedList = null)
+        public SecurityOptions(List<string> allowedList = null, List<string> blockedList = null)
         {
-            IPAllowedList = allowedList ?? new List<string>();
-            IPBlockedList = blockedList ?? new List<string>();
+            IPAllowedList = allowedList ?? new();
+            IPBlockedList = blockedList ?? new();
         }
 
-        public IList<string> IPAllowedList { get; }
-        public IList<string> IPBlockedList { get; }
+        public List<string> IPAllowedList { get; }
+        public List<string> IPBlockedList { get; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -4,8 +4,8 @@
     {
         public SecurityOptions()
         {
-            IPAllowedList = new();
-            IPBlockedList = new();
+            IPAllowedList = new List<string>();
+            IPBlockedList = new List<string>();
         }
 
         public SecurityOptions(string allowed = null, string blocked = null)
@@ -13,22 +13,22 @@
         {
             if (!string.IsNullOrEmpty(allowed))
             {
-                IPAllowedList.Add(allowed);
+                IPAllowedList = IPAllowedList.Append(allowed).ToList();
             }
 
             if (!string.IsNullOrEmpty(blocked))
             {
-                IPBlockedList.Add(blocked);
+                IPBlockedList = IPBlockedList.Append(blocked).ToList();
             }
         }
 
-        public SecurityOptions(List<string> allowedList = null, List<string> blockedList = null)
+        public SecurityOptions(IList<string> allowedList = null, IList<string> blockedList = null)
         {
-            IPAllowedList = allowedList ?? new();
-            IPBlockedList = blockedList ?? new();
+            IPAllowedList = allowedList ?? new List<string>();
+            IPBlockedList = blockedList ?? new List<string>();
         }
 
-        public List<string> IPAllowedList { get; }
-        public List<string> IPBlockedList { get; }
+        public IList<string> IPAllowedList { get; }
+        public IList<string> IPBlockedList { get; }
     }
 }

--- a/src/Ocelot/Configuration/SecurityOptions.cs
+++ b/src/Ocelot/Configuration/SecurityOptions.cs
@@ -13,12 +13,12 @@
         {
             if (!string.IsNullOrEmpty(allowed))
             {
-                IPAllowedList = IPAllowedList.Append(allowed).ToList();
+                IPAllowedList.Add(allowed);
             }
 
             if (!string.IsNullOrEmpty(blocked))
             {
-                IPBlockedList = IPBlockedList.Append(blocked).ToList();
+                IPBlockedList.Add(blocked);
             }
         }
 

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -18,7 +18,7 @@ namespace Ocelot.Security.IPSecurity
 
             if (securityOptions.IPBlockedList != null)
             {
-                if (securityOptions.IPBlockedList.Contains(clientIp.ToString()))
+                if (securityOptions.IPBlockedList.Exists(f => f == clientIp.ToString()))
                 {
                     var error = new UnauthenticatedError($" This request rejects access to {clientIp} IP");
                     return new ErrorResponse(error);
@@ -27,7 +27,7 @@ namespace Ocelot.Security.IPSecurity
 
             if (securityOptions.IPAllowedList?.Count > 0)
             {
-                if (!securityOptions.IPAllowedList.Contains(clientIp.ToString()))
+                if (!securityOptions.IPAllowedList.Exists(f => f == clientIp.ToString()))
                 {
                     var error = new UnauthenticatedError($"{clientIp} does not allow access, the request is invalid");
                     return new ErrorResponse(error);

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -18,7 +18,7 @@ namespace Ocelot.Security.IPSecurity
 
             if (securityOptions.IPBlockedList != null)
             {
-                if (securityOptions.IPBlockedList.Exists(f => f == clientIp.ToString()))
+                if (securityOptions.IPBlockedList.Contains(clientIp.ToString()))
                 {
                     var error = new UnauthenticatedError($" This request rejects access to {clientIp} IP");
                     return new ErrorResponse(error);
@@ -27,7 +27,7 @@ namespace Ocelot.Security.IPSecurity
 
             if (securityOptions.IPAllowedList?.Count > 0)
             {
-                if (!securityOptions.IPAllowedList.Exists(f => f == clientIp.ToString()))
+                if (!securityOptions.IPAllowedList.Contains(clientIp.ToString()))
                 {
                     var error = new UnauthenticatedError($"{clientIp} does not allow access, the request is invalid");
                     return new ErrorResponse(error);

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -16,7 +16,7 @@ namespace Ocelot.Security.IPSecurity
                 return new OkResponse();
             }
 
-            if (securityOptions.IPBlockedList != null)
+            if (securityOptions.IPBlockedList != null && securityOptions.IPBlockedList.Count > 0 && clientIp != null)
             {
                 if (securityOptions.IPBlockedList.Contains(clientIp.ToString()))
                 {
@@ -25,7 +25,7 @@ namespace Ocelot.Security.IPSecurity
                 }
             }
 
-            if (securityOptions.IPAllowedList?.Count > 0)
+            if (securityOptions.IPAllowedList != null && securityOptions.IPAllowedList.Count > 0 && clientIp != null)
             {
                 if (!securityOptions.IPAllowedList.Contains(clientIp.ToString()))
                 {

--- a/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
+++ b/src/Ocelot/Security/IPSecurity/IPSecurityPolicy.cs
@@ -3,38 +3,40 @@ using Ocelot.Configuration;
 using Ocelot.Middleware;
 using Ocelot.Responses;
 
-namespace Ocelot.Security.IPSecurity
+namespace Ocelot.Security.IPSecurity;
+
+public class IPSecurityPolicy : ISecurityPolicy
 {
-    public class IPSecurityPolicy : ISecurityPolicy
+    public Response Security(DownstreamRoute downstreamRoute, HttpContext context)
     {
-        public async Task<Response> Security(DownstreamRoute downstreamRoute, HttpContext httpContext)
+        var clientIp = context.Connection.RemoteIpAddress;
+        var options = downstreamRoute.SecurityOptions;
+        if (options == null || clientIp == null)
         {
-            var clientIp = httpContext.Connection.RemoteIpAddress;
-            var securityOptions = downstreamRoute.SecurityOptions;
-            if (securityOptions == null)
-            {
-                return new OkResponse();
-            }
-
-            if (securityOptions.IPBlockedList != null && securityOptions.IPBlockedList.Count > 0 && clientIp != null)
-            {
-                if (securityOptions.IPBlockedList.Contains(clientIp.ToString()))
-                {
-                    var error = new UnauthenticatedError($" This request rejects access to {clientIp} IP");
-                    return new ErrorResponse(error);
-                }
-            }
-
-            if (securityOptions.IPAllowedList != null && securityOptions.IPAllowedList.Count > 0 && clientIp != null)
-            {
-                if (!securityOptions.IPAllowedList.Contains(clientIp.ToString()))
-                {
-                    var error = new UnauthenticatedError($"{clientIp} does not allow access, the request is invalid");
-                    return new ErrorResponse(error);
-                }
-            }
-
-            return await Task.FromResult(new OkResponse());
+            return new OkResponse();
         }
+
+        if (options.IPBlockedList?.Count > 0)
+        {
+            if (options.IPBlockedList.Contains(clientIp.ToString()))
+            {
+                var error = new UnauthenticatedError($"This request rejects access to {clientIp} IP");
+                return new ErrorResponse(error);
+            }
+        }
+
+        if (options.IPAllowedList?.Count > 0)
+        {
+            if (!options.IPAllowedList.Contains(clientIp.ToString()))
+            {
+                var error = new UnauthenticatedError($"{clientIp} does not allow access, the request is invalid");
+                return new ErrorResponse(error);
+            }
+        }
+
+        return new OkResponse();
     }
+
+    public Task<Response> SecurityAsync(DownstreamRoute downstreamRoute, HttpContext context)
+        => Task.Run(() => Security(downstreamRoute, context));
 }

--- a/src/Ocelot/Security/ISecurityPolicy.cs
+++ b/src/Ocelot/Security/ISecurityPolicy.cs
@@ -2,10 +2,10 @@
 using Ocelot.Configuration;
 using Ocelot.Responses;
 
-namespace Ocelot.Security
+namespace Ocelot.Security;
+
+public interface ISecurityPolicy
 {
-    public interface ISecurityPolicy
-    {
-        Task<Response> Security(DownstreamRoute downstreamRoute, HttpContext httpContext);
-    }
+    Response Security(DownstreamRoute downstreamRoute, HttpContext context);
+    Task<Response> SecurityAsync(DownstreamRoute downstreamRoute, HttpContext context);
 }

--- a/src/Ocelot/Security/Middleware/SecurityMiddleware.cs
+++ b/src/Ocelot/Security/Middleware/SecurityMiddleware.cs
@@ -11,8 +11,7 @@ namespace Ocelot.Security.Middleware
 
         public SecurityMiddleware(RequestDelegate next,
             IOcelotLoggerFactory loggerFactory,
-            IEnumerable<ISecurityPolicy> securityPolicies
-            )
+            IEnumerable<ISecurityPolicy> securityPolicies)
             : base(loggerFactory.CreateLogger<SecurityMiddleware>())
         {
             _securityPolicies = securityPolicies;
@@ -27,7 +26,7 @@ namespace Ocelot.Security.Middleware
             {
                 foreach (var policy in _securityPolicies)
                 {
-                    var result = await policy.Security(downstreamRoute, httpContext);
+                    var result = policy.Security(downstreamRoute, httpContext);
                     if (!result.IsError)
                     {
                         continue;

--- a/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
+++ b/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
@@ -1,0 +1,163 @@
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+
+namespace Ocelot.AcceptanceTests.Security
+{
+    public sealed class SecurityOptionsTests: Steps
+    {
+        private readonly ServiceHandler _serviceHandler;
+
+        public SecurityOptionsTests()
+        {
+            _serviceHandler = new ServiceHandler();
+        }
+
+        public override void Dispose()
+        {
+            _serviceHandler.Dispose();
+            base.Dispose();
+        }
+
+        [Fact]
+        public void should_call_with_allowed_ip_in_global_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.35")[0];
+            var route = GivenRoute(port, "/myPath", "/worldPath");
+            var configuration = GivenConfigurationWithSecurityOptions(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public void should_block_call_with_blocked_ip_in_global_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.55")[0];
+            var route = GivenRoute(port, "/myPath", "/worldPath");
+            var configuration = GivenConfigurationWithSecurityOptions(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+        }
+
+        [Fact]
+        public void should_call_with_allowed_ip_in_route_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.1")[0];
+            var securityConfig = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.1" },
+            };
+
+            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+            var configuration = GivenConfiguration(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public void should_block_call_with_blocked_ip_in_route_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.1")[0];
+            var securityConfig = new FileSecurityOptions
+            {
+                IPBlockedList = new List<string> { "192.168.1.1" },
+            };
+
+            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+            var configuration = GivenConfiguration(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+                .And(x => GivenThereIsAConfiguration(configuration))
+                .And(x => GivenOcelotIsRunning())
+                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+        }
+
+        [Fact]
+        public void should_call_with_allowed_ip_in_route_config_and_blocked_ip_in_global_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.55")[0];
+            var securityConfig = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.55" },
+            };
+
+            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+            var configuration = GivenConfigurationWithSecurityOptions(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+               .And(x => GivenThereIsAConfiguration(configuration))
+               .And(x => GivenOcelotIsRunning())
+               .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+               .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public void should_block_call_with_blocked_ip_in_route_config_and_allowed_ip_in_global_config()
+        {
+            var port = PortFinder.GetRandomPort();
+            var ip = Dns.GetHostAddresses("192.168.1.35")[0];
+            var securityConfig = new FileSecurityOptions
+            {
+                IPBlockedList = new List<string> { "192.168.1.35" },
+            };
+
+            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+            var configuration = GivenConfigurationWithSecurityOptions(route);
+
+            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+               .And(x => GivenThereIsAConfiguration(configuration))
+               .And(x => GivenOcelotIsRunning())
+               .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+               .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+        }
+
+        private void GivenThereIsAServiceRunningOn(string url, IPAddress ipAddess)
+        {
+            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+            {
+                context.Connection.RemoteIpAddress = ipAddess;
+                context.Response.StatusCode = (int)HttpStatusCode.OK;
+                await context.Response.WriteAsync("a valida response body");
+            });
+        }
+
+        private static FileConfiguration GivenConfigurationWithSecurityOptions(params FileRoute[] routes)
+        {
+            var config = GivenConfiguration(routes);
+            config.GlobalConfiguration.SecurityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = new List<string> { "192.168.1.30-50" },
+                IPBlockedList = new List<string> { "192.168.1.1-100" },
+                ExcludeAllowedFromBlocked = true
+            };
+
+            return config;
+        }
+
+        private FileRoute GivenRoute(int port, string downstream, string upstream, FileSecurityOptions fileSecurityOptions = null)
+            => new()
+            {
+                DownstreamPathTemplate = downstream,
+                UpstreamPathTemplate = upstream,
+                UpstreamHttpMethod = new List<string> { "Get" },
+                SecurityOptions = fileSecurityOptions ?? new FileSecurityOptions(),
+            };
+    }
+}

--- a/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
+++ b/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
@@ -19,14 +19,15 @@ public sealed class SecurityOptionsTests: Steps
     }
 
     [Fact]
+    [Trait("Feat", "2170")]
     public void Should_call_with_allowed_ip_in_global_config()
     {
         var port = PortFinder.GetRandomPort();
         var ip = Dns.GetHostAddresses("192.168.1.35")[0];
         var route = GivenRoute(port, "/myPath", "/worldPath");
-        var configuration = GivenConfigurationWithSecurityOptions(route);
+        var configuration = GivenGlobalConfiguration(route, "192.168.1.30-50", "192.168.1.1-100");
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
@@ -34,14 +35,15 @@ public sealed class SecurityOptionsTests: Steps
     }
 
     [Fact]
+    [Trait("Feat", "2170")]
     public void Should_block_call_with_blocked_ip_in_global_config()
     {
         var port = PortFinder.GetRandomPort();
         var ip = Dns.GetHostAddresses("192.168.1.55")[0];
         var route = GivenRoute(port, "/myPath", "/worldPath");
-        var configuration = GivenConfigurationWithSecurityOptions(route);
+        var configuration = GivenGlobalConfiguration(route, "192.168.1.30-50", "192.168.1.1-100");
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
@@ -55,13 +57,12 @@ public sealed class SecurityOptionsTests: Steps
         var ip = Dns.GetHostAddresses("192.168.1.1")[0];
         var securityConfig = new FileSecurityOptions
         {
-            IPAllowedList = new List<string> { "192.168.1.1" },
+            IPAllowedList = new() { "192.168.1.1" },
         };
-
         var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
         var configuration = GivenConfiguration(route);
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
@@ -75,13 +76,12 @@ public sealed class SecurityOptionsTests: Steps
         var ip = Dns.GetHostAddresses("192.168.1.1")[0];
         var securityConfig = new FileSecurityOptions
         {
-            IPBlockedList = new List<string> { "192.168.1.1" },
+            IPBlockedList = new() { "192.168.1.1" },
         };
-
         var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
         var configuration = GivenConfiguration(route);
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
@@ -89,74 +89,74 @@ public sealed class SecurityOptionsTests: Steps
     }
 
     [Fact]
+    [Trait("Feat", "2170")]
     public void Should_call_with_allowed_ip_in_route_config_and_blocked_ip_in_global_config()
     {
         var port = PortFinder.GetRandomPort();
         var ip = Dns.GetHostAddresses("192.168.1.55")[0];
         var securityConfig = new FileSecurityOptions
         {
-            IPAllowedList = new List<string> { "192.168.1.55" },
+            IPAllowedList = new() { "192.168.1.55" },
         };
-
         var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-        var configuration = GivenConfigurationWithSecurityOptions(route);
+        var configuration = GivenGlobalConfiguration(route, "192.168.1.30-50", "192.168.1.1-100");
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
            .And(x => GivenThereIsAConfiguration(configuration))
            .And(x => GivenOcelotIsRunning())
            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-           .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+           .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+           .Then(x => ThenTheResponseBodyShouldBe("Hello from Fabrizio"));
     }
 
     [Fact]
+    [Trait("Feat", "2170")]
     public void Should_block_call_with_blocked_ip_in_route_config_and_allowed_ip_in_global_config()
     {
         var port = PortFinder.GetRandomPort();
         var ip = Dns.GetHostAddresses("192.168.1.35")[0];
         var securityConfig = new FileSecurityOptions
         {
-            IPBlockedList = new List<string> { "192.168.1.35" },
+            IPBlockedList = new() { "192.168.1.35" },
         };
-
         var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-        var configuration = GivenConfigurationWithSecurityOptions(route);
+        var configuration = GivenGlobalConfiguration(route, "192.168.1.30-50", "192.168.1.1-100");
 
-        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, ip))
            .And(x => GivenThereIsAConfiguration(configuration))
            .And(x => GivenOcelotIsRunning())
            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
     }
 
-    private void GivenThereIsAServiceRunningOn(string url, IPAddress ipAddess)
+    private void GivenThereIsAServiceRunningOn(int port, IPAddress ipAddess)
     {
+        string url = DownstreamUrl(port);
         _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
         {
             context.Connection.RemoteIpAddress = ipAddess;
             context.Response.StatusCode = (int)HttpStatusCode.OK;
-            await context.Response.WriteAsync("a valida response body");
+            await context.Response.WriteAsync("Hello from Fabrizio");
         });
     }
 
-    private static FileConfiguration GivenConfigurationWithSecurityOptions(params FileRoute[] routes)
+    private static FileConfiguration GivenGlobalConfiguration(FileRoute route, string allowed, string blocked, bool exclude = true)
     {
-        var config = GivenConfiguration(routes);
+        var config = GivenConfiguration(route);
         config.GlobalConfiguration.SecurityOptions = new FileSecurityOptions
         {
-            IPAllowedList = new List<string> { "192.168.1.30-50" },
-            IPBlockedList = new List<string> { "192.168.1.1-100" },
-            ExcludeAllowedFromBlocked = true
+            IPAllowedList = new() { allowed },
+            IPBlockedList = new() { blocked },
+            ExcludeAllowedFromBlocked = exclude,
         };
-
         return config;
     }
 
-    private FileRoute GivenRoute(int port, string downstream, string upstream, FileSecurityOptions fileSecurityOptions = null)
-        => new()
-        {
-            DownstreamPathTemplate = downstream,
-            UpstreamPathTemplate = upstream,
-            UpstreamHttpMethod = new List<string> { "Get" },
-            SecurityOptions = fileSecurityOptions ?? new FileSecurityOptions(),
-        };
+    private static FileRoute GivenRoute(int port, string downstream, string upstream, FileSecurityOptions fileSecurityOptions = null) => new()
+    {
+        DownstreamPathTemplate = downstream,
+        UpstreamPathTemplate = upstream,
+        UpstreamHttpMethod = new() { HttpMethods.Get },
+        SecurityOptions = fileSecurityOptions ?? new(),
+    };
 }

--- a/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
+++ b/test/Ocelot.AcceptanceTests/Security/SecurityOptionsTests.cs
@@ -1,163 +1,162 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration.File;
 
-namespace Ocelot.AcceptanceTests.Security
+namespace Ocelot.AcceptanceTests.Security;
+
+public sealed class SecurityOptionsTests: Steps
 {
-    public sealed class SecurityOptionsTests: Steps
+    private readonly ServiceHandler _serviceHandler;
+
+    public SecurityOptionsTests()
     {
-        private readonly ServiceHandler _serviceHandler;
-
-        public SecurityOptionsTests()
-        {
-            _serviceHandler = new ServiceHandler();
-        }
-
-        public override void Dispose()
-        {
-            _serviceHandler.Dispose();
-            base.Dispose();
-        }
-
-        [Fact]
-        public void should_call_with_allowed_ip_in_global_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.35")[0];
-            var route = GivenRoute(port, "/myPath", "/worldPath");
-            var configuration = GivenConfigurationWithSecurityOptions(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-                .And(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
-        }
-
-        [Fact]
-        public void should_block_call_with_blocked_ip_in_global_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.55")[0];
-            var route = GivenRoute(port, "/myPath", "/worldPath");
-            var configuration = GivenConfigurationWithSecurityOptions(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-                .And(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
-        }
-
-        [Fact]
-        public void should_call_with_allowed_ip_in_route_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.1")[0];
-            var securityConfig = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.1" },
-            };
-
-            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-            var configuration = GivenConfiguration(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-                .And(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
-        }
-
-        [Fact]
-        public void should_block_call_with_blocked_ip_in_route_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.1")[0];
-            var securityConfig = new FileSecurityOptions
-            {
-                IPBlockedList = new List<string> { "192.168.1.1" },
-            };
-
-            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-            var configuration = GivenConfiguration(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-                .And(x => GivenThereIsAConfiguration(configuration))
-                .And(x => GivenOcelotIsRunning())
-                .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
-        }
-
-        [Fact]
-        public void should_call_with_allowed_ip_in_route_config_and_blocked_ip_in_global_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.55")[0];
-            var securityConfig = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.55" },
-            };
-
-            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-            var configuration = GivenConfigurationWithSecurityOptions(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-               .And(x => GivenThereIsAConfiguration(configuration))
-               .And(x => GivenOcelotIsRunning())
-               .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-               .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
-        }
-
-        [Fact]
-        public void should_block_call_with_blocked_ip_in_route_config_and_allowed_ip_in_global_config()
-        {
-            var port = PortFinder.GetRandomPort();
-            var ip = Dns.GetHostAddresses("192.168.1.35")[0];
-            var securityConfig = new FileSecurityOptions
-            {
-                IPBlockedList = new List<string> { "192.168.1.35" },
-            };
-
-            var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
-            var configuration = GivenConfigurationWithSecurityOptions(route);
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
-               .And(x => GivenThereIsAConfiguration(configuration))
-               .And(x => GivenOcelotIsRunning())
-               .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
-               .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
-        }
-
-        private void GivenThereIsAServiceRunningOn(string url, IPAddress ipAddess)
-        {
-            _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
-            {
-                context.Connection.RemoteIpAddress = ipAddess;
-                context.Response.StatusCode = (int)HttpStatusCode.OK;
-                await context.Response.WriteAsync("a valida response body");
-            });
-        }
-
-        private static FileConfiguration GivenConfigurationWithSecurityOptions(params FileRoute[] routes)
-        {
-            var config = GivenConfiguration(routes);
-            config.GlobalConfiguration.SecurityOptions = new FileSecurityOptions
-            {
-                IPAllowedList = new List<string> { "192.168.1.30-50" },
-                IPBlockedList = new List<string> { "192.168.1.1-100" },
-                ExcludeAllowedFromBlocked = true
-            };
-
-            return config;
-        }
-
-        private FileRoute GivenRoute(int port, string downstream, string upstream, FileSecurityOptions fileSecurityOptions = null)
-            => new()
-            {
-                DownstreamPathTemplate = downstream,
-                UpstreamPathTemplate = upstream,
-                UpstreamHttpMethod = new List<string> { "Get" },
-                SecurityOptions = fileSecurityOptions ?? new FileSecurityOptions(),
-            };
+        _serviceHandler = new ServiceHandler();
     }
+
+    public override void Dispose()
+    {
+        _serviceHandler.Dispose();
+        base.Dispose();
+    }
+
+    [Fact]
+    public void Should_call_with_allowed_ip_in_global_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.35")[0];
+        var route = GivenRoute(port, "/myPath", "/worldPath");
+        var configuration = GivenConfigurationWithSecurityOptions(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+    }
+
+    [Fact]
+    public void Should_block_call_with_blocked_ip_in_global_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.55")[0];
+        var route = GivenRoute(port, "/myPath", "/worldPath");
+        var configuration = GivenConfigurationWithSecurityOptions(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+    }
+
+    [Fact]
+    public void Should_call_with_allowed_ip_in_route_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.1")[0];
+        var securityConfig = new FileSecurityOptions
+        {
+            IPAllowedList = new List<string> { "192.168.1.1" },
+        };
+
+        var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+        var configuration = GivenConfiguration(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+    }
+
+    [Fact]
+    public void Should_block_call_with_blocked_ip_in_route_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.1")[0];
+        var securityConfig = new FileSecurityOptions
+        {
+            IPBlockedList = new List<string> { "192.168.1.1" },
+        };
+
+        var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+        var configuration = GivenConfiguration(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+    }
+
+    [Fact]
+    public void Should_call_with_allowed_ip_in_route_config_and_blocked_ip_in_global_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.55")[0];
+        var securityConfig = new FileSecurityOptions
+        {
+            IPAllowedList = new List<string> { "192.168.1.55" },
+        };
+
+        var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+        var configuration = GivenConfigurationWithSecurityOptions(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+           .And(x => GivenThereIsAConfiguration(configuration))
+           .And(x => GivenOcelotIsRunning())
+           .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+           .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK));
+    }
+
+    [Fact]
+    public void Should_block_call_with_blocked_ip_in_route_config_and_allowed_ip_in_global_config()
+    {
+        var port = PortFinder.GetRandomPort();
+        var ip = Dns.GetHostAddresses("192.168.1.35")[0];
+        var securityConfig = new FileSecurityOptions
+        {
+            IPBlockedList = new List<string> { "192.168.1.35" },
+        };
+
+        var route = GivenRoute(port, "/myPath", "/worldPath", securityConfig);
+        var configuration = GivenConfigurationWithSecurityOptions(route);
+
+        this.Given(x => x.GivenThereIsAServiceRunningOn(DownstreamUrl(port), ip))
+           .And(x => GivenThereIsAConfiguration(configuration))
+           .And(x => GivenOcelotIsRunning())
+           .When(x => WhenIGetUrlOnTheApiGateway("/worldPath"))
+           .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Unauthorized));
+    }
+
+    private void GivenThereIsAServiceRunningOn(string url, IPAddress ipAddess)
+    {
+        _serviceHandler.GivenThereIsAServiceRunningOn(url, async context =>
+        {
+            context.Connection.RemoteIpAddress = ipAddess;
+            context.Response.StatusCode = (int)HttpStatusCode.OK;
+            await context.Response.WriteAsync("a valida response body");
+        });
+    }
+
+    private static FileConfiguration GivenConfigurationWithSecurityOptions(params FileRoute[] routes)
+    {
+        var config = GivenConfiguration(routes);
+        config.GlobalConfiguration.SecurityOptions = new FileSecurityOptions
+        {
+            IPAllowedList = new List<string> { "192.168.1.30-50" },
+            IPBlockedList = new List<string> { "192.168.1.1-100" },
+            ExcludeAllowedFromBlocked = true
+        };
+
+        return config;
+    }
+
+    private FileRoute GivenRoute(int port, string downstream, string upstream, FileSecurityOptions fileSecurityOptions = null)
+        => new()
+        {
+            DownstreamPathTemplate = downstream,
+            UpstreamPathTemplate = upstream,
+            UpstreamHttpMethod = new List<string> { "Get" },
+            SecurityOptions = fileSecurityOptions ?? new FileSecurityOptions(),
+        };
 }

--- a/test/Ocelot.UnitTests/Configuration/RoutesCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/RoutesCreatorTests.cs
@@ -303,7 +303,7 @@ namespace Ocelot.UnitTests.Configuration
             _hfarCreator.Verify(x => x.Create(fileRoute), Times.Once);
             _daCreator.Verify(x => x.Create(fileRoute), Times.Once);
             _lboCreator.Verify(x => x.Create(fileRoute.LoadBalancerOptions), Times.Once);
-            _soCreator.Verify(x => x.Create(fileRoute.SecurityOptions), Times.Once);
+            _soCreator.Verify(x => x.Create(fileRoute.SecurityOptions, globalConfig), Times.Once);
             _metadataCreator.Verify(x => x.Create(fileRoute.Metadata, globalConfig), Times.Once);
         }
     }

--- a/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
@@ -6,8 +6,9 @@ namespace Ocelot.UnitTests.Configuration
 {
     public class SecurityOptionsCreatorTests : UnitTest
     {
-        private FileRoute _fileRoute;
+        private FileSecurityOptions _fileSecurityOptions;
         private SecurityOptions _result;
+        private FileGlobalConfiguration _globalConfig;
         private readonly ISecurityOptionsCreator _creator;
 
         public SecurityOptionsCreatorTests()
@@ -16,11 +17,31 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_create_security_config()
+        public void should_create_route_security_config()
         {
             var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
             var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var fileRoute = new FileRoute
+            var securityOptions = new FileSecurityOptions
+            {
+                IPAllowedList = ipAllowedList,
+                IPBlockedList = ipBlockedList,
+            };
+
+            var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
+
+            this.Given(x => x.GivenThe(new FileGlobalConfiguration()))
+                .Given(x => x.GivenThe(securityOptions))
+                .When(x => x.WhenICreate())
+                .Then(x => x.ThenTheResultIs(expected))
+                .BDDfy();
+        }
+
+        [Fact]
+        public void should_create_global_security_config()
+        {
+            var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+            var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+            var globalConfig = new FileGlobalConfiguration
             {
                 SecurityOptions = new FileSecurityOptions
                 {
@@ -31,20 +52,57 @@ namespace Ocelot.UnitTests.Configuration
 
             var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
 
-            this.Given(x => x.GivenThe(fileRoute))
-              .When(x => x.WhenICreate())
-              .Then(x => x.ThenTheResultIs(expected))
-              .BDDfy();
+            this.Given(x => x.GivenThe(globalConfig))
+                .Given(x => x.GivenThe(new FileSecurityOptions()))
+                .When(x => x.WhenICreate())
+                .Then(x => x.ThenTheResultIs(expected))
+                .BDDfy();
         }
 
-        private void GivenThe(FileRoute route)
+        [Fact]
+        public void should_create_global_route_security_config()
         {
-            _fileRoute = route;
+            var routeIpAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+            var routeIpBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+            var securityOptions = new FileSecurityOptions
+                {
+                    IPAllowedList = routeIpAllowedList,
+                    IPBlockedList = routeIpBlockedList,
+                };
+
+            var globalIpAllowedList = new List<string> { "127.0.0.2", "192.168.1.2" };
+            var globalIpBlockedList = new List<string> { "127.0.0.2", "192.168.1.2" };
+            var globalConfig = new FileGlobalConfiguration
+            {
+                SecurityOptions = new FileSecurityOptions
+                {
+                    IPAllowedList = globalIpAllowedList,
+                    IPBlockedList = globalIpBlockedList,
+                },
+            };
+
+            var expected = new SecurityOptions(routeIpAllowedList, routeIpBlockedList);
+
+            this.Given(x => x.GivenThe(globalConfig))
+                .Given(x => x.GivenThe(securityOptions))
+                .When(x => x.WhenICreate())
+                .Then(x => x.ThenTheResultIs(expected))
+                .BDDfy();
+        }
+
+        private void GivenThe(FileSecurityOptions fileSecurityOptions)
+        {
+            _fileSecurityOptions = fileSecurityOptions;
+        }
+
+        private void GivenThe(FileGlobalConfiguration globalConfiguration)
+        {
+            _globalConfig = globalConfiguration;
         }
 
         private void WhenICreate()
         {
-            _result = _creator.Create(_fileRoute.SecurityOptions);
+            _result = _creator.Create(_fileSecurityOptions, _globalConfig);
         }
 
         private void ThenTheResultIs(SecurityOptions expected)

--- a/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
@@ -17,7 +17,7 @@ namespace Ocelot.UnitTests.Configuration
         }
 
         [Fact]
-        public void should_create_route_security_config()
+        public void Should_create_route_security_config()
         {
             var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
             var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
@@ -32,12 +32,11 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenThe(new FileGlobalConfiguration()))
                 .Given(x => x.GivenThe(securityOptions))
                 .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected))
-                .BDDfy();
+                .Then(x => x.ThenTheResultIs(expected));
         }
 
         [Fact]
-        public void should_create_global_security_config()
+        public void Should_create_global_security_config()
         {
             var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
             var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
@@ -55,12 +54,11 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenThe(globalConfig))
                 .Given(x => x.GivenThe(new FileSecurityOptions()))
                 .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected))
-                .BDDfy();
+                .Then(x => x.ThenTheResultIs(expected));
         }
 
         [Fact]
-        public void should_create_global_route_security_config()
+        public void Should_create_global_route_security_config()
         {
             var routeIpAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
             var routeIpBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
@@ -86,8 +84,7 @@ namespace Ocelot.UnitTests.Configuration
             this.Given(x => x.GivenThe(globalConfig))
                 .Given(x => x.GivenThe(securityOptions))
                 .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected))
-                .BDDfy();
+                .Then(x => x.ThenTheResultIs(expected));
         }
 
         private void GivenThe(FileSecurityOptions fileSecurityOptions)

--- a/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/SecurityOptionsCreatorTests.cs
@@ -2,117 +2,98 @@
 using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
 
-namespace Ocelot.UnitTests.Configuration
+namespace Ocelot.UnitTests.Configuration;
+
+public sealed class SecurityOptionsCreatorTests : UnitTest
 {
-    public class SecurityOptionsCreatorTests : UnitTest
+    private readonly SecurityOptionsCreator _creator = new();
+
+    [Fact]
+    public void Should_create_route_security_config()
     {
-        private FileSecurityOptions _fileSecurityOptions;
-        private SecurityOptions _result;
-        private FileGlobalConfiguration _globalConfig;
-        private readonly ISecurityOptionsCreator _creator;
-
-        public SecurityOptionsCreatorTests()
+        // Arrange
+        var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var securityOptions = new FileSecurityOptions
         {
-            _creator = new SecurityOptionsCreator();
-        }
+            IPAllowedList = ipAllowedList,
+            IPBlockedList = ipBlockedList,
+        };
+        var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
+        var globalConfig = new FileGlobalConfiguration();
 
-        [Fact]
-        public void Should_create_route_security_config()
+        // Act
+        var actual = _creator.Create(securityOptions, globalConfig);
+
+        // Assert
+        ThenTheResultIs(actual, expected);
+    }
+
+    [Fact]
+    [Trait("Feat", "2170")]
+    public void Should_create_global_security_config()
+    {
+        // Arrange
+        var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var globalConfig = new FileGlobalConfiguration
         {
-            var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var securityOptions = new FileSecurityOptions
+            SecurityOptions = new()
             {
                 IPAllowedList = ipAllowedList,
                 IPBlockedList = ipBlockedList,
-            };
+            },
+        };
+        var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
 
-            var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
+        // Act
+        var actual = _creator.Create(new(), globalConfig);
 
-            this.Given(x => x.GivenThe(new FileGlobalConfiguration()))
-                .Given(x => x.GivenThe(securityOptions))
-                .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected));
-        }
+        // Assert
+        ThenTheResultIs(actual, expected);
+    }
 
-        [Fact]
-        public void Should_create_global_security_config()
+    [Fact]
+    [Trait("Feat", "2170")]
+    public void Should_create_global_route_security_config()
+    {
+        // Arrange
+        var routeIpAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var routeIpBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
+        var securityOptions = new FileSecurityOptions
         {
-            var ipAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var ipBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var globalConfig = new FileGlobalConfiguration
+            IPAllowedList = routeIpAllowedList,
+            IPBlockedList = routeIpBlockedList,
+        };
+        var globalIpAllowedList = new List<string> { "127.0.0.2", "192.168.1.2" };
+        var globalIpBlockedList = new List<string> { "127.0.0.2", "192.168.1.2" };
+        var globalConfig = new FileGlobalConfiguration
+        {
+            SecurityOptions = new FileSecurityOptions
             {
-                SecurityOptions = new FileSecurityOptions
-                {
-                    IPAllowedList = ipAllowedList,
-                    IPBlockedList = ipBlockedList,
-                },
-            };
+                IPAllowedList = globalIpAllowedList,
+                IPBlockedList = globalIpBlockedList,
+            },
+        };
+        var expected = new SecurityOptions(routeIpAllowedList, routeIpBlockedList);
 
-            var expected = new SecurityOptions(ipAllowedList, ipBlockedList);
+        // Act
+        var actual = _creator.Create(securityOptions, globalConfig);
 
-            this.Given(x => x.GivenThe(globalConfig))
-                .Given(x => x.GivenThe(new FileSecurityOptions()))
-                .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected));
+        // Assert
+        ThenTheResultIs(actual, expected);
+    }
+
+    private static void ThenTheResultIs(SecurityOptions actual, SecurityOptions expected)
+    {
+        for (var i = 0; i < expected.IPAllowedList.Count; i++)
+        {
+            actual.IPAllowedList[i].ShouldBe(expected.IPAllowedList[i]);
         }
 
-        [Fact]
-        public void Should_create_global_route_security_config()
+        for (var i = 0; i < expected.IPBlockedList.Count; i++)
         {
-            var routeIpAllowedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var routeIpBlockedList = new List<string> { "127.0.0.1", "192.168.1.1" };
-            var securityOptions = new FileSecurityOptions
-                {
-                    IPAllowedList = routeIpAllowedList,
-                    IPBlockedList = routeIpBlockedList,
-                };
-
-            var globalIpAllowedList = new List<string> { "127.0.0.2", "192.168.1.2" };
-            var globalIpBlockedList = new List<string> { "127.0.0.2", "192.168.1.2" };
-            var globalConfig = new FileGlobalConfiguration
-            {
-                SecurityOptions = new FileSecurityOptions
-                {
-                    IPAllowedList = globalIpAllowedList,
-                    IPBlockedList = globalIpBlockedList,
-                },
-            };
-
-            var expected = new SecurityOptions(routeIpAllowedList, routeIpBlockedList);
-
-            this.Given(x => x.GivenThe(globalConfig))
-                .Given(x => x.GivenThe(securityOptions))
-                .When(x => x.WhenICreate())
-                .Then(x => x.ThenTheResultIs(expected));
-        }
-
-        private void GivenThe(FileSecurityOptions fileSecurityOptions)
-        {
-            _fileSecurityOptions = fileSecurityOptions;
-        }
-
-        private void GivenThe(FileGlobalConfiguration globalConfiguration)
-        {
-            _globalConfig = globalConfiguration;
-        }
-
-        private void WhenICreate()
-        {
-            _result = _creator.Create(_fileSecurityOptions, _globalConfig);
-        }
-
-        private void ThenTheResultIs(SecurityOptions expected)
-        {
-            for (var i = 0; i < expected.IPAllowedList.Count; i++)
-            {
-                _result.IPAllowedList[i].ShouldBe(expected.IPAllowedList[i]);
-            }
-
-            for (var i = 0; i < expected.IPBlockedList.Count; i++)
-            {
-                _result.IPBlockedList[i].ShouldBe(expected.IPBlockedList[i]);
-            }
+            actual.IPBlockedList[i].ShouldBe(expected.IPBlockedList[i]);
         }
     }
 }

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -31,298 +31,271 @@ namespace Ocelot.UnitTests.Security
         }
 
         [Fact]
-        public void should_No_blocked_Ip_and_allowed_Ip()
+        public void Should_No_blocked_Ip_and_allowed_Ip()
         {
             this.Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_blockedIp_clientIp_block()
+        public void Should_blockedIp_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
             this.Given(x => x.GivenSetBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_blockedIp_clientIp_Not_block()
+        public void Should_blockedIp_clientIp_Not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
             this.Given(x => x.GivenSetBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_allowedIp_clientIp_block()
+        public void Should_allowedIp_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
             this.Given(x => x.GivenSetAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_allowedIp_clientIp_Not_block()
+        public void Should_allowedIp_clientIp_Not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
             this.Given(x => x.GivenSetAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_cidrNotation_allowed24_clientIp_block()
+        public void Should_cidrNotation_allowed24_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
             this.Given(x => x.GivenCidr24AllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_cidrNotation_allowed24_clientIp_not_block()
+        public void Should_cidrNotation_allowed24_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
             this.Given(x => x.GivenCidr24AllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_cidrNotation_allowed29_clientIp_block()
+        public void Should_cidrNotation_allowed29_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
             this.Given(x => x.GivenCidr29AllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_cidrNotation_blocked24_clientIp_block()
+        public void Should_cidrNotation_blocked24_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
             this.Given(x => x.GivenCidr24BlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_cidrNotation_blocked24_clientIp_not_block()
+        public void Should_cidrNotation_blocked24_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
             this.Given(x => x.GivenCidr24BlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_range_allowed_clientIp_block()
+        public void Should_range_allowed_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenRangeAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_range_allowed_clientIp_not_block()
+        public void Should_range_allowed_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
             this.Given(x => x.GivenRangeAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_range_blocked_clientIp_block()
+        public void Should_range_blocked_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
             this.Given(x => x.GivenRangeBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_range_blocked_clientIp_not_block()
+        public void Should_range_blocked_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenRangeBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_shortRange_allowed_clientIp_block()
+        public void Should_shortRange_allowed_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenShortRangeAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_shortRange_allowed_clientIp_not_block()
+        public void Should_shortRange_allowed_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
             this.Given(x => x.GivenShortRangeAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_shortRange_blocked_clientIp_block()
+        public void Should_shortRange_blocked_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
             this.Given(x => x.GivenShortRangeBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_shortRange_blocked_clientIp_not_block()
+        public void Should_shortRange_blocked_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenShortRangeBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_ipSubnet_allowed_clientIp_block()
+        public void Should_ipSubnet_allowed_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
             this.Given(x => x.GivenIpSubnetAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_ipSubnet_allowed_clientIp_not_block()
+        public void Should_ipSubnet_allowed_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenIpSubnetAllowedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_ipSubnet_blocked_clientIp_block()
+        public void Should_ipSubnet_blocked_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
             this.Given(x => x.GivenIpSubnetBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_ipSubnet_blocked_clientIp_not_block()
+        public void Should_ipSubnet_blocked_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
             this.Given(x => x.GivenIpSubnetBlockedIP())
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+        public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
             this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+        public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
             this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+        public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
             this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenNotSecurityPassing());
         }
 
         [Fact]
-        public void should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+        public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
             this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         [Fact]
-        public void should_route_config_overrides_global_config()
+        public void Should_route_config_overrides_global_config()
         {
             _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
             this.Given(x => x.GivenRouteConfigAndGlobalConfig(false))
                 .Given(x => x.GivenSetDownstreamRoute())
                 .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing())
-                .BDDfy();
+                .Then(x => x.ThenSecurityPassing());
         }
 
         private void GivenSetAllowedIP()

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -8,403 +8,391 @@ using Ocelot.Request.Middleware;
 using Ocelot.Responses;
 using Ocelot.Security.IPSecurity;
 
-namespace Ocelot.UnitTests.Security
+namespace Ocelot.UnitTests.Security;
+
+public sealed class IPSecurityPolicyTests : UnitTest
 {
-    public class IPSecurityPolicyTests : UnitTest
+    private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
+    private readonly IPSecurityPolicy _policy;
+    private readonly HttpContext _context;
+    private readonly SecurityOptionsCreator _securityOptionsCreator;
+    private static readonly FileGlobalConfiguration Empty = new();
+
+    public IPSecurityPolicyTests()
     {
-        private readonly DownstreamRouteBuilder _downstreamRouteBuilder;
-        private readonly IPSecurityPolicy _ipSecurityPolicy;
-        private Response response;
-        private readonly HttpContext _httpContext;
-        private readonly SecurityOptionsCreator _securityOptionsCreator;
-        private readonly FileGlobalConfiguration _emptyFileGlobalConfiguration;
+        _context = new DefaultHttpContext();
+        _context.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        _downstreamRouteBuilder = new DownstreamRouteBuilder();
+        _policy = new IPSecurityPolicy();
+        _securityOptionsCreator = new SecurityOptionsCreator();
+    }
 
-        public IPSecurityPolicyTests()
+    [Fact]
+    public void Should_No_blocked_Ip_and_allowed_Ip()
+    {
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_blockedIp_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        GivenSetBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_blockedIp_clientIp_Not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+        GivenSetBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_allowedIp_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        GivenSetAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_allowedIp_clientIp_Not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
+        GivenSetAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_cidrNotation_allowed24_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
+        GivenCidr24AllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_cidrNotation_allowed24_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        GivenCidr24AllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_cidrNotation_allowed29_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        GivenCidr29AllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_cidrNotation_blocked24_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
+        GivenCidr24BlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_cidrNotation_blocked24_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+        GivenCidr24BlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_range_allowed_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenRangeAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_range_allowed_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+        GivenRangeAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_range_blocked_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        GivenRangeBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_range_blocked_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenRangeBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_shortRange_allowed_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenShortRangeAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_shortRange_allowed_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
+        GivenShortRangeAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_shortRange_blocked_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
+        GivenShortRangeBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_shortRange_blocked_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenShortRangeBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_ipSubnet_allowed_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
+        GivenIpSubnetAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_ipSubnet_allowed_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenIpSubnetAllowedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_ipSubnet_blocked_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
+        GivenIpSubnetBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_ipSubnet_blocked_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
+        GivenIpSubnetBlockedIP();
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+        GivenIpMoreAllowedThanBlocked(false);
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
+        GivenIpMoreAllowedThanBlocked(true);
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        GivenIpMoreBlockedThanAllowed(false);
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.True(actual.IsError);
+    }
+
+    [Fact]
+    public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        GivenIpMoreBlockedThanAllowed(true);
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    [Fact]
+    [Trait("Feat", "2170")]
+    public void Should_route_config_overrides_global_config()
+    {
+        _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
+        GivenRouteConfigAndGlobalConfig(false);
+        GivenSetDownstreamRoute();
+        var actual = WhenTheSecurityPolicy();
+        Assert.False(actual.IsError);
+    }
+
+    private void GivenSetAllowedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions("192.168.1.1"));
+    }
+
+    private void GivenSetBlockedIP()
+    {
+        _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(blocked: "192.168.1.1"));
+    }
+
+    private void GivenSetDownstreamRoute()
+    {
+        _context.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
+    }
+
+    private void GivenCidr24AllowedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/24"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenCidr29AllowedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/29"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenCidr24BlockedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/24"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenRangeAllowedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-192.168.1.10"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenRangeBlockedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenShortRangeAllowedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-10"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenShortRangeBlockedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-10"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenIpSubnetAllowedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/255.255.255.0"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenIpSubnetBlockedIP()
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0"), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
+    {
+        var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked), Empty);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
+
+    private void GivenRouteConfigAndGlobalConfig(bool excludeAllowedInBlocked)
+    {
+        var globalConfig = new FileGlobalConfiguration
         {
-            _httpContext = new DefaultHttpContext();
-            _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            _downstreamRouteBuilder = new DownstreamRouteBuilder();
-            _ipSecurityPolicy = new IPSecurityPolicy();
-            _securityOptionsCreator = new SecurityOptionsCreator();
-            _emptyFileGlobalConfiguration = new FileGlobalConfiguration();
-        }
+            SecurityOptions = new FileSecurityOptions("192.168.1.30-50", "192.168.1.1-100", true),
+        };
+        
+        var localConfig = new FileSecurityOptions("192.168.1.10", "", excludeAllowedInBlocked);
 
-        [Fact]
-        public void Should_No_blocked_Ip_and_allowed_Ip()
-        {
-            this.Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
+        var securityOptions = _securityOptionsCreator.Create(localConfig, globalConfig);
+        _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
+    }
 
-        [Fact]
-        public void Should_blockedIp_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenSetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_blockedIp_clientIp_Not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-            this.Given(x => x.GivenSetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_allowedIp_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenSetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_allowedIp_clientIp_Not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
-            this.Given(x => x.GivenSetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_cidrNotation_allowed24_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
-            this.Given(x => x.GivenCidr24AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_cidrNotation_allowed24_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenCidr24AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_cidrNotation_allowed29_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenCidr29AllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_cidrNotation_blocked24_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
-            this.Given(x => x.GivenCidr24BlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_cidrNotation_blocked24_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-            this.Given(x => x.GivenCidr24BlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_range_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_range_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-            this.Given(x => x.GivenRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_range_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_range_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_shortRange_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenShortRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_shortRange_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
-            this.Given(x => x.GivenShortRangeAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_shortRange_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
-            this.Given(x => x.GivenShortRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_shortRange_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenShortRangeBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_ipSubnet_allowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
-            this.Given(x => x.GivenIpSubnetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_ipSubnet_allowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenIpSubnetAllowedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_ipSubnet_blocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
-            this.Given(x => x.GivenIpSubnetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_ipSubnet_blocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
-            this.Given(x => x.GivenIpSubnetBlockedIP())
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-            this.Given(x => x.GivenIpMoreAllowedThanBlocked(false))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
-            this.Given(x => x.GivenIpMoreAllowedThanBlocked(true))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenIpMoreBlockedThanAllowed(false))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenNotSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenIpMoreBlockedThanAllowed(true))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        [Fact]
-        public void Should_route_config_overrides_global_config()
-        {
-            _httpContext.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
-            this.Given(x => x.GivenRouteConfigAndGlobalConfig(false))
-                .Given(x => x.GivenSetDownstreamRoute())
-                .When(x => x.WhenTheSecurityPolicy())
-                .Then(x => x.ThenSecurityPassing());
-        }
-
-        private void GivenSetAllowedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions("192.168.1.1"));
-        }
-
-        private void GivenSetBlockedIP()
-        {
-            _downstreamRouteBuilder.WithSecurityOptions(new SecurityOptions(blocked: "192.168.1.1"));
-        }
-
-        private void GivenSetDownstreamRoute()
-        {
-            _httpContext.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
-        }
-
-        private void GivenCidr24AllowedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/24"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenCidr29AllowedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/29"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenCidr24BlockedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/24"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenRangeAllowedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-192.168.1.10"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenRangeBlockedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenShortRangeAllowedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0-10"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenShortRangeBlockedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0-10"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenIpSubnetAllowedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.0/255.255.255.0"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenIpSubnetBlockedIP()
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0"), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenIpMoreAllowedThanBlocked(bool excludeAllowedInBlocked)
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", excludeAllowedInBlocked), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenIpMoreBlockedThanAllowed(bool excludeAllowedInBlocked)
-        {
-            var securityOptions = _securityOptionsCreator.Create(new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", excludeAllowedInBlocked), _emptyFileGlobalConfiguration);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private void GivenRouteConfigAndGlobalConfig(bool excludeAllowedInBlocked)
-        {
-            var globalConfig = new FileGlobalConfiguration
-            {
-                SecurityOptions = new FileSecurityOptions("192.168.1.30-50", "192.168.1.1-100", true),
-            };
-            
-            var localConfig = new FileSecurityOptions("192.168.1.10", "", excludeAllowedInBlocked);
-
-            var securityOptions = _securityOptionsCreator.Create(localConfig, globalConfig);
-            _downstreamRouteBuilder.WithSecurityOptions(securityOptions);
-        }
-
-        private async Task WhenTheSecurityPolicy()
-        {
-            response = await _ipSecurityPolicy.Security(_httpContext.Items.DownstreamRoute(), _httpContext);
-        }
-
-        private void ThenSecurityPassing()
-        {
-            Assert.False(response.IsError);
-        }
-
-        private void ThenNotSecurityPassing()
-        {
-            Assert.True(response.IsError);
-        }
+    private Response WhenTheSecurityPolicy()
+    {
+        return _policy.Security(_context.Items.DownstreamRoute(), _context);
     }
 }

--- a/test/Ocelot.UnitTests/Security/SecurityMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Security/SecurityMiddlewareTests.cs
@@ -7,83 +7,84 @@ using Ocelot.Responses;
 using Ocelot.Security;
 using Ocelot.Security.Middleware;
 
-namespace Ocelot.UnitTests.Security
+namespace Ocelot.UnitTests.Security;
+
+public sealed class SecurityMiddlewareTests : UnitTest
 {
-    public class SecurityMiddlewareTests : UnitTest
+    private readonly List<Mock<ISecurityPolicy>> _securityPolicyList;
+    private readonly Mock<IOcelotLoggerFactory> _loggerFactory;
+    private readonly Mock<IOcelotLogger> _logger;
+    private readonly SecurityMiddleware _middleware;
+    private readonly RequestDelegate _next;
+    private readonly HttpContext _httpContext;
+
+    public SecurityMiddlewareTests()
     {
-        private readonly List<Mock<ISecurityPolicy>> _securityPolicyList;
-        private readonly Mock<IOcelotLoggerFactory> _loggerFactory;
-        private readonly Mock<IOcelotLogger> _logger;
-        private readonly SecurityMiddleware _middleware;
-        private readonly RequestDelegate _next;
-        private readonly HttpContext _httpContext;
-
-        public SecurityMiddlewareTests()
+        _httpContext = new DefaultHttpContext();
+        _loggerFactory = new Mock<IOcelotLoggerFactory>();
+        _logger = new Mock<IOcelotLogger>();
+        _loggerFactory.Setup(x => x.CreateLogger<SecurityMiddleware>()).Returns(_logger.Object);
+        _securityPolicyList = new List<Mock<ISecurityPolicy>>
         {
-            _httpContext = new DefaultHttpContext();
-            _loggerFactory = new Mock<IOcelotLoggerFactory>();
-            _logger = new Mock<IOcelotLogger>();
-            _loggerFactory.Setup(x => x.CreateLogger<SecurityMiddleware>()).Returns(_logger.Object);
-            _securityPolicyList = new List<Mock<ISecurityPolicy>>
+            new(),
+            new(),
+        };
+        _next = context => Task.CompletedTask;
+        _middleware = new SecurityMiddleware(_next, _loggerFactory.Object, _securityPolicyList.Select(f => f.Object).ToList());
+        _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
+    }
+
+    [Fact]
+    public async Task Should_legal_request()
+    {
+        // Arrange
+        GivenPassingSecurityVerification();
+
+        // Act
+        await _middleware.Invoke(_httpContext);
+
+        // Assert: security passed
+        _httpContext.Items.Errors().Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task Should_verification_failed_request()
+    {
+        // Arrange
+        GivenNotPassingSecurityVerification();
+
+        // Act
+        await _middleware.Invoke(_httpContext);
+
+        // Assert: security not passed
+        _httpContext.Items.Errors().Count.ShouldBeGreaterThan(0);
+    }
+
+    private void GivenPassingSecurityVerification()
+    {
+        foreach (var item in _securityPolicyList)
+        {
+            Response response = new OkResponse();
+            item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
+        }
+    }
+
+    private void GivenNotPassingSecurityVerification()
+    {
+        for (var i = 0; i < _securityPolicyList.Count; i++)
+        {
+            var item = _securityPolicyList[i];
+            if (i == 0)
             {
-                new(),
-                new(),
-            };
-            _next = context => Task.CompletedTask;
-            _middleware = new SecurityMiddleware(_next, _loggerFactory.Object, _securityPolicyList.Select(f => f.Object).ToList());
-            _httpContext.Items.UpsertDownstreamRequest(new DownstreamRequest(new HttpRequestMessage(HttpMethod.Get, "http://test.com")));
-        }
-
-        [Fact]
-        public void Should_legal_request()
-        {
-            this.Given(x => x.GivenPassingSecurityVerification())
-                .When(x => x.WhenICallTheMiddleware())
-                .Then(x => x.ThenTheRequestIsPassingSecurity())
-                .BDDfy();
-        }
-
-        [Fact]
-        public void Should_verification_failed_request()
-        {
-            this.Given(x => x.GivenNotPassingSecurityVerification())
-                .When(x => x.WhenICallTheMiddleware())
-                .Then(x => x.ThenTheRequestIsNotPassingSecurity())
-                .BDDfy();
-        }
-
-        private void GivenPassingSecurityVerification()
-        {
-            foreach (var item in _securityPolicyList)
+                Error error = new UnauthenticatedError("Not passing security verification");
+                Response response = new ErrorResponse(error);
+                item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
+            }
+            else
             {
                 Response response = new OkResponse();
-                item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(Task.FromResult(response));
+                item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
             }
         }
-
-        private void GivenNotPassingSecurityVerification()
-        {
-            for (var i = 0; i < _securityPolicyList.Count; i++)
-            {
-                var item = _securityPolicyList[i];
-                if (i == 0)
-                {
-                    Error error = new UnauthenticatedError("Not passing security verification");
-                    Response response = new ErrorResponse(error);
-                    item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(Task.FromResult(response));
-                }
-                else
-                {
-                    Response response = new OkResponse();
-                    item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(Task.FromResult(response));
-                }
-            }
-        }
-
-        private Task WhenICallTheMiddleware() => _middleware.Invoke(_httpContext);
-
-        private void ThenTheRequestIsPassingSecurity() => _httpContext.Items.Errors().Count.ShouldBe(0);
-
-        private void ThenTheRequestIsNotPassingSecurity() => _httpContext.Items.Errors().Count.ShouldBeGreaterThan(0);
     }
 }


### PR DESCRIPTION
## Closes #2165 
- #2165 

## Proposed Changes

As the issue #2165 reports, the `SecurityOptions` are missing in `GlobalConfiguration`.

This pull request adds the ability to configure Allowed and Blocked IPs globally: the global configuration will be applied for every route unless an existing `SecurityOptions` is present on it
