### PR TITLE
#2199 Adding support of placeholder matching between slashes👍 

### DIFF
--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -69,11 +69,26 @@ In order to change this you can specify on a per Route basis the following setti
 
   "RouteIsCaseSensitive": true
 
-This means that when Ocelot tries to match the incoming upstream URL with an upstream template the evaluation will be case sensitive. 
+This means that when Ocelot tries to match the incoming upstream URL with an upstream template the evaluation will be case sensitive.
+
+.. _routing-embedded-placeholders:
+
+Embedded Placeholders [#f1]_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Until now (November 2024), Ocelot could not evaluate multiple placeholders embedded between two forward slashes. 
+Additionally, it was not possible to distinguish the placeholder from other elements between the slashes. 
+For instance, ``/{url}-2/`` for ``/y-2/`` would return ``{url} = y-2``. We now propose a revised version of placeholder evaluation that enables the resolution of placeholders in complex URLs, such as:
+
+Path pattern: ``/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}``
+
+Upstream path: ``/api/invoices_super/123-456_abcd/789?urlId=987``
+
+Parsed placeholders: ``{url0} = super``, ``{url1} = 123``, ``{url2} = 456``, ``{url3} = 789``, ``{url4} = 987`` 
 
 .. _routing-empty-placeholders:
 
-Empty Placeholders [#f1]_
+Empty Placeholders [#f2]_
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This is a special edge case of :ref:`routing-placeholders`, where the value of the placeholder is simply an empty string ``""``.
@@ -135,7 +150,7 @@ If you also have the Route below in your config then Ocelot would match it befor
 
 .. _routing-upstream-host:
 
-Upstream Host [#f2]_
+Upstream Host [#f3]_
 --------------------
 
 This feature allows you to have Routes based on the *upstream host*.
@@ -156,7 +171,7 @@ This means that if you have two Routes that are the same, apart from the **Upstr
 
 .. _routing-upstream-headers:
 
-Upstream Headers [#f3]_
+Upstream Headers [#f4]_
 -----------------------
 
 In addition to routing by ``UpstreamPathTemplate``, you can also define ``UpstreamHeaderTemplates``.
@@ -302,7 +317,7 @@ The placeholder ``{everything}`` name does not matter, any name will work.
 This entire query string routing feature is very useful in cases where the query string should not be transformed but rather routed without any changes,
 such as OData filters and etc (see issue `1174`_).
 
-  **Note**, the ``{everything}`` placeholder can be empty while catching all query strings, because this is a part of the :ref:`routing-empty-placeholders` feature! [#f1]_
+  **Note**, the ``{everything}`` placeholder can be empty while catching all query strings, because this is a part of the :ref:`routing-empty-placeholders` feature! [#f2]_
   Thus, upstream paths ``/contracts?`` and ``/contracts`` are routed to downstream path ``/apipath/contracts``, which has no query string at all.
 
 .. _routing-merging-of-query-parameters:
@@ -365,7 +380,7 @@ Consider the following 2 development scenarios :htm:`&rarr;`
 
 .. _routing-security-options:
 
-Security Options [#f4]_
+Security Options [#f5]_
 -----------------------
 
 Ocelot allows you to manage multiple patterns for allowed/blocked IPs using the `IPAddressRange <https://github.com/jsakamoto/ipaddressrange>`_ package
@@ -397,19 +412,19 @@ The current patterns managed are the following:
 
 .. _routing-dynamic:
 
-Dynamic Routing [#f5]_
+Dynamic Routing [#f6]_
 ----------------------
 
 The idea is to enable dynamic routing when using a :doc:`../features/servicediscovery` provider so you don't have to provide the Route config.
 See the :ref:`sd-dynamic-routing` docs if this sounds interesting to you.
 
-""""
 
-.. [#f1] ":ref:`routing-empty-placeholders`" feature is available starting in version `23.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0>`_, see issue `748 <https://github.com/ThreeMammals/Ocelot/issues/748>`_ and the `23.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0>`__ release notes for details.
-.. [#f2] ":ref:`routing-upstream-host`" feature was requested as part of `issue 216 <https://github.com/ThreeMammals/Ocelot/pull/216>`_.
-.. [#f3] ":ref:`routing-upstream-headers`" feature was proposed in `issue 360 <https://github.com/ThreeMammals/Ocelot/issues/360>`_, and released in version `24.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0>`_.
-.. [#f4] ":ref:`routing-security-options`" feature was requested as part of `issue 628 <https://github.com/ThreeMammals/Ocelot/issues/628>`_ (of `12.0.1 <https://github.com/ThreeMammals/Ocelot/releases/tag/12.0.1>`_ version), then redesigned and improved by `issue 1400 <https://github.com/ThreeMammals/Ocelot/issues/1400>`_, and published in version `20.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/20.0.0>`_ docs.
-.. [#f5] ":ref:`routing-dynamic`" feature was requested as part of `issue 340 <https://github.com/ThreeMammals/Ocelot/issues/340>`_. Complete reference: :ref:`sd-dynamic-routing`.
+.. [#f1] ":ref:`routing-embedded-placeholders`" feature was requested as part of `issue 2199 <https://github.com/ThreeMammals/Ocelot/issues/2199>`_.
+.. [#f2] ":ref:`routing-empty-placeholders`" feature is available starting in version `23.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0>`_, see issue `748 <https://github.com/ThreeMammals/Ocelot/issues/748>`_ and the `23.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0>`__ release notes for details.
+.. [#f3] ":ref:`routing-upstream-host`" feature was requested as part of `issue 216 <https://github.com/ThreeMammals/Ocelot/pull/216>`_.
+.. [#f4] ":ref:`routing-upstream-headers`" feature was proposed in `issue 360 <https://github.com/ThreeMammals/Ocelot/issues/360>`_, and released in version `24.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0>`_.
+.. [#f5] ":ref:`routing-security-options`" feature was requested as part of `issue 628 <https://github.com/ThreeMammals/Ocelot/issues/628>`_ (of `12.0.1 <https://github.com/ThreeMammals/Ocelot/releases/tag/12.0.1>`_ version), then redesigned and improved by `issue 1400 <https://github.com/ThreeMammals/Ocelot/issues/1400>`_, and published in version `20.0 <https://github.com/ThreeMammals/Ocelot/releases/tag/20.0.0>`_ docs.
+.. [#f6] ":ref:`routing-dynamic`" feature was requested as part of `issue 340 <https://github.com/ThreeMammals/Ocelot/issues/340>`_. Complete reference: :ref:`sd-dynamic-routing`.
 
 .. _model binding: https://learn.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-8.0#collections
 .. _Bind arrays and string values from headers and query strings: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/parameter-binding?view=aspnetcore-8.0#bind-arrays-and-string-values-from-headers-and-query-strings

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -83,7 +83,7 @@ public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFind
     /// <returns>True if it matches and the found placeholder.</returns>
     private static (bool IsMatch, string Placeholder) IsCatchAllQuery(string template)
     {
-        Regex catchAllQueryRegex = new(@"^[^{{}}]*\?\{{(.*?)\}}$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
+        Regex catchAllQueryRegex = new(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
         Match catchAllMatch = catchAllQueryRegex.Match(template);
 
         return (catchAllMatch.Success, catchAllMatch.Success ? catchAllMatch.Groups[1].Value : string.Empty);
@@ -98,7 +98,7 @@ public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFind
     /// <returns>True if it matches.</returns>
     private static bool IsCatchAllPath(string template)
     {
-        Regex catchAllPathRegex = new(@"^[^{{}}]*\{{(.*?)\}}/?$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
+        Regex catchAllPathRegex = new(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
         return catchAllPathRegex.IsMatch(template) && !template.Contains('?');
     }
     

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -1,23 +1,29 @@
+using Ocelot.Infrastructure;
 using Ocelot.Responses;
 
 namespace Ocelot.DownstreamRouteFinder.UrlMatcher;
 
-public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFinder
+/// <summary>The finder locates all occurrences of placeholders' names and values within URL paths.
+/// <para>This is the default implementation of the <see cref="IPlaceholderNameAndValueFinder"/> interface.</para>
+/// </summary>
+public partial class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFinder
 {
-    private const char LeftCurlyBracket = '{';
-    private const char RightCurlyBracket = '}';
+    private const char LeftBrace = '{';
+    private const char RightBrace = '}';
 
-    /// <summary>
-    /// Finds the placeholders in the request path and query and returns their matching values.
-    /// We might encounter the following scenarios:
-    /// - The path template contains a catch-all query parameter. If so, we return the catch-all placeholder with an empty value.
-    /// - The path template contains a catch-all path parameter. If so, we return the catch-all placeholder with an empty value.
-    /// - The path template contains placeholders. We return the placeholders with their matching values.
+    /// <summary>Finds the placeholders in the request path and query and returns their matching values.
+    /// <para>We might encounter the following scenarios:
+    /// <list type="bullet">
+    /// <item>The path template contains a Catch-All query parameter. If so, we return the Catch-All placeholder with an empty value.</item>
+    /// <item>The path template contains a Catch-All path parameter. If so, we return the Catch-All placeholder with an empty value.</item>
+    /// <item>The path template contains placeholders. We return the placeholders with their matching values.</item>
+    /// </list>
+    /// </para>
     /// </summary>
     /// <param name="path">The request path.</param>
     /// <param name="query">The query parameters.</param>
     /// <param name="pathTemplate">The request path template.</param>
-    /// <returns>The list of the placeholders with their matching values.</returns>
+    /// <returns>A <see cref="List{PlaceholderNameAndValue}"/> object, where T is <see cref="PlaceholderNameAndValue"/>: the list of the placeholders with their matching values.</returns>
     public Response<List<PlaceholderNameAndValue>> Find(string path, string query, string pathTemplate)
     {
         (bool isCatchAllQuery, string catchAllQueryPlaceholder) = IsCatchAllQuery(pathTemplate);
@@ -25,46 +31,47 @@ public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFind
         {
             return new OkResponse<List<PlaceholderNameAndValue>>(new List<PlaceholderNameAndValue>
             {
-                new($"{LeftCurlyBracket}{catchAllQueryPlaceholder}{RightCurlyBracket}", string.Empty),
+                new($"{LeftBrace}{catchAllQueryPlaceholder}{RightBrace}", string.Empty),
             });
         }
 
         // Find matching groups from path and query
-        IList<Group> groups = FindGroups(path, query, pathTemplate);
-        List<PlaceholderNameAndValue> placeholderNameAndValues = groups
-            .Select(group => new PlaceholderNameAndValue($"{LeftCurlyBracket}{group.Name}{RightCurlyBracket}", group.Value))
+        var placeholders = FindGroups(path, query, pathTemplate)
+            .Select(g => new PlaceholderNameAndValue($"{LeftBrace}{g.Name}{RightBrace}", g.Value))
             .ToList();
-
-        return new OkResponse<List<PlaceholderNameAndValue>>(placeholderNameAndValues);
+        return new OkResponse<List<PlaceholderNameAndValue>>(placeholders);
     }
 
-    /// <summary>
-    /// Finds the placeholders in the request path and query.
-    /// We use a regex pattern to match the placeholders in the path template.
-    /// We have two slight optimizations:
-    /// - First, we skip the query if it is not present in the path template.
-    /// - Second, we append a trailing slash to the path if it is a catch-all path.
+    private const int PlaceholdersMilliseconds = 1000;
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"\{(.*?)\}", RegexOptions.None, PlaceholdersMilliseconds)]
+    private static partial Regex RegexPlaceholders();
+#else
+    private static readonly Regex _regexPlaceholders = RegexGlobal.New(@"\{(.*?)\}", RegexOptions.None, TimeSpan.FromMilliseconds(PlaceholdersMilliseconds));
+    private static Regex RegexPlaceholders() => _regexPlaceholders;
+#endif
+
+    /// <summary>Finds the placeholders in the request path and query.
+    /// We use a <see cref="Regex"/> pattern to match the placeholders in the path template.
+    /// <para>We have two slight optimizations:
+    /// <list type="number">
+    /// <item>First, we skip the query if it is not present in the path template.</item>
+    /// <item>Second, we append a trailing slash to the path if it is a Catch-All path.</item>
+    /// </list>
+    /// </para>
     /// </summary>
     /// <param name="path">The request path.</param>
     /// <param name="query">The query parameters.</param>
     /// <param name="template">The path template.</param>
-    /// <returns>The matching groups.</returns>
-    private static IList<Group> FindGroups(string path, string query, string template)
+    /// <returns>A <see cref="List{Group}"/> object (T is <see cref="Group"/>): the matching groups.</returns>
+    private static List<Group> FindGroups(string path, string query, string template)
     {
-        Regex regex = new(@"\{(.*?)\}", RegexOptions.None, TimeSpan.FromSeconds(1));
         template = EscapeExceptBraces(template);
-        string regexPattern = $"^{regex.Replace(template, match => $"(?<{match.Groups[1].Value}>[^&]*)")}";
-        
-        string testedPath = ShouldSkipQuery(query, template) ? path : $"{path}{query}";
-        Match match = Regex.Match(testedPath, regexPattern);
-        List<Group> foundGroups = match.Groups.Cast<Group>().Skip(1).ToList();
-        
-        if (foundGroups.Count > 0)
-        {
-            return foundGroups;
-        }
-
-        if (!IsCatchAllPath(template))
+        var regexPattern = $"^{RegexPlaceholders().Replace(template, match => $"(?<{match.Groups[1].Value}>[^&]*)")}";
+        var testedPath = ShouldSkipQuery(query, template) ? path : $"{path}{query}";
+        var match = Regex.Match(testedPath, regexPattern);
+        var foundGroups = match.Groups.Cast<Group>().Skip(1).ToList();
+        if (foundGroups.Count > 0 || !IsCatchAllPath(template))
         {
             return foundGroups;
         }
@@ -74,56 +81,66 @@ public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFind
         return match.Groups.Cast<Group>().Skip(1).ToList();
     }
 
-    /// <summary>
-    /// Checks if the path template contains a catch-all query parameter.
-    /// It means that the path template ends with a question mark and a placeholder.
-    /// And no other placeholders are present in the path template.
+    private const int CatchAllQueryMilliseconds = 300;
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, CatchAllQueryMilliseconds)]
+    private static partial Regex RegexCatchAllQuery();
+#else
+    private static readonly Regex _regexCatchAllQuery = RegexGlobal.New(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, TimeSpan.FromMilliseconds(CatchAllQueryMilliseconds));
+    private static Regex RegexCatchAllQuery() => _regexCatchAllQuery;
+#endif
+
+    /// <summary>Checks if the path template contains a Catch-All query parameter.
+    /// <para>It means that the path template ends with a question mark and a placeholder.
+    /// And no other placeholders are present in the path template.</para>
     /// </summary>
     /// <param name="template">The path template.</param>
-    /// <returns>True if it matches and the found placeholder.</returns>
+    /// <returns><see langword="true"/> if it matches and the found placeholder.</returns>
     private static (bool IsMatch, string Placeholder) IsCatchAllQuery(string template)
     {
-        Regex catchAllQueryRegex = new(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
-        Match catchAllMatch = catchAllQueryRegex.Match(template);
-
-        return (catchAllMatch.Success, catchAllMatch.Success ? catchAllMatch.Groups[1].Value : string.Empty);
+        var catchAllMatch = RegexCatchAllQuery().Match(template);
+        return (catchAllMatch.Success,
+            catchAllMatch.Success ? catchAllMatch.Groups[1].Value : string.Empty);
     }
 
-    /// <summary>
-    /// Check if the path template contains a catch-all path parameter.
-    /// It means that the path template ends with a placeholder and no other placeholders are present in the path template,
-    /// without a question mark (query parameters).
+    private const int CatchAllPathMilliseconds = 300;
+#if NET7_0_OR_GREATER
+    [GeneratedRegex(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, CatchAllPathMilliseconds)]
+    private static partial Regex RegexCatchAllPath();
+#else
+    private static readonly Regex _regexCatchAllPath = RegexGlobal.New(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, TimeSpan.FromMilliseconds(CatchAllPathMilliseconds));
+    private static Regex RegexCatchAllPath() => _regexCatchAllPath;
+#endif
+
+    /// <summary>Check if the path template contains a Catch-All path parameter.
+    /// <para>It means that the path template ends with a placeholder and no other placeholders are present in the path template, without a question mark (query parameters).</para>
     /// </summary>
     /// <param name="template">The path template.</param>
-    /// <returns>True if it matches.</returns>
-    private static bool IsCatchAllPath(string template)
-    {
-        Regex catchAllPathRegex = new(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
-        return catchAllPathRegex.IsMatch(template) && !template.Contains('?');
-    }
-    
-    /// <summary>
-    /// Checks if the query should be skipped.
-    /// It should be skipped if it is not present in the path template.
+    /// <returns><see langword="true"/> if it matches.</returns>
+    private static bool IsCatchAllPath(string template) => RegexCatchAllPath().IsMatch(template) && !template.Contains('?');
+
+    /// <summary>Checks if the query should be skipped.
+    /// <para>It should be skipped if it is not present in the path template.</para>
     /// </summary>
     /// <param name="query">The query string.</param>
     /// <param name="template">The path template.</param>
-    /// <returns>True if query should be skipped.</returns>
+    /// <returns><see langword="true"/> if query should be skipped.</returns>
     private static bool ShouldSkipQuery(string query, string template) => !string.IsNullOrEmpty(query) && !template.Contains('?');
 
-    /// <summary>
-    /// Escapes all characters except braces, eg { and }.
-    /// </summary>
+    /// <summary>Escapes all characters except braces, eg { and }.</summary>
     /// <param name="input">The input string.</param>
-    /// <returns>The formatted string.</returns>
+    /// <returns>The formatted <see cref="string"/>.</returns>
     private static string EscapeExceptBraces(string input)
     {
-        StringBuilder escaped = new();
-        ReadOnlySpan<char> span = input.AsSpan();
- 
-        foreach (char c in span)
+        if (string.IsNullOrEmpty(input))
         {
-            if (c is LeftCurlyBracket or RightCurlyBracket)
+            return string.Empty;
+        }
+
+        StringBuilder escaped = new();
+        foreach (char c in input.AsSpan())
+        {
+            if (c is LeftBrace or RightBrace)
             {
                 escaped.Append(c);
             }

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -118,19 +118,15 @@ public class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndValueFind
     /// <returns>The formatted string.</returns>
     private static string EscapeExceptBraces(string input)
     {
-        StringBuilder escaped = new ();
-        foreach (char c in input)
+        StringBuilder escaped = new();
+        ReadOnlySpan<char> span = input.AsSpan();
+ 
+        foreach (char c in span)
         {
-            if (c.ToString() == PlaceHolderLeft || c.ToString() == PlaceHolderRight)
-            {
-                escaped.Append(c);
-            }
-            else
-            {
-                escaped.Append(Regex.Escape(c.ToString()));
-            }
+            string str = c.ToString();
+            escaped.Append(str is PlaceHolderLeft or PlaceHolderRight ? str : Regex.Escape(str));
         }
-        
+ 
         return escaped.ToString();
     }
 }

--- a/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
@@ -779,37 +779,18 @@ namespace Ocelot.AcceptanceTests.Routing
                 .BDDfy();
         }
 
-        [Fact]
-        public void should_return_response_200_with_placeholder_for_final_url_path()
+        [Theory]
+        [Trait("Feat", "89")]
+        [InlineData("/api/{finalUrlPath}", "/api/api1/{finalUrlPath}", "/api/api1/product/products/categories/", "/api/product/products/categories/")]
+        [InlineData("/api/{urlPath}", "/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "/api/products/1")]
+        public void Should_return_response_200_with_placeholder_for_final_url_path2(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL, string downstreamPath)
         {
             var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/{urlPath}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/myApp1Name/api/{urlPath}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/products/1", HttpStatusCode.OK, "Some Product"))
+            var configuration = GivenDefaultConfiguration(port, upstreamPathTemplate, downstreamPathTemplate);
+            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", downstreamPath, HttpStatusCode.OK, "Some Product"))
                 .And(x => _steps.GivenThereIsAConfiguration(configuration))
                 .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/myApp1Name/api/products/1"))
+                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL))
                 .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
                 .And(x => _steps.ThenTheResponseBodyShouldBe("Some Product"))
                 .BDDfy();

--- a/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
@@ -1,1218 +1,596 @@
 using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration.File;
+using Ocelot.LoadBalancer.LoadBalancers;
 using System.Web;
 
-namespace Ocelot.AcceptanceTests.Routing
+namespace Ocelot.AcceptanceTests.Routing;
+
+public sealed class RoutingTests : Steps, IDisposable
 {
-    public sealed class RoutingTests : IDisposable
+    private readonly ServiceHandler _serviceHandler;
+    private string _downstreamPath;
+    private string _downstreamQuery;
+
+    public RoutingTests()
     {
-        private readonly Steps _steps;
-        private readonly ServiceHandler _serviceHandler;
-        private string _downstreamPath;
-        private string _downstreamQuery;
-
-        public RoutingTests()
-        {
-            _serviceHandler = new ServiceHandler();
-            _steps = new Steps();
-        }
-
-        public void Dispose()
-        {
-            _serviceHandler.Dispose();
-            _steps.Dispose();
-        }
-
-        [Fact]
-        public void should_not_match_forward_slash_in_pattern_before_next_forward_slash()
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/v{apiVersion}/cards",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/api/v{apiVersion}/cards",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            Priority = 1,
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/api/v1/aaaaaaaaa/cards", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/api/v1/aaaaaaaaa/cards"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_404_when_no_configuration_at_all()
-        {
-            this.Given(x => _steps.GivenThereIsAConfiguration(new FileConfiguration()))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_forward_slash_and_placeholder_only()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{url}",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_favouring_forward_slash_with_path_route()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{url}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 50810,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/test", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/test"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_favouring_forward_slash()
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{url}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 51880,
-                                },
-                            },
-                            UpstreamPathTemplate = "/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_favouring_forward_slash_route_because_it_is_first()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{url}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 51879,
-                                },
-                            },
-                            UpstreamPathTemplate = "/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_nothing_and_placeholder_only()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{url}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(string.Empty))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_simple_url()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        [Trait("Bug", "134")]
-        public void should_fix_issue_134()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                {
-                    new()
-                    {
-                        DownstreamPathTemplate = "/api/v1/vacancy",
-                        DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "localhost",
-                                Port = port,
-                            },
-                        },
-                        UpstreamPathTemplate = "/vacancy/",
-                        UpstreamHttpMethod = new List<string> { "Options",  "Put", "Get", "Post", "Delete" },
-                        LoadBalancerOptions = new FileLoadBalancerOptions { Type = "LeastConnection" },
-                    },
-                    new()
-                    {
-                        DownstreamPathTemplate = "/api/v1/vacancy/{vacancyId}",
-                        DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "localhost",
-                                Port = port,
-                            },
-                        },
-                        UpstreamPathTemplate = "/vacancy/{vacancyId}",
-                        UpstreamHttpMethod = new List<string> { "Options",  "Put", "Get", "Post", "Delete" },
-                        LoadBalancerOptions = new FileLoadBalancerOptions { Type = "LeastConnection" },
-                    },
-                },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/v1/vacancy/1", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/vacancy/1"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_when_path_missing_forward_slash_as_first_char()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/products",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/products", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_when_host_has_trailing_slash()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/products",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/products", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Theory]
-        [InlineData("/products")]
-        [InlineData("/products/")]
-        public void should_return_ok_when_upstream_url_ends_with_forward_slash_but_template_does_not(string url)
-        {
-            var port = PortFinder.GetRandomPort();
-            var downstreamBasePath = "/products";
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = downstreamBasePath,
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = downstreamBasePath+"/",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", downstreamBasePath, HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(url))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "649")]
-        [InlineData("/account/authenticate")]
-        [InlineData("/account/authenticate/")]
-        public void should_fix_issue_649(string url)
-        {
-            var port = PortFinder.GetRandomPort();
-            var baseUrl = $"http://localhost:{port}";
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                {
-                    new()
-                    {
-                        UpstreamPathTemplate = "/account/authenticate/",
-
-                        DownstreamPathTemplate = "/authenticate",
-                        DownstreamScheme = Uri.UriSchemeHttp,
-                        DownstreamHostAndPorts = new()
-                        {
-                            new("localhost", port),
-                        },
-                    },
-                },
-                GlobalConfiguration =
-                {
-                    BaseUrl = baseUrl,
-                },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn(baseUrl, "/authenticate", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(url))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_not_found_when_upstream_url_ends_with_forward_slash_but_template_does_not()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/products",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/products",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/products", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/products/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
-                .BDDfy();
-        }
-
-        [Theory]
-        [InlineData("/products/{productId}", "/products/{productId}", "/products/")]
-
-        public void should_return_response_200_with_empty_placeholder(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL)
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                {
-                    new()
-                    {
-                        DownstreamPathTemplate = downstreamPathTemplate,
-                        DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new("localhost", port),
-                        },
-                        UpstreamPathTemplate = upstreamPathTemplate,
-                        UpstreamHttpMethod = new List<string> { "Get" },
-                    },
-                },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", requestURL, HttpStatusCode.OK, "Hello from Aly"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Aly"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_complex_url()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/products/1", HttpStatusCode.OK, "Some Product"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/products/1"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Some Product"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_complex_url_that_starts_with_placeholder()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/{variantId}/products/{productId}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/{variantId}/products/{productId}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/23/products/1", HttpStatusCode.OK, "Some Product"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("23/products/1"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Some Product"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_not_add_trailing_slash_to_downstream_url()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/products/{productId}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/products/{productId}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/products/1", HttpStatusCode.OK, "Some Product"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/products/1"))
-                .Then(x => ThenTheDownstreamUrlPathShouldBe("/api/products/1"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_201_with_simple_url()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Post" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.Created, string.Empty))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .And(x => _steps.GivenThePostHasContent("postContent"))
-                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.Created))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_201_with_complex_query_string()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/newThing",
-                            UpstreamPathTemplate = "/newThing",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/newThing", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/newThing?DeviceType=IphoneApp&Browser=moonpigIphone&BrowserString=-&CountryCode=123&DeviceName=iPhone 5 (GSM+CDMA)&OperatingSystem=iPhone OS 7.1.2&BrowserVersion=3708AdHoc&ipAddress=-"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Feat", "89")]
-        [InlineData("/api/{finalUrlPath}", "/api/api1/{finalUrlPath}", "/api/api1/product/products/categories/", "/api/product/products/categories/")]
-        [InlineData("/api/{urlPath}", "/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "/api/products/1")]
-        public void Should_return_response_200_with_placeholder_for_final_url_path2(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL, string downstreamPath)
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = GivenDefaultConfiguration(port, upstreamPathTemplate, downstreamPathTemplate);
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", downstreamPath, HttpStatusCode.OK, "Some Product"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Some Product"))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "748")]
-        [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test/1", "/downstream/test/1", "?p1=v1&p2=v2&something-else")]
-        [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test/", "/downstream/test/", "?p1=v1&p2=v2&something-else")]
-        [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test", "/downstream/test", "?p1=v1&p2=v2&something-else")]
-        [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test123", null, null)]
-        [InlineData("/downstream/{version}/test/{everything}", "/upstream/{version}/test/{everything}", "/upstream/v1/test/123", "/downstream/v1/test/123", "?p1=v1&p2=v2&something-else")]
-        [InlineData("/downstream/{version}/test", "/upstream/{version}/test", "/upstream/v1/test", "/downstream/v1/test", "?p1=v1&p2=v2&something-else")]
-        [InlineData("/downstream/{version}/test", "/upstream/{version}/test", "/upstream/test", null, null)]
-        public void should_return_correct_downstream_when_omitting_ending_placeholder(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL, string downstreamURL, string queryString)
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = GivenDefaultConfiguration(port, upstreamPathTemplate, downstreamPathTemplate);
-            this.Given(x => GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.OK, "Hello from Aly"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL))
-                .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamURL))
-
-                // Now check the same URL but with query string
-                // Catch-All placeholder should forward any path + query string combinations to the downstream service
-                // More: https://ocelot.readthedocs.io/en/latest/features/routing.html#placeholders:~:text=This%20will%20forward%20any%20path%20%2B%20query%20string%20combinations%20to%20the%20downstream%20service%20after%20the%20path%20%2Fapi.
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL + queryString))
-                .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamURL))
-                .And(x => x.ThenTheDownstreamUrlQueryStringShouldBe(queryString))
-                .BDDfy();
-        }
-
-        [Trait("PR", "1911")]
-        [Trait("Link", "https://ocelot.readthedocs.io/en/latest/features/routing.html#catch-all-query-string")]
-        [Theory(DisplayName = "Catch All Query String should be forwarded with all query string parameters with(out) last slash")]
-        [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts", "/apipath/contracts", "")]
-        [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?", "/apipath/contracts", "")]
-        [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?p1=v1&p2=v2", "/apipath/contracts", "?p1=v1&p2=v2")]
-        [InlineData("/apipath/contracts/?{everything}", "/contracts/?{everything}", "/contracts/?", "/apipath/contracts/", "")]
-        [InlineData("/apipath/contracts/?{everything}", "/contracts/?{everything}", "/contracts/?p3=v3&p4=v4", "/apipath/contracts/", "?p3=v3&p4=v4")]
-        [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?filter=(-something+123+else)", "/apipath/contracts", "?filter=(-something%20123%20else)")]
-        public void Should_forward_Catch_All_query_string_when_last_slash(string downstream, string upstream, string requestURL, string downstreamPath, string queryString)
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = GivenDefaultConfiguration(port, upstream, downstream);
-            this.Given(x => GivenThereIsAServiceRunningOn($"http://localhost:{port}", downstreamPath, HttpStatusCode.OK, "Hello from Raman"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway(requestURL))
-                .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamPath)) // !
-                .And(x => x.ThenTheDownstreamUrlQueryStringShouldBe(queryString)) // !!
-                .And(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Raman"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_201_with_simple_url_and_multiple_upstream_http_method()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string> { "Get", "Post" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.Created, nameof(HttpStatusCode.Created)))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .And(x => _steps.GivenThePostHasContent("postContent"))
-                .When(x => _steps.WhenIPostUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.Created))
-                .And(x => _steps.ThenTheResponseBodyShouldBe(nameof(HttpStatusCode.Created)))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_response_200_with_simple_url_and_any_upstream_http_method()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/",
-                            UpstreamHttpMethod = new List<string>(),
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_return_404_when_calling_upstream_route_with_no_matching_downstream_re_route_github_issue_134()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                {
-                    new()
-                    {
-                        DownstreamPathTemplate = "/api/v1/vacancy",
-                        DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "localhost",
-                                Port = port,
-                            },
-                        },
-                        UpstreamPathTemplate = "/vacancy/",
-                        UpstreamHttpMethod = new List<string> { "Options",  "Put", "Get", "Post", "Delete" },
-                        LoadBalancerOptions = new FileLoadBalancerOptions { Type = "LeastConnection" },
-                    },
-                    new()
-                    {
-                        DownstreamPathTemplate = "/api/v1/vacancy/{vacancyId}",
-                        DownstreamScheme = "http",
-                        DownstreamHostAndPorts = new List<FileHostAndPort>
-                        {
-                            new()
-                            {
-                                Host = "localhost",
-                                Port = port,
-                            },
-                        },
-                        UpstreamPathTemplate = "/vacancy/{vacancyId}",
-                        UpstreamHttpMethod = new List<string> { "Options",  "Put", "Get", "Post", "Delete" },
-                        LoadBalancerOptions = new FileLoadBalancerOptions { Type = "LeastConnection" },
-                    },
-                },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/v1/vacancy/1", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("api/vacancy/1"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_not_set_trailing_slash_on_url_template()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/{url}",
-                            DownstreamScheme = "http",
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                            UpstreamPathTemplate = "/platform/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", "/api/swagger/lib/backbone-min.js", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/platform/swagger/lib/backbone-min.js"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .And(x => ThenTheDownstreamUrlPathShouldBe("/api/swagger/lib/backbone-min.js"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_use_priority()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/goods/{url}",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/goods/{url}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 53879,
-                                },
-                            },
-                            Priority = 0,
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/goods/delete",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/goods/delete",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/goods/delete", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/goods/delete"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_match_multiple_paths_with_catch_all()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/{everything}",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/{everything}",
-                            UpstreamHttpMethod = new List<string> { "Get" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/test/toot", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/test/toot"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_fix_issue_271()
-        {
-            var port = PortFinder.GetRandomPort();
-
-            var configuration = new FileConfiguration
-            {
-                Routes = new List<FileRoute>
-                    {
-                        new()
-                        {
-                            DownstreamPathTemplate = "/api/v1/{everything}",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/api/v1/{everything}",
-                            UpstreamHttpMethod = new List<string> { "Get", "Put", "Post" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = port,
-                                },
-                            },
-                        },
-                        new()
-                        {
-                            DownstreamPathTemplate = "/connect/token",
-                            DownstreamScheme = "http",
-                            UpstreamPathTemplate = "/connect/token",
-                            UpstreamHttpMethod = new List<string> { "Post" },
-                            DownstreamHostAndPorts = new List<FileHostAndPort>
-                            {
-                                new()
-                                {
-                                    Host = "localhost",
-                                    Port = 5001,
-                                },
-                            },
-                        },
-                    },
-            };
-
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}/", "/api/v1/modules/Test", HttpStatusCode.OK, "Hello from Laura"))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway("/api/v1/modules/Test"))
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => _steps.ThenTheResponseBodyShouldBe("Hello from Laura"))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "2116")]
-        [InlineData("debug()")] // no query
-        [InlineData("debug%28%29")] // debug()
-        public void Should_change_downstream_path_by_upstream_path_when_path_contains_malicious_characters(string path)
-        {
-            var port = PortFinder.GetRandomPort();
-            var configuration = GivenDefaultConfiguration(port, "/api/{path}", "/routed/api/{path}");
-            var decodedDownstreamUrlPath = $"/routed/api/{HttpUtility.UrlDecode(path)}";
-            this.Given(x => x.GivenThereIsAServiceRunningOn($"http://localhost:{port}", decodedDownstreamUrlPath, HttpStatusCode.OK, string.Empty))
-                .And(x => _steps.GivenThereIsAConfiguration(configuration))
-                .And(x => _steps.GivenOcelotIsRunning())
-                .When(x => _steps.WhenIGetUrlOnTheApiGateway($"/api/{path}")) // should be encoded
-                .Then(x => _steps.ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-                .And(x => ThenTheDownstreamUrlPathShouldBe(decodedDownstreamUrlPath))
-                .BDDfy();
-        }
-
-        private void GivenThereIsAServiceRunningOn(string baseUrl, string basePath, HttpStatusCode statusCode, string responseBody)
-        {
-            _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, async context =>
-            {
-                _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value) ? context.Request.PathBase.Value + context.Request.Path.Value : context.Request.Path.Value;
-                _downstreamQuery = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : string.Empty;
-
-                if (_downstreamPath != basePath)
-                {
-                    context.Response.StatusCode = (int)HttpStatusCode.NotFound;
-                    await context.Response.WriteAsync("Downstream path didn't match base path");
-                }
-                else
-                {
-                    context.Response.StatusCode = (int)statusCode;
-                    await context.Response.WriteAsync(responseBody);
-                }
-            });
-        }
-
-        internal void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
-        {
-            _downstreamPath.ShouldBe(expectedDownstreamPath);
-        }
-
-        internal void ThenTheDownstreamUrlQueryStringShouldBe(string expectedQueryString)
-        {
-            _downstreamQuery.ShouldBe(expectedQueryString);
-        }
-
-        private FileConfiguration GivenDefaultConfiguration(int port, string upstream, string downstream) => new()
-        {
-            Routes = new()
-            {
-                new()
-                {
-                    DownstreamPathTemplate = downstream,
-                    DownstreamScheme = Uri.UriSchemeHttp,
-                    DownstreamHostAndPorts =
-                    {
-                        new("localhost", port),
-                    },
-                    UpstreamPathTemplate = upstream,
-                    UpstreamHttpMethod = new() { HttpMethods.Get },
-                },
-            },
-        };
+        _serviceHandler = new ServiceHandler();
     }
+
+    public override void Dispose()
+    {
+        _serviceHandler.Dispose();
+        base.Dispose();
+    }
+
+    [Fact]
+    public void Should_not_match_forward_slash_in_pattern_before_next_forward_slash()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/api/v{apiVersion}/cards", "/api/v{apiVersion}/cards")
+            .SetPriority(1);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/v1/aaaaaaaaa/cards", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/api/v1/aaaaaaaaa/cards"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_404_when_no_configuration_at_all()
+    {
+        this.Given(x => GivenThereIsAConfiguration(new()))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_with_forward_slash_and_placeholder_only()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/{url}", "/{url}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_favouring_forward_slash_with_path_route()
+    {
+        var port1 = PortFinder.GetRandomPort();
+        var port2 = PortFinder.GetRandomPort();
+        var route1 = GivenRoute(port1, "/{url}", "/{url}");
+        var route2 = GivenRoute(port2, "/", "/");
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port1, "/test", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/test"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_favouring_forward_slash()
+    {
+        var port1 = PortFinder.GetRandomPort();
+        var port2 = PortFinder.GetRandomPort();
+        var route1 = GivenRoute(port1, "/{url}", "/{url}");
+        var route2 = GivenRoute(port2, "/", "/");
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port2, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_favouring_forward_slash_route_because_it_is_first()
+    {
+        var port1 = PortFinder.GetRandomPort();
+        var port2 = PortFinder.GetRandomPort();
+        var route1 = GivenRoute(port1, "/", "/");
+        var route2 = GivenRoute(port2, "/{url}", "/{url}");
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port1, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_with_nothing_and_placeholder_only()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/{url}", "/{url}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(string.Empty))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_with_simple_url()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Bug", "134")]
+    public void Should_fix_issue_134()
+    {
+        var port = PortFinder.GetRandomPort(); //var port2 = PortFinder.GetRandomPort();
+        var methods = new string[] { HttpMethods.Options, HttpMethods.Put, HttpMethods.Get, HttpMethods.Post, HttpMethods.Delete };
+        var route1 = GivenRoute(port, "/vacancy/", "/api/v1/vacancy")
+            .WithMethods(methods);
+        var route2 = GivenRoute(port, "/vacancy/{vacancyId}", "/api/v1/vacancy/{vacancyId}")
+            .WithMethods(methods);
+        route1.LoadBalancerOptions.Type = route2.LoadBalancerOptions.Type = nameof(LeastConnection);
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/v1/vacancy/1", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/vacancy/1"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_when_path_missing_forward_slash_as_first_char()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/api/products");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/products", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_when_host_has_trailing_slash()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/api/products");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/products", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Theory]
+    [InlineData("/products")]
+    [InlineData("/products/")]
+    public void Should_return_ok_when_upstream_url_ends_with_forward_slash_but_template_does_not(string url)
+    {
+        const string downstreamBasePath = "/products";
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, $"{downstreamBasePath}/", downstreamBasePath);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, downstreamBasePath, HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(url))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Theory]
+    [Trait("Bug", "649")]
+    [InlineData("/account/authenticate")]
+    [InlineData("/account/authenticate/")]
+    public void Should_fix_issue_649(string url)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/account/authenticate/", "/authenticate");
+        var configuration = GivenConfiguration(route);
+        configuration.GlobalConfiguration.BaseUrl = DownstreamUrl(port);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/authenticate", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(url))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_not_found_when_upstream_url_ends_with_forward_slash_but_template_does_not()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/products", "/products");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/products", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/products/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
+            .BDDfy();
+    }
+
+    [Theory]
+    [Trait("Bug", "683")]
+    [InlineData("/products/{productId}", "/products/{productId}", "/products/")]
+    public void Should_return_response_200_with_empty_placeholder(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, upstreamPathTemplate, downstreamPathTemplate);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, requestURL, HttpStatusCode.OK, "Hello from Aly"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(requestURL))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Aly"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_with_complex_url()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/products/{productId}", "/api/products/{productId}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/products/1", HttpStatusCode.OK, "Some Product"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/products/1"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Some Product"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_200_with_complex_url_that_starts_with_placeholder()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/{variantId}/products/{productId}", "/api/{variantId}/products/{productId}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/23/products/1", HttpStatusCode.OK, "Some Product"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("23/products/1"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Some Product"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_not_add_trailing_slash_to_downstream_url()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/products/{productId}", "/api/products/{productId}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => GivenThereIsAServiceRunningOn(port, "/api/products/1", HttpStatusCode.OK, "Some Product"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/products/1"))
+            .Then(x => ThenTheDownstreamUrlPathShouldBe("/api/products/1"))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_201_with_simple_url()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/").WithMethods(HttpMethods.Post);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.Created, string.Empty))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .And(x => GivenThePostHasContent("postContent"))
+            .When(x => WhenIPostUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Created))
+            .BDDfy();
+    }
+
+    [Fact]
+    public void Should_return_response_201_with_complex_query_string()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/newThing", "/newThing");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/newThing", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/newThing?DeviceType=IphoneApp&Browser=moonpigIphone&BrowserString=-&CountryCode=123&DeviceName=iPhone 5 (GSM+CDMA)&OperatingSystem=iPhone OS 7.1.2&BrowserVersion=3708AdHoc&ipAddress=-"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Theory]
+    [Trait("Feat", "89")]
+    [InlineData("/api/{finalUrlPath}", "/api/api1/{finalUrlPath}", "/api/api1/product/products/categories/", "/api/product/products/categories/")]
+    [InlineData("/api/{urlPath}", "/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "/api/products/1")]
+    public void Should_return_response_200_with_placeholder_for_final_url_path2(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL, string downstreamPath)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, upstreamPathTemplate, downstreamPathTemplate);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, downstreamPath, HttpStatusCode.OK, "Some Product"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(requestURL))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Some Product"))
+            .BDDfy();
+    }
+
+    [Theory]
+    [Trait("Bug", "748")]
+    [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test/1", "/downstream/test/1", "?p1=v1&p2=v2&something-else")]
+    [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test/", "/downstream/test/", "?p1=v1&p2=v2&something-else")]
+    [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test", "/downstream/test", "?p1=v1&p2=v2&something-else")]
+    [InlineData("/downstream/test/{everything}", "/upstream/test/{everything}", "/upstream/test123", null, null)]
+    [InlineData("/downstream/{version}/test/{everything}", "/upstream/{version}/test/{everything}", "/upstream/v1/test/123", "/downstream/v1/test/123", "?p1=v1&p2=v2&something-else")]
+    [InlineData("/downstream/{version}/test", "/upstream/{version}/test", "/upstream/v1/test", "/downstream/v1/test", "?p1=v1&p2=v2&something-else")]
+    [InlineData("/downstream/{version}/test", "/upstream/{version}/test", "/upstream/test", null, null)]
+    public void Should_return_correct_downstream_when_omitting_ending_placeholder(string downstreamPathTemplate, string upstreamPathTemplate, string requestURL, string downstreamURL, string queryString)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, upstreamPathTemplate, downstreamPathTemplate);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.OK, "Hello from Aly"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(requestURL))
+            .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamURL))
+
+            // Now check the same URL but with query string
+            // Catch-All placeholder should forward any path + query string combinations to the downstream service
+            // More: https://ocelot.readthedocs.io/en/latest/features/routing.html#placeholders:~:text=This%20will%20forward%20any%20path%20%2B%20query%20string%20combinations%20to%20the%20downstream%20service%20after%20the%20path%20%2Fapi.
+            .When(x => WhenIGetUrlOnTheApiGateway(requestURL + queryString))
+            .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamURL))
+            .And(x => ThenTheDownstreamUrlQueryStringShouldBe(queryString))
+            .BDDfy();
+    }
+
+    [Trait("PR", "1911")]
+    [Trait("Link", "https://ocelot.readthedocs.io/en/latest/features/routing.html#catch-all-query-string")]
+    [Theory(DisplayName = "Catch All Query String should be forwarded with all query string parameters with(out) last slash")]
+    [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts", "/apipath/contracts", "")]
+    [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?", "/apipath/contracts", "")]
+    [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?p1=v1&p2=v2", "/apipath/contracts", "?p1=v1&p2=v2")]
+    [InlineData("/apipath/contracts/?{everything}", "/contracts/?{everything}", "/contracts/?", "/apipath/contracts/", "")]
+    [InlineData("/apipath/contracts/?{everything}", "/contracts/?{everything}", "/contracts/?p3=v3&p4=v4", "/apipath/contracts/", "?p3=v3&p4=v4")]
+    [InlineData("/apipath/contracts?{everything}", "/contracts?{everything}", "/contracts?filter=(-something+123+else)", "/apipath/contracts", "?filter=(-something%20123%20else)")]
+    public void Should_forward_Catch_All_query_string_when_last_slash(string downstream, string upstream, string requestURL, string downstreamPath, string queryString)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, upstream, downstream);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => GivenThereIsAServiceRunningOn(port, downstreamPath, HttpStatusCode.OK, "Hello from Raman"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(requestURL))
+            .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamPath)) // !
+            .And(x => ThenTheDownstreamUrlQueryStringShouldBe(queryString)) // !!
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Raman"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Feat", "91, 94")]
+    public void Should_return_response_201_with_simple_url_and_multiple_upstream_http_method()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/").WithMethods(HttpMethods.Get, HttpMethods.Post);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.Created, nameof(HttpStatusCode.Created)))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .And(x => GivenThePostHasContent("postContent"))
+            .When(x => WhenIPostUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.Created))
+            .And(x => ThenTheResponseBodyShouldBe(nameof(HttpStatusCode.Created)))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Feat", "91, 94")]
+    public void Should_return_response_200_with_simple_url_and_any_upstream_http_method()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/", "/").WithMethods();
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Bug", "134")]
+    public void Should_return_404_when_calling_upstream_route_with_no_matching_downstream_route()
+    {
+        var port = PortFinder.GetRandomPort();
+        var methods = new string[] { HttpMethods.Options, HttpMethods.Put, HttpMethods.Get, HttpMethods.Post, HttpMethods.Delete };
+        var route1 = GivenRoute(port, "/vacancy/", "/api/v1/vacancy").WithMethods(methods);
+        var route2 = GivenRoute(port, "/vacancy/{vacancyId}", "/api/v1/vacancy/{vacancyId}").WithMethods(methods);
+        route1.LoadBalancerOptions.Type = route2.LoadBalancerOptions.Type = nameof(LeastConnection);
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/v1/vacancy/1", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("api/vacancy/1"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.NotFound))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Bug", "145")]
+    public void Should_not_set_trailing_slash_on_url_template()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/platform/{url}", "/api/{url}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/swagger/lib/backbone-min.js", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/platform/swagger/lib/backbone-min.js"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .And(x => ThenTheDownstreamUrlPathShouldBe("/api/swagger/lib/backbone-min.js"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Feat", "270, 272")]
+    public void Should_use_priority()
+    {
+        var port1 = PortFinder.GetRandomPort();
+        var port2 = PortFinder.GetRandomPort();
+        var route1 = GivenRoute(port1, "/goods/{url}", "/goods/{url}")
+            .SetPriority(0);
+        var route2 = GivenRoute(port2, "/goods/delete", "/goods/delete");
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port2, "/goods/delete", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/goods/delete"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Bug", "548")]
+    public void Should_match_multiple_paths_with_catch_all()
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/{everything}", "/{everything}");
+        var configuration = GivenConfiguration(route);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/test/toot", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/test/toot"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Fact]
+    [Trait("Bug", "271")]
+    public void Should_fix_issue_271()
+    {
+        var port = PortFinder.GetRandomPort();
+        var port2 = PortFinder.GetRandomPort();
+        var route1 = GivenRoute(port, "/api/v1/{everything}", "/api/v1/{everything}")
+            .WithMethods(HttpMethods.Get, HttpMethods.Put, HttpMethods.Post);
+        var route2 = GivenRoute(port2, "/connect/token", "/connect/token")
+            .WithMethods(HttpMethods.Post);
+        var configuration = GivenConfiguration(route1, route2);
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, "/api/v1/modules/Test", HttpStatusCode.OK, "Hello from Laura"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway("/api/v1/modules/Test"))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
+            .BDDfy();
+    }
+
+    [Theory]
+    [Trait("Bug", "2116")]
+    [InlineData("debug()")] // no query
+    [InlineData("debug%28%29")] // debug()
+    public void Should_change_downstream_path_by_upstream_path_when_path_contains_malicious_characters(string path)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/api/{path}", "/routed/api/{path}");
+        var configuration = GivenConfiguration(route);
+        var decodedDownstreamUrlPath = $"/routed/api/{HttpUtility.UrlDecode(path)}";
+        this.Given(x => x.GivenThereIsAServiceRunningOn(port, decodedDownstreamUrlPath, HttpStatusCode.OK, string.Empty))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway($"/api/{path}")) // should be encoded
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheDownstreamUrlPathShouldBe(decodedDownstreamUrlPath))
+            .BDDfy();
+    }
+
+    private void GivenThereIsAServiceRunningOn(int port, string basePath, HttpStatusCode statusCode, string responseBody)
+    {
+        var baseUrl = DownstreamUrl(port);
+        _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, HttpHandler);
+
+        async Task HttpHandler(HttpContext context)
+        {
+            _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value)
+                ? context.Request.PathBase.Value + context.Request.Path.Value
+                : context.Request.Path.Value;
+            _downstreamQuery = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : string.Empty;
+
+            if (_downstreamPath != basePath)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await context.Response.WriteAsync("Downstream path didn't match base path");
+            }
+            else
+            {
+                context.Response.StatusCode = (int)statusCode;
+                await context.Response.WriteAsync(responseBody);
+            }
+        }
+    }
+
+    private void ThenTheDownstreamUrlPathShouldBe(string expectedDownstreamPath)
+    {
+        _downstreamPath.ShouldBe(expectedDownstreamPath);
+    }
+
+    private void ThenTheDownstreamUrlQueryStringShouldBe(string expectedQueryString)
+    {
+        _downstreamQuery.ShouldBe(expectedQueryString);
+    }
+
+    private static FileRoute GivenRoute(int port, string upstream, string downstream) => new()
+    {
+        DownstreamPathTemplate = downstream,
+        DownstreamScheme = Uri.UriSchemeHttp,
+        DownstreamHostAndPorts = { Localhost(port) },
+        UpstreamPathTemplate = upstream,
+        UpstreamHttpMethod = new() { HttpMethods.Get },
+    };
 }

--- a/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
@@ -407,6 +407,41 @@ public sealed class RoutingTests : Steps, IDisposable
             .And(x => ThenTheResponseBodyShouldBe("Hello from Raman"))
             .BDDfy();
     }
+    
+    [Theory(DisplayName = "Should match complex queries with embedded placeholders.")]
+    [Trait("Bug", "2199")]
+    [Trait("Feat", "2200")]
+    [InlineData("/api/invoices/{url0}-{url1}-{url2}", "/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}", 
+        "/api/invoices_abc/def-ghi_abcd/xyz?urlId=bla", "/api/invoices/abc-def-ghi", "?urlId=bla")]
+    [InlineData("/api/products/{category}-{subcategory}/{filter}", "/api/products_{category}/{subcategory}_details/{itemId}?filter={filter}", 
+        "/api/products_electronics/computers_details/123?filter=active", "/api/products/electronics-computers/active", "")]
+    [InlineData("/api/users/{userId}/posts/{postId}/{lang}", "/api/users/{userId}/{postId}_content/{timestamp}?lang={lang}", 
+        "/api/users/101/2022_content/2024?lang=en", "/api/users/101/posts/2022/en", "")]
+    [InlineData("/api/categories/{cat}-{subcat}?sort={sort}", "/api/categories_{cat}/{subcat}_items/{itemId}?sort={sort}", 
+        "/api/categories_home/furniture_items/789?sort=asc", "/api/categories/home-furniture", "?sort=asc")]
+    [InlineData("/api/orders/{order}-{detail}?status={status}", "/api/orders_{order}/{detail}_invoice/{ref}?status={status}", 
+        "/api/orders_987/abc_invoice/123?status=shipped", "/api/orders/987-abc", "?status=shipped")]
+    [InlineData("/api/transactions/{type}-{region}", "/api/transactions_{type}/{region}_summary/{year}?q={query}", 
+        "/api/transactions_sales/NA_summary/2024?q=forecast", "/api/transactions/sales-NA", "?q=forecast")]
+    [InlineData("/api/resources/{resource}-{subresource}", "/api/resources_{resource}/{subresource}_data/{id}?key={apikey}", 
+        "/api/resources_images/photos_data/555?key=xyz123", "/api/resources/images-photos", "?key=xyz123")]
+    [InlineData("/api/accounts/{account}-{detail}", "/api/accounts_{account}/{detail}_info/{id}?opt={option}", 
+        "/api/accounts_admin/settings_info/101?opt=true", "/api/accounts/admin-settings", "?opt=true")]
+    public void ShouldMatchComplexQueriesWithEmbeddedPlaceholder(string downstream, string upstream, string requestUrl, string downstreamPath, string queryString)
+    {
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, upstream, downstream);
+        var configuration = GivenConfiguration(route);
+        this.Given(x => GivenThereIsAServiceRunningOn(port, downstreamPath, HttpStatusCode.OK, "Hello friends!"))
+            .And(x => GivenThereIsAConfiguration(configuration))
+            .And(x => GivenOcelotIsRunning())
+            .When(x => WhenIGetUrlOnTheApiGateway(requestUrl))
+            .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamPath))
+            .And(x => ThenTheDownstreamUrlQueryStringShouldBe(queryString))
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
+            .And(x => ThenTheResponseBodyShouldBe("Hello friends!"))
+            .BDDfy();
+    }
 
     [Fact]
     [Trait("Feat", "91, 94")]
@@ -549,6 +584,7 @@ public sealed class RoutingTests : Steps, IDisposable
             .And(x => ThenTheDownstreamUrlPathShouldBe(decodedDownstreamUrlPath))
             .BDDfy();
     }
+    
 
     private void GivenThereIsAServiceRunningOn(int port, string basePath, HttpStatusCode statusCode, string responseBody)
     {

--- a/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
+++ b/test/Ocelot.AcceptanceTests/Routing/RoutingTests.cs
@@ -408,7 +408,7 @@ public sealed class RoutingTests : Steps, IDisposable
             .BDDfy();
     }
     
-    [Theory(DisplayName = "Should match complex queries with embedded placeholders.")]
+    [Theory]
     [Trait("Bug", "2199")]
     [Trait("Feat", "2200")]
     [InlineData("/api/invoices/{url0}-{url1}-{url2}", "/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}", 
@@ -427,19 +427,19 @@ public sealed class RoutingTests : Steps, IDisposable
         "/api/resources_images/photos_data/555?key=xyz123", "/api/resources/images-photos", "?key=xyz123")]
     [InlineData("/api/accounts/{account}-{detail}", "/api/accounts_{account}/{detail}_info/{id}?opt={option}", 
         "/api/accounts_admin/settings_info/101?opt=true", "/api/accounts/admin-settings", "?opt=true")]
-    public void ShouldMatchComplexQueriesWithEmbeddedPlaceholder(string downstream, string upstream, string requestUrl, string downstreamPath, string queryString)
+    public void ShouldMatchComplexQueriesWithEmbeddedPlaceholders(string downstream, string upstream, string requestUrl, string downstreamPath, string queryString)
     {
         var port = PortFinder.GetRandomPort();
         var route = GivenRoute(port, upstream, downstream);
         var configuration = GivenConfiguration(route);
-        this.Given(x => GivenThereIsAServiceRunningOn(port, downstreamPath, HttpStatusCode.OK, "Hello friends!"))
+        this.Given(x => GivenThereIsAServiceRunningOn(port, downstreamPath, HttpStatusCode.OK, "Hello from Guillaume"))
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenIGetUrlOnTheApiGateway(requestUrl))
             .Then(x => ThenTheDownstreamUrlPathShouldBe(downstreamPath))
             .And(x => ThenTheDownstreamUrlQueryStringShouldBe(queryString))
             .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.OK))
-            .And(x => ThenTheResponseBodyShouldBe("Hello friends!"))
+            .And(x => ThenTheResponseBodyShouldBe("Hello from Guillaume"))
             .BDDfy();
     }
 
@@ -585,7 +585,6 @@ public sealed class RoutingTests : Steps, IDisposable
             .BDDfy();
     }
     
-
     private void GivenThereIsAServiceRunningOn(int port, string basePath, HttpStatusCode statusCode, string responseBody)
     {
         var baseUrl = DownstreamUrl(port);

--- a/test/Ocelot.Testing/FileRouteExtensions.cs
+++ b/test/Ocelot.Testing/FileRouteExtensions.cs
@@ -9,4 +9,16 @@ public static class FileRouteExtensions
         route.DownstreamHostAndPorts.AddRange(hosts);
         return route;
     }
+
+    public static FileRoute SetPriority(this FileRoute route, int priority)
+    {
+        route.Priority = priority;
+        return route;
+    }
+
+    public static FileRoute WithMethods(this FileRoute route, params string[] methods)
+    {
+        route.UpstreamHttpMethod.AddRange(methods);
+        return route;
+    }
 }

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
@@ -310,7 +310,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/categories/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
@@ -1,501 +1,374 @@
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Responses;
 
-namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
+namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher;
+
+public class UrlPathPlaceholderNameAndValueFinderTests : UnitTest
 {
-    public class UrlPathPlaceholderNameAndValueFinderTests : UnitTest
+    private readonly UrlPathPlaceholderNameAndValueFinder _finder;
+    private Response<List<PlaceholderNameAndValue>> _result;
+    private static readonly string Empty = string.Empty;
+
+    public UrlPathPlaceholderNameAndValueFinderTests()
     {
-        private readonly IPlaceholderNameAndValueFinder _finder;
-        private string _downstreamUrlPath;
-        private string _downstreamPathTemplate;
-        private Response<List<PlaceholderNameAndValue>> _result;
-        private string _query;
+        _finder = new UrlPathPlaceholderNameAndValueFinder();
+    }
 
-        public UrlPathPlaceholderNameAndValueFinderTests()
+    [Fact]
+    public void Can_match_down_stream_url()
+    {
+        // Arrange, Act
+        _result = _finder.Find(Empty, Empty, Empty);
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_nothing_then_placeholder_no_value_is_blank()
+    {
+        // Arrange, Act
+        _result = _finder.Find(Empty, Empty, "/{url}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{url}", Empty);
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_nothing_then_placeholder_value_is_test()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/test", Empty, "/{url}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{url}", "test");
+    }
+
+    [Fact]
+    public void Should_match_everything_in_path_with_query()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/test/toot", "?$filter=Name%20eq%20'Sam'", "/{everything}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{everything}", "test/toot");
+    }
+
+    [Fact]
+    public void Should_match_everything_in_path()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/test/toot", Empty, "/{everything}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{everything}", "test/toot");
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_forward_slash_then_placeholder_no_value_is_blank()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/", Empty, "/{url}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{url}", Empty);
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_forward_slash()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/", Empty, "/");
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_forward_slash_then_placeholder_then_another_value()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/1/products", Empty, "/{url}/products");
+
+        // Assert
+        ThenSinglePlaceholderIs("{url}", "1");
+    }
+
+    [Fact]
+    public void Should_not_find_anything()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products", Empty, "/products/");
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Should_find_query_string()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products", "?productId=1", "/products?productId={productId}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{productId}", "1");
+    }
+
+    [Fact]
+    public void Should_find_query_string_dont_include_hardcoded()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products", "?productId=1&categoryId=2", "/products?productId={productId}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{productId}", "1");
+    }
+
+    [Fact]
+    public void Should_find_multiple_query_string()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products", "?productId=1&categoryId=2", "/products?productId={productId}&categoryId={categoryId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"));
+    }
+
+    [Fact]
+    public void Should_find_multiple_query_string_and_path()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products/3", "?productId=1&categoryId=2", "/products/{account}?productId={productId}&categoryId={categoryId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"),
+            new("{account}", "3"));
+    }
+
+    [Fact]
+    public void Should_find_multiple_query_string_and_path_that_ends_with_slash()
+    {
+        // Arrange, Act
+        _result = _finder.Find("/products/3/", "?productId=1&categoryId=2", "/products/{account}/?productId={productId}&categoryId={categoryId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"),
+            new("{account}", "3"));
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_no_slash()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api", Empty, "api");
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_one_slash()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/", Empty, "api/");
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/", Empty, "api/product/products/");
+
+        // Assert
+        ThenTheTemplatesVariablesAre();
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template_with_one_place_holder()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/1", Empty, "api/product/products/{productId}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{productId}", "1");
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template_with_two_place_holders()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/1/2", Empty, "api/product/products/{productId}/{categoryId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"));
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template_with_two_place_holders_seperated_by_something()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/1/categories/2", Empty, "api/product/products/{productId}/categories/{categoryId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"));
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template_with_three_place_holders_seperated_by_something()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/1/categories/2/variant/123", Empty, "api/product/products/{productId}/categories/{categoryId}/variant/{variantId}");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"),
+            new("{variantId}", "123"));
+    }
+
+    [Fact]
+    public void Can_match_down_stream_url_with_downstream_template_with_three_place_holders()
+    {
+        // Arrange, Act
+        _result = _finder.Find("api/product/products/1/categories/2/variant/", Empty, "api/product/products/{productId}/categories/{categoryId}/variant/");
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new("{productId}", "1"),
+            new("{categoryId}", "2"));
+    }
+
+    [Theory]
+    [Trait("Feat", "89")]
+    [InlineData("/api/{finalUrlPath}", "/api/product/products/categories/", "{finalUrlPath}", "product/products/categories/")]
+    [InlineData("/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "{urlPath}", "products/1")]
+    public void Can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path(string template, string path, string placeholderName, string placeholderValue)
+    {
+        // Arrange, Act
+        _result = _finder.Find(path, Empty, template);
+
+        // Assert
+        ThenSinglePlaceholderIs(placeholderName, placeholderValue);
+    }
+
+    [Fact]
+    [Trait("Bug", "748")]
+    public void Check_for_placeholder_at_end_of_template() 
+    {
+        // Arrange, Act
+        _result = _finder.Find("/upstream/test/", Empty, "/upstream/test/{testId}");
+
+        // Assert
+        ThenSinglePlaceholderIs("{testId}", Empty);
+    }
+
+    [Theory]
+    [Trait("Bug", "748")]
+    [InlineData("/api/invoices/{url}", "/api/invoices/123", "{url}", "123")]
+    [InlineData("/api/invoices/{url}", "/api/invoices/", "{url}", "")]
+    [InlineData("/api/invoices/{url}", "/api/invoices", "{url}", "")]
+    [InlineData("/api/{version}/invoices/", "/api/v1/invoices/", "{version}", "v1")]
+    public void Should_fix_issue_748(string template, string path, string placeholderName, string placeholderValue)
+    {
+        // Arrange, Act
+        _result = _finder.Find(path, Empty, template);
+
+        // Assert
+        ThenSinglePlaceholderIs(placeholderName, placeholderValue);
+    }
+
+    [Theory]
+    [Trait("Bug", "748")]
+    [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/123", "{version}", "v1", "{url}", "123")]
+    [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/", "{version}", "v1", "{url}", "")]
+    [InlineData("/api/invoices/{url}?{query}", "/api/invoices/test?query=1", "{url}", "test", "{query}", "query=1")]
+    [InlineData("/api/invoices/{url}?{query}", "/api/invoices/?query=1", "{url}", "", "{query}", "query=1")]
+    public void Should_resolve_catchall_at_end_with_middle_placeholder(string template, string path, string placeholderName, string placeholderValue, string catchallName, string catchallValue)
+    {
+        // Arrange, Act
+        _result = _finder.Find(path, Empty, template);
+
+        // Assert
+        ThenTheTemplatesVariablesAre(
+            new(placeholderName, placeholderValue),
+            new(catchallName, catchallValue));
+    }
+
+    [Theory]
+    [Trait("Bug", "2199")]
+    [InlineData("/api/invoices/{url}-abcd", "/api/invoices/123-abcd", "{url}", "123")]
+    [InlineData("/api/invoices/{url1}-{url2}_abcd", "/api/invoices/123-456_abcd", "{url1}", "123")]
+    public void Can_match_between_slashes(string template, string path, string placeholderName, string placeholderValue)
+    {
+        // Arrange, Act
+        _result = _finder.Find(path, Empty, template);
+
+        // Assert
+        ThenSinglePlaceholderIs(placeholderName, placeholderValue);
+    }
+
+    [Theory]
+    [Trait("Bug", "2199")]
+    [Trait("Feat", "2200")]
+    [InlineData("/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}", "/api/invoices_super/123-456_abcd/789?urlId=987",
+        "{url0}", "super", "{url1}", "123", "{url2}", "456", "{url3}", "789", "{url4}", "987")]
+    [InlineData("/api/users/{userId}/posts/{postId}_abcd/{timestamp}?filter={filter}", "/api/users/101/posts/2022_abcd/2024?filter=active",
+        "{userId}", "101", "{postId}", "2022", "{timestamp}", "2024", "{filter}", "active")]
+    [InlineData("/api/categories/{categoryId}/{subCategoryId}_abcd/{itemId}?sort={sortBy}", "/api/categories/1/2_abcd/5?sort=desc",
+        "{categoryId}", "1", "{subCategoryId}", "2", "{itemId}", "5", "{sortBy}", "desc")]
+    [InlineData("/api/products/{productId}/{category}_{itemId}_details/{status}", "/api/products/789/electronics_123_details/available",
+        "{productId}", "789", "{category}", "electronics", "{itemId}", "123", "{status}", "available")]
+    public void Can_match_all_placeholders_between_slashes(string template, string path,
+        string placeholderName1, string placeholderValue1, string placeholderName2, string placeholderValue2,
+        string placeholderName3, string placeholderValue3, string placeholderName4, string placeholderValue4,
+        string placeholderName5 = null, string placeholderValue5 = null)
+    {
+        // Arrange
+        var expectedTemplates = new List<PlaceholderNameAndValue>
         {
-            _finder = new UrlPathPlaceholderNameAndValueFinder();
+            new(placeholderName1, placeholderValue1),
+            new(placeholderName2, placeholderValue2),
+            new(placeholderName3, placeholderValue3),
+            new(placeholderName4, placeholderValue4),
+        };
+
+        // Add optional placeholders if they exist
+        if (!string.IsNullOrEmpty(placeholderName5))
+        {
+            expectedTemplates.Add(new(placeholderName5, placeholderValue5));
         }
 
-        [Fact]
-        public void can_match_down_stream_url()
+        // Act
+        _result = _finder.Find(path, Empty, template);
+
+        // Assert
+        ThenTheTemplatesVariablesAre(expectedTemplates.ToArray());
+    }
+
+    private void ThenSinglePlaceholderIs(string expectedName, string expectedValue)
+    {
+        var item = _result.Data.Single(t => t.Name == expectedName);
+        item.Value.ShouldBe(expectedValue);
+    }
+
+    private void ThenTheTemplatesVariablesAre(params PlaceholderNameAndValue[] collection)
+    {
+        foreach (var expected in collection)
         {
-            this.Given(x => x.GivenIHaveAUpstreamPath(string.Empty))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(string.Empty))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_nothing_then_placeholder_no_value_is_blank()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", string.Empty),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath(string.Empty))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_nothing_then_placeholder_value_is_test()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", "test"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/test"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_match_everything_in_path_with_query()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{everything}", "test/toot"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
-                .And(x => GivenIHaveAQuery("?$filter=Name%20eq%20'Sam'"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{everything}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_match_everything_in_path()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{everything}", "test/toot"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{everything}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_forward_slash_then_placeholder_no_value_is_blank()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", string.Empty),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_forward_slash()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>();
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_forward_slash_then_placeholder_then_another_value()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", "1"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/1/products"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}/products"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_not_find_anything()
-        {
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_find_query_string()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
-                .And(x => x.GivenIHaveAQuery("?productId=1"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products?productId={productId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_find_query_string_dont_include_hardcoded()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
-                .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products?productId={productId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_find_multiple_query_string()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
-                .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products?productId={productId}&categoryId={categoryId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_find_multiple_query_string_and_path()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{account}", "3"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products/3"))
-                .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}?productId={productId}&categoryId={categoryId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void should_find_multiple_query_string_and_path_that_ends_with_slash()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{account}", "3"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("/products/3/"))
-                .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}/?productId={productId}&categoryId={categoryId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_no_slash()
-        {
-            this.Given(x => x.GivenIHaveAUpstreamPath("api"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                 .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_one_slash()
-        {
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                 .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template()
-        {
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/"))
-              .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/"))
-              .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-              .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-              .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template_with_one_place_holder()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1"))
-               .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}"))
-               .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-               .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-               .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template_with_two_place_holders()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/2"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/{categoryId}"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template_with_two_place_holders_seperated_by_something()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template_with_three_place_holders_seperated_by_something()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{variantId}", "123"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/123"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/{variantId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Fact]
-        public void can_match_down_stream_url_with_downstream_template_with_three_place_holders()
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-            };
-
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/"))
-                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Feat", "89")]
-        [InlineData("/api/{finalUrlPath}", "/api/product/products/categories/", "{finalUrlPath}", "product/products/categories/")]
-        [InlineData("/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "{urlPath}", "products/1")]
-        public void Can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path(string template, string path, string placeholderName, string placeholderValue)
-        {
-            // Arrange
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName, placeholderValue),
-            };
-            GivenIHaveAUpstreamPath(path);
-            GivenIHaveAnUpstreamUrlTemplate(template);
-
-            // Act
-            WhenIFindTheUrlVariableNamesAndValues();
-
-            // Assert
-            ThenTheTemplatesVariablesAre(expectedTemplates);
-        }
-
-        [Fact]
-        [Trait("Bug", "748")]
-        public void check_for_placeholder_at_end_of_template() 
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{testId}", string.Empty),
-            };
-            this.Given(x => x.GivenIHaveAUpstreamPath("/upstream/test/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/upstream/test/{testId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "748")]
-        [InlineData("/api/invoices/{url}", "/api/invoices/123", "{url}", "123")]
-        [InlineData("/api/invoices/{url}", "/api/invoices/", "{url}", "")]
-        [InlineData("/api/invoices/{url}", "/api/invoices", "{url}", "")]
-        [InlineData("/api/{version}/invoices/", "/api/v1/invoices/", "{version}", "v1")]
-        public void should_fix_issue_748(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue)
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName, placeholderValue),
-            };
-            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "748")]
-        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/123", "{version}", "v1", "{url}", "123")]
-        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/", "{version}", "v1", "{url}", "")]
-        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/test?query=1", "{url}", "test", "{query}", "query=1")]
-        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/?query=1", "{url}", "", "{query}", "query=1")]
-        public void should_resolve_catchall_at_end_with_middle_placeholder(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue, string catchallName, string catchallValue)
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName, placeholderValue),
-                new(catchallName, catchallValue),
-            };
-            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
-
-        [Theory]
-        [Trait("Bug", "2199")]
-        [InlineData("/api/invoices/{url}-abcd", "/api/invoices/123-abcd", "{url}", "123")]
-        [InlineData("/api/invoices/{url1}-{url2}_abcd", "/api/invoices/123-456_abcd", "{url1}", "123")]
-        public void Can_match_between_slashes(string upstreamTemplate, string requestURL, string placeholderName,
-            string placeholderValue)
-        {
-            // Arrange
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
-            GivenIHaveAUpstreamPath(requestURL);
-            GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate);
-
-            // Act
-            WhenIFindTheUrlVariableNamesAndValues();
-
-            // Assert
-            ThenTheTemplatesVariablesAre(expectedTemplates);
-        }
-
-        [Theory]
-        [Trait("Bug", "2199")]
-        [Trait("Feat", "2200")]
-        [InlineData("/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}", "/api/invoices_super/123-456_abcd/789?urlId=987",
-            "{url0}", "super", "{url1}", "123", "{url2}", "456", "{url3}", "789", "{url4}", "987")]
-        [InlineData("/api/users/{userId}/posts/{postId}_abcd/{timestamp}?filter={filter}", "/api/users/101/posts/2022_abcd/2024?filter=active",
-            "{userId}", "101", "{postId}", "2022", "{timestamp}", "2024", "{filter}", "active")]
-        [InlineData("/api/categories/{categoryId}/{subCategoryId}_abcd/{itemId}?sort={sortBy}", "/api/categories/1/2_abcd/5?sort=desc",
-            "{categoryId}", "1", "{subCategoryId}", "2", "{itemId}", "5", "{sortBy}", "desc")]
-        [InlineData("/api/products/{productId}/{category}_{itemId}_details/{status}", "/api/products/789/electronics_123_details/available",
-            "{productId}", "789", "{category}", "electronics", "{itemId}", "123", "{status}", "available")]
-        public void Can_match_all_placeholders_between_slashes(string upstreamTemplate, string requestURL,
-            string placeholderName1, string placeholderValue1, string placeholderName2, string placeholderValue2,
-            string placeholderName3, string placeholderValue3, string placeholderName4, string placeholderValue4,
-            string placeholderName5 = null, string placeholderValue5 = null)
-        {
-            // Arrange
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName1, placeholderValue1),
-                new(placeholderName2, placeholderValue2),
-                new(placeholderName3, placeholderValue3),
-                new(placeholderName4, placeholderValue4),
-            };
-
-            // Add optional placeholders if they exist
-            if (!string.IsNullOrEmpty(placeholderName5))
-            {
-                expectedTemplates.Add(new(placeholderName5, placeholderValue5));
-            }
-
-            GivenIHaveAUpstreamPath(requestURL);
-            GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate);
-
-            // Act
-            WhenIFindTheUrlVariableNamesAndValues();
-
-            // Assert
-            ThenTheTemplatesVariablesAre(expectedTemplates);
-        }
-
-        private void ThenTheTemplatesVariablesAre(List<PlaceholderNameAndValue> expectedResults)
-        {
-            foreach (var expectedResult in expectedResults)
-            {
-                var result = _result.Data.First(t => t.Name == expectedResult.Name);
-                result.Value.ShouldBe(expectedResult.Value);
-            }
-        }
-
-        private void GivenIHaveAUpstreamPath(string downstreamPath)
-        {
-            _downstreamUrlPath = downstreamPath;
-        }
-
-        private void GivenIHaveAnUpstreamUrlTemplate(string downstreamUrlTemplate)
-        {
-            _downstreamPathTemplate = downstreamUrlTemplate;
-        }
-
-        private void WhenIFindTheUrlVariableNamesAndValues()
-        {
-            _result = _finder.Find(_downstreamUrlPath, _query, _downstreamPathTemplate);
-        }
-
-        private void GivenIHaveAQuery(string query)
-        {
-            _query = query;
+            ThenSinglePlaceholderIs(expected.Name, expected.Value);
         }
     }
 }

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
@@ -29,7 +29,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_nothing_then_placeholder_no_value_is_blank()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", string.Empty), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{url}", string.Empty),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath(string.Empty))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -41,7 +44,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_nothing_then_placeholder_value_is_test()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", "test"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{url}", "test"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -53,7 +59,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_match_everything_in_path_with_query()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{everything}", "test/toot"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{everything}", "test/toot"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
                 .And(x => GivenIHaveAQuery("?$filter=Name%20eq%20'Sam'"))
@@ -66,7 +75,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_match_everything_in_path()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{everything}", "test/toot"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{everything}", "test/toot"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{everything}"))
@@ -78,7 +90,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_forward_slash_then_placeholder_no_value_is_blank()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", string.Empty), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{url}", string.Empty),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -102,7 +117,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_forward_slash_then_placeholder_then_another_value()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", "1"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{url}", "1"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/1/products"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}/products"))
@@ -124,7 +142,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_find_query_string()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{productId}", "1"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
                 .And(x => x.GivenIHaveAQuery("?productId=1"))
@@ -137,7 +158,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_find_query_string_dont_include_hardcoded()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{productId}", "1"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
@@ -152,7 +176,8 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
@@ -168,13 +193,14 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"), new("{account}", "3"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
+                new("{account}", "3"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products/3"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
-                    "/products/{account}?productId={productId}&categoryId={categoryId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}?productId={productId}&categoryId={categoryId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -185,13 +211,14 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"), new("{account}", "3"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
+                new("{account}", "3"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products/3/"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
-                    "/products/{account}/?productId={productId}&categoryId={categoryId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}/?productId={productId}&categoryId={categoryId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -201,42 +228,45 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         public void can_match_down_stream_url_with_no_slash()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api"))
-                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                .BDDfy();
+                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api"))
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+                 .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_one_slash()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api/"))
-                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                .BDDfy();
+                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/"))
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+                 .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_downstream_template()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/"))
-                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                .BDDfy();
+              .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/"))
+              .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+              .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+              .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_downstream_template_with_one_place_holder()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{productId}", "1"),
+            };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1"))
-                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
+               .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}"))
+               .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+               .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+               .BDDfy();
         }
 
         [Fact]
@@ -244,14 +274,15 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/2"))
-                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/{categoryId}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
+                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/{categoryId}"))
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                 .BDDfy();
         }
 
         [Fact]
@@ -259,7 +290,8 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2"))
@@ -274,12 +306,13 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"), new("{variantId}", "123"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
+                new("{variantId}", "123"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/123"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
-                    "api/product/products/{productId}/categories/{categoryId}/variant/{variantId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/{variantId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -290,18 +323,19 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"), new("{categoryId}", "2"),
+                new("{productId}", "1"),
+                new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
-                    "api/product/products/{productId}/categories/{categoryId}/variant/"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
+                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/"))
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                 .BDDfy();
         }
 
         [Fact]
+        [Trait("Feat", "89")]
         public void can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path()
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
@@ -310,17 +344,20 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/categories/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}"))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
+                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/")) // Gui, don't remove final slash! We should not break old functionality
+                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                 .BDDfy();
         }
 
         [Fact]
         [Trait("Bug", "748")]
-        public void check_for_placeholder_at_end_of_template()
+        public void check_for_placeholder_at_end_of_template() 
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{testId}", string.Empty), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new("{testId}", string.Empty),
+            };
             this.Given(x => x.GivenIHaveAUpstreamPath("/upstream/test/"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/upstream/test/{testId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
@@ -329,12 +366,17 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         }
 
         [Theory]
-        [InlineData("/api/invoices/{url}-abcd", "/api/invoices/123-abcd", "{url}", "123")]
-        [InlineData("/api/invoices/{url1}-{url2}_abcd", "/api/invoices/123-456_abcd", "{url1}", "123")]
-        public void can_match_between_slashes(string upstreamTemplate, string requestURL, string placeholderName,
-            string placeholderValue)
+        [Trait("Bug", "748")]
+        [InlineData("/api/invoices/{url}", "/api/invoices/123", "{url}", "123")]
+        [InlineData("/api/invoices/{url}", "/api/invoices/", "{url}", "")]
+        [InlineData("/api/invoices/{url}", "/api/invoices", "{url}", "")]
+        [InlineData("/api/{version}/invoices/", "/api/v1/invoices/", "{version}", "v1")]
+        public void should_fix_issue_748(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue)
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new(placeholderName, placeholderValue),
+            };
             this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
@@ -343,21 +385,61 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         }
 
         [Theory]
-        [InlineData("/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}",
-            "/api/invoices_super/123-456_abcd/789?urlId=987", "{url0}", "super", "{url1}", "123", "{url2}", "456",
-            "{url3}", "789", "{url4}", "987")]
-        [InlineData("/api/users/{userId}/posts/{postId}_abcd/{timestamp}?filter={filter}",
-            "/api/users/101/posts/2022_abcd/2024?filter=active", "{userId}", "101", "{postId}", "2022", "{timestamp}",
-            "2024", "{filter}", "active")]
-        [InlineData("/api/categories/{categoryId}/{subCategoryId}_abcd/{itemId}?sort={sortBy}",
-            "/api/categories/1/2_abcd/5?sort=desc", "{categoryId}", "1", "{subCategoryId}", "2", "{itemId}", "5",
-            "{sortBy}", "desc")]
-        [InlineData("/api/products/{productId}/{category}_{itemId}_details/{status}", "/api/products/789/electronics_123_details/available", "{productId}", "789", "{category}", "electronics", "{itemId}", "123", "{status}", "available")]
-        public void can_match_all_placeholders_between_slashes(string upstreamTemplate, string requestURL,
+        [Trait("Bug", "748")]
+        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/123", "{version}", "v1", "{url}", "123")]
+        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/", "{version}", "v1", "{url}", "")]
+        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/test?query=1", "{url}", "test", "{query}", "query=1")]
+        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/?query=1", "{url}", "", "{query}", "query=1")]
+        public void should_resolve_catchall_at_end_with_middle_placeholder(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue, string catchallName, string catchallValue)
+        {
+            var expectedTemplates = new List<PlaceholderNameAndValue>
+            {
+                new(placeholderName, placeholderValue),
+                new(catchallName, catchallValue),
+            };
+            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
+        }
+
+        [Theory]
+        [Trait("Bug", "2199")]
+        [InlineData("/api/invoices/{url}-abcd", "/api/invoices/123-abcd", "{url}", "123")]
+        [InlineData("/api/invoices/{url1}-{url2}_abcd", "/api/invoices/123-456_abcd", "{url1}", "123")]
+        public void Can_match_between_slashes(string upstreamTemplate, string requestURL, string placeholderName,
+            string placeholderValue)
+        {
+            // Arrange
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
+            GivenIHaveAUpstreamPath(requestURL);
+            GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate);
+
+            // Act
+            WhenIFindTheUrlVariableNamesAndValues();
+
+            // Assert
+            ThenTheTemplatesVariablesAre(expectedTemplates);
+        }
+
+        [Theory]
+        [Trait("Bug", "2199")]
+        [Trait("Feat", "2200")]
+        [InlineData("/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}", "/api/invoices_super/123-456_abcd/789?urlId=987",
+            "{url0}", "super", "{url1}", "123", "{url2}", "456", "{url3}", "789", "{url4}", "987")]
+        [InlineData("/api/users/{userId}/posts/{postId}_abcd/{timestamp}?filter={filter}", "/api/users/101/posts/2022_abcd/2024?filter=active",
+            "{userId}", "101", "{postId}", "2022", "{timestamp}", "2024", "{filter}", "active")]
+        [InlineData("/api/categories/{categoryId}/{subCategoryId}_abcd/{itemId}?sort={sortBy}", "/api/categories/1/2_abcd/5?sort=desc",
+            "{categoryId}", "1", "{subCategoryId}", "2", "{itemId}", "5", "{sortBy}", "desc")]
+        [InlineData("/api/products/{productId}/{category}_{itemId}_details/{status}", "/api/products/789/electronics_123_details/available",
+            "{productId}", "789", "{category}", "electronics", "{itemId}", "123", "{status}", "available")]
+        public void Can_match_all_placeholders_between_slashes(string upstreamTemplate, string requestURL,
             string placeholderName1, string placeholderValue1, string placeholderName2, string placeholderValue2,
             string placeholderName3, string placeholderValue3, string placeholderName4, string placeholderValue4,
             string placeholderName5 = null, string placeholderValue5 = null)
         {
+            // Arrange
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
                 new(placeholderName1, placeholderValue1),
@@ -372,48 +454,14 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
                 expectedTemplates.Add(new(placeholderName5, placeholderValue5));
             }
 
-            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
+            GivenIHaveAUpstreamPath(requestURL);
+            GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate);
 
-        [Theory]
-        [Trait("Bug", "748")]
-        [InlineData("/api/invoices/{url}", "/api/invoices/123", "{url}", "123")]
-        [InlineData("/api/invoices/{url}", "/api/invoices/", "{url}", "")]
-        [InlineData("/api/invoices/{url}", "/api/invoices", "{url}", "")]
-        [InlineData("/api/{version}/invoices/", "/api/v1/invoices/", "{version}", "v1")]
-        public void should_fix_issue_748(string upstreamTemplate, string requestURL, string placeholderName,
-            string placeholderValue)
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
-            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
-        }
+            // Act
+            WhenIFindTheUrlVariableNamesAndValues();
 
-        [Theory]
-        [Trait("Bug", "748")]
-        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/123", "{version}", "v1", "{url}", "123")]
-        [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/", "{version}", "v1", "{url}", "")]
-        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/test?query=1", "{url}", "test", "{query}", "query=1")]
-        [InlineData("/api/invoices/{url}?{query}", "/api/invoices/?query=1", "{url}", "", "{query}", "query=1")]
-        public void should_resolve_catchall_at_end_with_middle_placeholder(string upstreamTemplate, string requestURL,
-            string placeholderName, string placeholderValue, string catchallName, string catchallValue)
-        {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName, placeholderValue), new(catchallName, catchallValue),
-            };
-            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
-                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                .BDDfy();
+            // Assert
+            ThenTheTemplatesVariablesAre(expectedTemplates);
         }
 
         private void ThenTheTemplatesVariablesAre(List<PlaceholderNameAndValue> expectedResults)

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
@@ -334,20 +334,25 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
                  .BDDfy();
         }
 
-        [Fact]
+        [Theory]
         [Trait("Feat", "89")]
-        public void can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path()
+        [InlineData("/api/{finalUrlPath}", "/api/product/products/categories/", "{finalUrlPath}", "product/products/categories/")]
+        [InlineData("/myApp1Name/api/{urlPath}", "/myApp1Name/api/products/1", "{urlPath}", "products/1")]
+        public void Can_match_down_stream_url_with_downstream_template_with_place_holder_to_final_url_path(string template, string path, string placeholderName, string placeholderValue)
         {
+            // Arrange
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{finalUrlPath}", "product/products/categories/"),
+                new(placeholderName, placeholderValue),
             };
+            GivenIHaveAUpstreamPath(path);
+            GivenIHaveAnUpstreamUrlTemplate(template);
 
-            this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/categories/"))
-                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/")) // Gui, don't remove final slash! We should not break old functionality
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
+            // Act
+            WhenIFindTheUrlVariableNamesAndValues();
+
+            // Assert
+            ThenTheTemplatesVariablesAre(expectedTemplates);
         }
 
         [Fact]

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinderTests.cs
@@ -29,10 +29,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_nothing_then_placeholder_no_value_is_blank()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", string.Empty),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", string.Empty), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath(string.Empty))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -44,10 +41,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_nothing_then_placeholder_value_is_test()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", "test"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", "test"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -59,10 +53,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_match_everything_in_path_with_query()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{everything}", "test/toot"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{everything}", "test/toot"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
                 .And(x => GivenIHaveAQuery("?$filter=Name%20eq%20'Sam'"))
@@ -75,10 +66,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_match_everything_in_path()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{everything}", "test/toot"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{everything}", "test/toot"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/test/toot"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{everything}"))
@@ -90,10 +78,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_forward_slash_then_placeholder_no_value_is_blank()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", string.Empty),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", string.Empty), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}"))
@@ -117,10 +102,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void can_match_down_stream_url_with_forward_slash_then_placeholder_then_another_value()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{url}", "1"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{url}", "1"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/1/products"))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/{url}/products"))
@@ -142,10 +124,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_find_query_string()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
                 .And(x => x.GivenIHaveAQuery("?productId=1"))
@@ -158,10 +137,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [Fact]
         public void should_find_query_string_dont_include_hardcoded()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
@@ -176,8 +152,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
+                new("{productId}", "1"), new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products"))
@@ -193,14 +168,13 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{account}", "3"),
+                new("{productId}", "1"), new("{categoryId}", "2"), new("{account}", "3"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products/3"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}?productId={productId}&categoryId={categoryId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
+                    "/products/{account}?productId={productId}&categoryId={categoryId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -211,14 +185,13 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{account}", "3"),
+                new("{productId}", "1"), new("{categoryId}", "2"), new("{account}", "3"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("/products/3/"))
                 .And(x => x.GivenIHaveAQuery("?productId=1&categoryId=2"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/products/{account}/?productId={productId}&categoryId={categoryId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
+                    "/products/{account}/?productId={productId}&categoryId={categoryId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -228,45 +201,42 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         public void can_match_down_stream_url_with_no_slash()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                 .BDDfy();
+                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+                .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_one_slash()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api/"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-                 .BDDfy();
+                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+                .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_downstream_template()
         {
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/"))
-              .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/"))
-              .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-              .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
-              .BDDfy();
+                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(new List<PlaceholderNameAndValue>()))
+                .BDDfy();
         }
 
         [Fact]
         public void can_match_down_stream_url_with_downstream_template_with_one_place_holder()
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new("{productId}", "1"),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{productId}", "1"), };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1"))
-               .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}"))
-               .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-               .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-               .BDDfy();
+                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
         }
 
         [Fact]
@@ -274,15 +244,14 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
+                new("{productId}", "1"), new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/2"))
-                 .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/{categoryId}"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
+                .Given(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/{categoryId}"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
         }
 
         [Fact]
@@ -290,8 +259,7 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
+                new("{productId}", "1"), new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2"))
@@ -306,13 +274,12 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
-                new("{variantId}", "123"),
+                new("{productId}", "1"), new("{categoryId}", "2"), new("{variantId}", "123"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/123"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/{variantId}"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
+                    "api/product/products/{productId}/categories/{categoryId}/variant/{variantId}"))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -323,15 +290,15 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{productId}", "1"),
-                new("{categoryId}", "2"),
+                new("{productId}", "1"), new("{categoryId}", "2"),
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/1/categories/2/variant/"))
-                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/product/products/{productId}/categories/{categoryId}/variant/"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(
+                    "api/product/products/{productId}/categories/{categoryId}/variant/"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
         }
 
         [Fact]
@@ -343,22 +310,70 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
             };
 
             this.Given(x => x.GivenIHaveAUpstreamPath("api/product/products/categories/"))
-                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/"))
-                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
-                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
-                 .BDDfy();
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("api/{finalUrlPath}/"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
         }
 
         [Fact]
         [Trait("Bug", "748")]
-        public void check_for_placeholder_at_end_of_template() 
+        public void check_for_placeholder_at_end_of_template()
+        {
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new("{testId}", string.Empty), };
+            this.Given(x => x.GivenIHaveAUpstreamPath("/upstream/test/"))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/upstream/test/{testId}"))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
+        }
+
+        [Theory]
+        [InlineData("/api/invoices/{url}-abcd", "/api/invoices/123-abcd", "{url}", "123")]
+        [InlineData("/api/invoices/{url1}-{url2}_abcd", "/api/invoices/123-456_abcd", "{url1}", "123")]
+        public void can_match_between_slashes(string upstreamTemplate, string requestURL, string placeholderName,
+            string placeholderValue)
+        {
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
+            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
+                .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
+                .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
+                .BDDfy();
+        }
+
+        [Theory]
+        [InlineData("/api/invoices_{url0}/{url1}-{url2}_abcd/{url3}?urlId={url4}",
+            "/api/invoices_super/123-456_abcd/789?urlId=987", "{url0}", "super", "{url1}", "123", "{url2}", "456",
+            "{url3}", "789", "{url4}", "987")]
+        [InlineData("/api/users/{userId}/posts/{postId}_abcd/{timestamp}?filter={filter}",
+            "/api/users/101/posts/2022_abcd/2024?filter=active", "{userId}", "101", "{postId}", "2022", "{timestamp}",
+            "2024", "{filter}", "active")]
+        [InlineData("/api/categories/{categoryId}/{subCategoryId}_abcd/{itemId}?sort={sortBy}",
+            "/api/categories/1/2_abcd/5?sort=desc", "{categoryId}", "1", "{subCategoryId}", "2", "{itemId}", "5",
+            "{sortBy}", "desc")]
+        [InlineData("/api/products/{productId}/{category}_{itemId}_details/{status}", "/api/products/789/electronics_123_details/available", "{productId}", "789", "{category}", "electronics", "{itemId}", "123", "{status}", "available")]
+        public void can_match_all_placeholders_between_slashes(string upstreamTemplate, string requestURL,
+            string placeholderName1, string placeholderValue1, string placeholderName2, string placeholderValue2,
+            string placeholderName3, string placeholderValue3, string placeholderName4, string placeholderValue4,
+            string placeholderName5 = null, string placeholderValue5 = null)
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new("{testId}", string.Empty),
+                new(placeholderName1, placeholderValue1),
+                new(placeholderName2, placeholderValue2),
+                new(placeholderName3, placeholderValue3),
+                new(placeholderName4, placeholderValue4),
             };
-            this.Given(x => x.GivenIHaveAUpstreamPath("/upstream/test/"))
-                .And(x => x.GivenIHaveAnUpstreamUrlTemplate("/upstream/test/{testId}"))
+
+            // Add optional placeholders if they exist
+            if (!string.IsNullOrEmpty(placeholderName5))
+            {
+                expectedTemplates.Add(new(placeholderName5, placeholderValue5));
+            }
+
+            this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
+                .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
                 .And(x => x.ThenTheTemplatesVariablesAre(expectedTemplates))
                 .BDDfy();
@@ -370,12 +385,10 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [InlineData("/api/invoices/{url}", "/api/invoices/", "{url}", "")]
         [InlineData("/api/invoices/{url}", "/api/invoices", "{url}", "")]
         [InlineData("/api/{version}/invoices/", "/api/v1/invoices/", "{version}", "v1")]
-        public void should_fix_issue_748(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue)
+        public void should_fix_issue_748(string upstreamTemplate, string requestURL, string placeholderName,
+            string placeholderValue)
         {
-            var expectedTemplates = new List<PlaceholderNameAndValue>
-            {
-                new(placeholderName, placeholderValue),
-            };
+            var expectedTemplates = new List<PlaceholderNameAndValue> { new(placeholderName, placeholderValue), };
             this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))
                 .When(x => x.WhenIFindTheUrlVariableNamesAndValues())
@@ -389,12 +402,12 @@ namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher
         [InlineData("/api/{version}/invoices/{url}", "/api/v1/invoices/", "{version}", "v1", "{url}", "")]
         [InlineData("/api/invoices/{url}?{query}", "/api/invoices/test?query=1", "{url}", "test", "{query}", "query=1")]
         [InlineData("/api/invoices/{url}?{query}", "/api/invoices/?query=1", "{url}", "", "{query}", "query=1")]
-        public void should_resolve_catchall_at_end_with_middle_placeholder(string upstreamTemplate, string requestURL, string placeholderName, string placeholderValue, string catchallName, string catchallValue)
+        public void should_resolve_catchall_at_end_with_middle_placeholder(string upstreamTemplate, string requestURL,
+            string placeholderName, string placeholderValue, string catchallName, string catchallValue)
         {
             var expectedTemplates = new List<PlaceholderNameAndValue>
             {
-                new(placeholderName, placeholderValue),
-                new(catchallName, catchallValue),
+                new(placeholderName, placeholderValue), new(catchallName, catchallValue),
             };
             this.Given(x => x.GivenIHaveAUpstreamPath(requestURL))
                 .And(x => x.GivenIHaveAnUpstreamUrlTemplate(upstreamTemplate))


### PR DESCRIPTION
## Fixes #2199
- #2199

## Proposed Changes
  - Reworked `UrlPathPlaceholderNameAndValueFinder.cs` supporting now embedded placeholders
  - Pattern matching with Regexes
  
     ```c#
     Regex regex = new($@"\{PlaceHolderLeft}(.*?)\{PlaceHolderRight}", RegexOptions.None, TimeSpan.FromSeconds(1));
     template = EscapeExceptBraces(template);
     string regexPattern = $"^{regex.Replace(template, match => $"(?<{match.Groups[1].Value}>[^&]*)")}";
     ```

  - Some tweaks:
    - If the path template contains a catch-all query, then return the catch-all placeholder with an empty value
    ```c#
    private static (bool IsMatch, string Placeholder) IsCatchAllQuery(string template)
        {
            Regex catchAllQueryRegex = new($@"^[^{{}}]*\?\{PlaceHolderLeft}(.*?)\{PlaceHolderRight}$", RegexOptions.None, TimeSpan.FromMilliseconds(300));
            Match catchAllMatch = catchAllQueryRegex.Match(template);
    
            return (catchAllMatch.Success, catchAllMatch.Success ? catchAllMatch.Groups[1].Value : string.Empty);
        }
    ```
    - If the path template contains a catch all path, then return the catch-all placeholder with an empty value
    - Skipping the query evaluation if not present in the path template
 - Added some unit tests with complex path templates.
 - Added code comments
