### PR TITLE
Introducing Ocelot Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ All versions can be found [on nuget](https://www.nuget.org/packages/Ocelot#versi
   <br/>This includes lots of information and will be helpful if you want to understand the features Ocelot currently offers.
 - [Ocelot RST Docs](https://github.com/ThreeMammals/Ocelot/tree/develop/docs)
   <br/>This includes source code of documentation as **.rst** files which are up to date for current development.
+- [Ask Ocelot Guru](https://gurubase.io/g/ocelot)
+  <br/>It's a Ocelot-focused AI to answer your questions.
 
 ## Coming up
 You can see what we are working on in [backlog](https://github.com/ThreeMammals/Ocelot/issues).


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Ocelot Guru](https://gurubase.io/g/ocelot) to Gurubase. Ocelot Guru uses the data from this repo and data from the [docs](https://ocelot.readthedocs.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "Ocelot Guru", which highlights that Ocelot now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Ocelot Guru in Gurubase, just let me know that's totally fine.
