### PR TITLE
#2219 Remove preprocessor directives targeted at old .NET 6 and 7

### DIFF
--- a/src/Ocelot/Authorization/ClaimsAuthorizer.cs
+++ b/src/Ocelot/Authorization/ClaimsAuthorizer.cs
@@ -18,13 +18,9 @@ public partial class ClaimsAuthorizer : IClaimsAuthorizer
         _claimsParser = claimsParser;
     }
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"^{(?<variable>.+)}$", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex RegexAuthorize();
-#else
-    private static readonly Regex _regexAuthorize = RegexGlobal.New(@"^{(?<variable>.+)}$");
-    private static Regex RegexAuthorize() => _regexAuthorize;
-#endif
+
     public Response<bool> Authorize(
         ClaimsPrincipal claimsPrincipal,
         Dictionary<string, string> routeClaimsRequirement,

--- a/src/Ocelot/Configuration/Creator/UpstreamHeaderTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamHeaderTemplatePatternCreator.cs
@@ -10,14 +10,8 @@ namespace Ocelot.Configuration.Creator;
 /// <remarks>Ocelot feature: Routing based on request header.</remarks>
 public partial class UpstreamHeaderTemplatePatternCreator : IUpstreamHeaderTemplatePatternCreator
 {
-    private const string PlaceHolderPattern = @"(\{header:.*?\})";
-#if NET7_0_OR_GREATER
-    [GeneratedRegex(PlaceHolderPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds, "en-US")]
+    [GeneratedRegex(@"(\{header:.*?\})", RegexOptions.IgnoreCase | RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds, "en-US")]
     private static partial Regex RegexPlaceholders();
-#else
-    private static readonly Regex _regexPlaceholders = RegexGlobal.New(PlaceHolderPattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
-    private static Regex RegexPlaceholders() => _regexPlaceholders;
-#endif
 
     public IDictionary<string, UpstreamHeaderTemplate> Create(IRoute route)
     {

--- a/src/Ocelot/Configuration/Parser/ClaimToThingConfigurationParser.cs
+++ b/src/Ocelot/Configuration/Parser/ClaimToThingConfigurationParser.cs
@@ -9,17 +9,12 @@ namespace Ocelot.Configuration.Parser;
 public partial class ClaimToThingConfigurationParser : IClaimToThingConfigurationParser
 {
     private const char SplitToken = '>';
-#if NET7_0_OR_GREATER
+
     [GeneratedRegex("Claims\\[.*\\]", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex ClaimRegex();
+
     [GeneratedRegex("value\\[.*\\]", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex IndexRegex();
-#else
-    private static readonly Regex _claimRegex = RegexGlobal.New("Claims\\[.*\\]");
-    private static readonly Regex _indexRegex = RegexGlobal.New("value\\[.*\\]");
-    private static Regex ClaimRegex() => _claimRegex;
-    private static Regex IndexRegex() => _indexRegex;
-#endif
 
     public Response<ClaimToThing> Extract(string existingKey, string value)
     {

--- a/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/FileConfigurationFluentValidator.cs
@@ -99,13 +99,8 @@ public partial class FileConfigurationFluentValidator : AbstractValidator<FileCo
         return routesForAggregate.Count() == fileAggregateRoute.RouteKeys.Count;
     }
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"\{\w+\}", RegexOptions.IgnoreCase | RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds, "en-US")]
     private static partial Regex PlaceholderRegex();
-#else
-    private static readonly Regex _placeholderRegex = RegexGlobal.New(@"\{\w+\}", RegexOptions.IgnoreCase | RegexOptions.Singleline);
-    private static Regex PlaceholderRegex() => _placeholderRegex;
-#endif
 
     private static bool IsPlaceholderNotDuplicatedIn(string pathTemplate)
     {

--- a/src/Ocelot/Configuration/Validator/RouteFluentValidator.cs
+++ b/src/Ocelot/Configuration/Validator/RouteFluentValidator.cs
@@ -111,7 +111,6 @@ public partial class RouteFluentValidator : AbstractValidator<FileRoute>
             || (string.IsNullOrEmpty(primary) && options.AuthenticationProviderKeys.All(supportedSchemes.Contains));
     }
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex("^[0-9]+s", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex SecondsRegex();
     [GeneratedRegex("^[0-9]+m", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
@@ -120,16 +119,6 @@ public partial class RouteFluentValidator : AbstractValidator<FileRoute>
     private static partial Regex HoursRegex();
     [GeneratedRegex("^[0-9]+d", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex DaysRegex();
-#else
-    private static readonly Regex _secondsRegex = RegexGlobal.New("^[0-9]+s");
-    private static readonly Regex _minutesRegex = RegexGlobal.New("^[0-9]+m");
-    private static readonly Regex _hoursRegex = RegexGlobal.New("^[0-9]+h");
-    private static readonly Regex _daysRegex = RegexGlobal.New("^[0-9]+d");
-    private static Regex SecondsRegex() => _secondsRegex;
-    private static Regex MinutesRegex() => _minutesRegex;
-    private static Regex HoursRegex() => _hoursRegex;
-    private static Regex DaysRegex() => _daysRegex;
-#endif
 
     private static bool IsValidPeriod(FileRateLimitRule rateLimitOptions)
     {

--- a/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
+++ b/src/Ocelot/DependencyInjection/ConfigurationBuilderExtensions.cs
@@ -96,13 +96,9 @@ public static partial class ConfigurationBuilderExtensions
             AddOcelotJsonFile(builder, json, primaryConfigFile, optional, reloadOnChange);
     }
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"^ocelot\.(.*?)\.json$", RegexOptions.IgnoreCase | RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds, "en-US")]
     private static partial Regex SubConfigRegex();
-#else
-    private static readonly Regex _subConfigRegex = RegexGlobal.New(@"^ocelot\.(.*?)\.json$", RegexOptions.IgnoreCase | RegexOptions.Singleline);
-    private static Regex SubConfigRegex() => _subConfigRegex;
-#endif
+
     private static string GetMergedOcelotJson(string folder, IWebHostEnvironment env,
         FileConfiguration fileConfiguration = null, string primaryFile = null, string globalFile = null, string environmentFile = null)
     {

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/UrlPathPlaceholderNameAndValueFinder.cs
@@ -43,13 +43,8 @@ public partial class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndV
     }
 
     private const int PlaceholdersMilliseconds = 1000;
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"\{(.*?)\}", RegexOptions.None, PlaceholdersMilliseconds)]
     private static partial Regex RegexPlaceholders();
-#else
-    private static readonly Regex _regexPlaceholders = RegexGlobal.New(@"\{(.*?)\}", RegexOptions.None, TimeSpan.FromMilliseconds(PlaceholdersMilliseconds));
-    private static Regex RegexPlaceholders() => _regexPlaceholders;
-#endif
 
     /// <summary>Finds the placeholders in the request path and query.
     /// We use a <see cref="Regex"/> pattern to match the placeholders in the path template.
@@ -107,13 +102,8 @@ public partial class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndV
     }
 
     private const int CatchAllQueryMilliseconds = 300;
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, CatchAllQueryMilliseconds)]
     private static partial Regex RegexCatchAllQuery();
-#else
-    private static readonly Regex _regexCatchAllQuery = RegexGlobal.New(@"^[^{{}}]*\?\{(.*?)\}$", RegexOptions.None, TimeSpan.FromMilliseconds(CatchAllQueryMilliseconds));
-    private static Regex RegexCatchAllQuery() => _regexCatchAllQuery;
-#endif
 
     /// <summary>Checks if the path template contains a Catch-All query parameter.
     /// <para>It means that the path template ends with a question mark and a placeholder.
@@ -129,13 +119,8 @@ public partial class UrlPathPlaceholderNameAndValueFinder : IPlaceholderNameAndV
     }
 
     private const int CatchAllPathMilliseconds = 300;
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, CatchAllPathMilliseconds)]
     private static partial Regex RegexCatchAllPath();
-#else
-    private static readonly Regex _regexCatchAllPath = RegexGlobal.New(@"^[^{{}}]*\{(.*?)\}/?$", RegexOptions.None, TimeSpan.FromMilliseconds(CatchAllPathMilliseconds));
-    private static Regex RegexCatchAllPath() => _regexCatchAllPath;
-#endif
 
     /// <summary>Check if the path template contains a Catch-All path parameter.
     /// <para>It means that the path template ends with a placeholder and no other placeholders are present in the path template, without a question mark (query parameters).</para>

--- a/src/Ocelot/Infrastructure/ConfigAwarePlaceholders.cs
+++ b/src/Ocelot/Infrastructure/ConfigAwarePlaceholders.cs
@@ -48,13 +48,8 @@ public partial class ConfigAwarePlaceholders : IPlaceholders
     public Response Remove(string key)
         => _placeholders.Remove(key);
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex(@"[{}]", RegexOptions.None, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex Regex();
-#else
-    private static readonly Regex _regex = RegexGlobal.New(@"[{}]");
-    private static Regex Regex() => _regex;
-#endif
     private static string CleanKey(string key)
         => Regex().Replace(key, string.Empty);
 

--- a/src/Ocelot/Values/UpstreamPathTemplate.cs
+++ b/src/Ocelot/Values/UpstreamPathTemplate.cs
@@ -5,13 +5,8 @@ namespace Ocelot.Values;
 /// <summary>The model to keep data of upstream path.</summary>
 public partial class UpstreamPathTemplate
 {
-#if NET7_0_OR_GREATER
     [GeneratedRegex("$^", RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex RegexNoTemplate();
-#else
-    private static readonly Regex _regexNoTemplate = RegexGlobal.New("$^", RegexOptions.Singleline);
-    private static Regex RegexNoTemplate() => _regexNoTemplate;
-#endif
     private static readonly ConcurrentDictionary<string, Regex> _regex = new();
 
     public UpstreamPathTemplate(string template, int priority, bool containsQueryString, string originalValue)

--- a/src/Ocelot/WebSockets/ClientWebSocketOptionsProxy.cs
+++ b/src/Ocelot/WebSockets/ClientWebSocketOptionsProxy.cs
@@ -13,17 +13,9 @@ public class ClientWebSocketOptionsProxy : IClientWebSocketOptions
         _real = options;
     }
 
-    // .NET 6 and lower doesn't support the properties below.
-    // Instead of throwing a NotSupportedException, we just implement the getter/setter.
-    // This way, we can use the same code for .NET 6 and .NET 7+.
     // TODO The design should be reviewed since we are hiding the ClientWebSocketOptions properties.
-#if NET7_0_OR_GREATER
     public Version HttpVersion { get => _real.HttpVersion; set => _real.HttpVersion = value; }
     public HttpVersionPolicy HttpVersionPolicy { get => _real.HttpVersionPolicy; set => _real.HttpVersionPolicy = value; }
-#else
-    public Version HttpVersion { get; set; }
-    public HttpVersionPolicy HttpVersionPolicy { get; set; }
-#endif
     public bool UseDefaultCredentials { get => _real.UseDefaultCredentials; set => _real.UseDefaultCredentials = value; }
     public ICredentials Credentials { get => _real.Credentials; set => _real.Credentials = value; }
     public IWebProxy Proxy { get => _real.Proxy; set => _real.Proxy = value; }
@@ -32,16 +24,10 @@ public class ClientWebSocketOptionsProxy : IClientWebSocketOptions
     public CookieContainer Cookies { get => _real.Cookies; set => _real.Cookies = value; }
     public TimeSpan KeepAliveInterval { get => _real.KeepAliveInterval; set => _real.KeepAliveInterval = value; }
     public WebSocketDeflateOptions DangerousDeflateOptions { get => _real.DangerousDeflateOptions; set => _real.DangerousDeflateOptions = value; }
-#if NET7_0_OR_GREATER
     public bool CollectHttpResponseDetails { get => _real.CollectHttpResponseDetails; set => _real.CollectHttpResponseDetails = value; }
-#else
-    public bool CollectHttpResponseDetails { get; set; }
-#endif
+
     public void AddSubProtocol(string subProtocol) => _real.AddSubProtocol(subProtocol);
-
     public void SetBuffer(int receiveBufferSize, int sendBufferSize) => _real.SetBuffer(receiveBufferSize, sendBufferSize);
-
     public void SetBuffer(int receiveBufferSize, int sendBufferSize, ArraySegment<byte> buffer) => _real.SetBuffer(receiveBufferSize, sendBufferSize, buffer);
-
     public void SetRequestHeader(string headerName, string headerValue) => _real.SetRequestHeader(headerName, headerValue);
 }

--- a/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
+++ b/test/Ocelot.AcceptanceTests/CancelRequestTests.cs
@@ -48,11 +48,7 @@ public sealed class CancelRequestTests : Steps, IDisposable
         // Assert
         started.NotificationSent.ShouldBeTrue();
         stopped.NotificationSent.ShouldBeFalse();
-#if NET8_0_OR_GREATER
         ex.ShouldNotBeNull().ShouldBeOfType<TaskCanceledException>();
-#else
-        ex.ShouldNotBeNull().ShouldBeOfType<OperationCanceledException>();
-#endif
     }
 
     private Task Cancel(Task t) => Task.Run(_ocelotClient.CancelPendingRequests);

--- a/test/Ocelot.AcceptanceTests/ServiceDiscovery/ConsulServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscovery/ConsulServiceDiscoveryTests.cs
@@ -594,13 +594,9 @@ public sealed partial class ConsulServiceDiscoveryTests : ConcurrentSteps, IDisp
     private void GivenTheServicesAreRegisteredWithConsul(params ServiceEntry[] serviceEntries) => _consulServices.AddRange(serviceEntries);
     private void GivenTheServiceNodesAreRegisteredWithConsul(params Node[] nodes) => _consulNodes.AddRange(nodes);
 
-#if NET7_0_OR_GREATER
     [GeneratedRegex("/v1/health/service/(?<serviceName>[^/]+)", RegexOptions.Singleline, RegexGlobal.DefaultMatchTimeoutMilliseconds)]
     private static partial Regex ServiceNameRegex();
-#else
-    private static readonly Regex ServiceNameRegexVar = RegexGlobal.New("/v1/health/service/(?<serviceName>[^/]+)", RegexOptions.Singleline);
-    private static Regex ServiceNameRegex() => ServiceNameRegexVar;
-#endif
+
     private void GivenThereIsAFakeConsulServiceDiscoveryProvider(string url)
     {
         _consulHandler.GivenThereIsAServiceRunningOn(url, async context =>


### PR DESCRIPTION
## Closes #2219:5
- #2219 (task 5)

## Proposed Changes
- **Removed** preprocessor directives for `Regex` objects, constructions targeted at old .NET6-7
