### PR TITLE
#2145 Refactor Infrastructure `StringExtensions`

### DIFF
--- a/src/Ocelot.Provider.Consul/DefaultConsulServiceBuilder.cs
+++ b/src/Ocelot.Provider.Consul/DefaultConsulServiceBuilder.cs
@@ -102,7 +102,7 @@ public class DefaultConsulServiceBuilder : IConsulServiceBuilder
     protected virtual string GetServiceVersion(ServiceEntry entry, Node node)
         => entry.Service.Tags
             ?.FirstOrDefault(tag => tag.StartsWith(VersionPrefix, StringComparison.Ordinal))
-            ?.TrimStart(VersionPrefix)
+            ?.TrimPrefix(VersionPrefix)
             ?? string.Empty;
 
     protected virtual IEnumerable<string> GetServiceTags(ServiceEntry entry, Node node)

--- a/src/Ocelot/Infrastructure/Extensions/StringExtensions.cs
+++ b/src/Ocelot/Infrastructure/Extensions/StringExtensions.cs
@@ -2,29 +2,32 @@
 
 public static class StringExtensions
 {
-    public static string TrimStart(this string source, string trim, StringComparison stringComparison = StringComparison.Ordinal)
+    /// <summary>Removes the prefix from the beginning of the string repeatedly until all occurrences are eliminated.</summary>
+    /// <param name="source">The string to trim.</param>
+    /// <param name="prefix">The prefix string to remove.</param>
+    /// <param name="comparison">The 2nd argument of the <see cref="string.StartsWith(string)"/> method.</param>
+    /// <returns>A new <see cref="string"/> without the prefix all occurrences.</returns>
+    public static string TrimPrefix(this string source, string prefix, StringComparison comparison = StringComparison.Ordinal)
     {
-        if (source == null)
+        if (source == null || string.IsNullOrEmpty(prefix))
         {
-            return null;
+            return source;
         }
 
         var s = source;
-        while (s.StartsWith(trim, stringComparison))
+        while (s.StartsWith(prefix, comparison))
         {
-            s = s.Substring(trim.Length);
+            s = s[prefix.Length..];
         }
 
         return s;
     }
 
-    public static string LastCharAsForwardSlash(this string source)
-    {
-        if (source.EndsWith('/'))
-        {
-            return source;
-        }
+    public const char Slash = '/';
 
-        return $"{source}/";
-    }
+    /// <summary>Ensures that the last char of the string is forward slash, '/'.</summary>
+    /// <param name="source">The string to check its last slash char.</param>
+    /// <returns>A <see cref="string"/> witl the last forward slash.</returns>
+    public static string LastCharAsForwardSlash(this string source)
+        => source.EndsWith(Slash) ? source : source + Slash;
 }

--- a/test/Ocelot.UnitTests/Infrastructure/StringExtensionsTests.cs
+++ b/test/Ocelot.UnitTests/Infrastructure/StringExtensionsTests.cs
@@ -5,22 +5,25 @@ namespace Ocelot.UnitTests.Infrastructure;
 public class StringExtensionsTests
 {
     [Fact]
-    public void should_trim_start()
+    public void TrimPrefix_ArgsCheck_ReturnedSource()
     {
-        var test = "/string";
-
-        test = test.TrimStart("/");
-
-        test.ShouldBe("string");
+        ((string)null).TrimPrefix("/").ShouldBeNull();
+        "x".TrimPrefix(null).ShouldBe("x");
+        "x".TrimPrefix(string.Empty).ShouldBe("x");
     }
 
     [Fact]
-    public void should_return_source()
+    public void TrimPrefix_HasPrefix_HappyPath()
     {
-        var test = "string";
+        "/string".TrimPrefix("/").ShouldBe("string");
+        "///string".TrimPrefix("/").ShouldBe("string");
+        "ABABstring".TrimPrefix("AB").ShouldBe("string");
+    }
 
-        test = test.LastCharAsForwardSlash();
-
-        test.ShouldBe("string/");
+    [Fact]
+    public void LastCharAsForwardSlash_HappyPath()
+    {
+        "string".LastCharAsForwardSlash().ShouldBe("string/");
+        "string/".LastCharAsForwardSlash().ShouldBe("string/");
     }
 }


### PR DESCRIPTION
## Fixes #2145 
- #2145 

## Proposed Changes
  - Refactored `StringExtensions`: added developer's XML docs
  - Renamed `TrimStart` method to `TrimPrefix` because of .NET Runtime [TrimStart](https://github.com/search?q=repo%3Adotnet%2Fruntime%20TrimStart&type=code).
  - Updated unit tests
