### PR TITLE
#2246 Review Core cache and redesign `Regex` caching

### DIFF
--- a/src/Ocelot.Cache.CacheManager/OcelotCacheManagerCache.cs
+++ b/src/Ocelot.Cache.CacheManager/OcelotCacheManagerCache.cs
@@ -37,4 +37,9 @@ public class OcelotCacheManagerCache<T> : IOcelotCache<T>
     {
         _cacheManager.ClearRegion(region);
     }
+
+    public bool TryGetValue(string key, string region, out T value)
+    {
+        return _cacheManager.TryGetOrAdd(key, region, (a, b) => default, out value);
+    }
 }

--- a/src/Ocelot/Cache/IOcelotCache.cs
+++ b/src/Ocelot/Cache/IOcelotCache.cs
@@ -9,4 +9,6 @@ public interface IOcelotCache<T>
     void ClearRegion(string region);
 
     void AddAndDelete(string key, T value, TimeSpan ttl, string region);
+
+    bool TryGetValue(string key, string region, out T value);
 }

--- a/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
@@ -1,4 +1,6 @@
+using Ocelot.Cache;
 using Ocelot.Configuration.File;
+using Ocelot.Infrastructure;
 using Ocelot.Values;
 
 namespace Ocelot.Configuration.Creator;
@@ -11,11 +13,16 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
     private const string RegExIgnoreCase = "(?i)";
     private const string RegExForwardSlashOnly = "^/$";
     private const string RegExForwardSlashAndOnePlaceHolder = "^/.*";
+    private readonly IOcelotCache<Regex> _cache;
+
+    public UpstreamTemplatePatternCreator(IOcelotCache<Regex> cache)
+    {
+        _cache = cache;
+    }
 
     public UpstreamPathTemplate Create(IRoute route)
     {
         var upstreamTemplate = route.UpstreamPathTemplate;
-
         var placeholders = new List<string>();
 
         for (var i = 0; i < upstreamTemplate.Length; i++)
@@ -27,10 +34,10 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
                 var placeHolderName = upstreamTemplate.Substring(i, difference);
                 placeholders.Add(placeHolderName);
 
-                //hack to handle /{url} case
+                // Hack to handle /{url} case
                 if (ForwardSlashAndOnePlaceHolder(upstreamTemplate, placeholders, postitionOfPlaceHolderClosingBracket))
                 {
-                    return new UpstreamPathTemplate(RegExForwardSlashAndOnePlaceHolder, 0, false, route.UpstreamPathTemplate);
+                    return CreateTemplate(RegExForwardSlashAndOnePlaceHolder, 0, false, route.UpstreamPathTemplate);
                 }
             }
         }
@@ -59,7 +66,7 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
 
         if (upstreamTemplate == "/")
         {
-            return new UpstreamPathTemplate(RegExForwardSlashOnly, route.Priority, containsQueryString, route.UpstreamPathTemplate);
+            return CreateTemplate(RegExForwardSlashOnly, route.Priority, containsQueryString, route.UpstreamPathTemplate);
         }
 
         var index = upstreamTemplate.LastIndexOf('/'); // index of last forward slash
@@ -77,21 +84,40 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
             ? $"^{upstreamTemplate}{RegExMatchEndString}"
             : $"^{RegExIgnoreCase}{upstreamTemplate}{RegExMatchEndString}";
 
-        return new UpstreamPathTemplate(template, route.Priority, containsQueryString, route.UpstreamPathTemplate);
+        return CreateTemplate(template, route.Priority, containsQueryString, route.UpstreamPathTemplate);
     }
 
-    private static bool ForwardSlashAndOnePlaceHolder(string upstreamTemplate, List<string> placeholders, int postitionOfPlaceHolderClosingBracket)
+    /// <summary>Time-to-live for caching <see cref="Regex"/> to initialize the <see cref="UpstreamPathTemplate.Pattern"/> property.</summary>
+    /// <value>A constant <see cref="TimeSpan"/> structure, default absolute value is 1 minute.</value>
+    public static TimeSpan RegexCachingTTL { get; } = TimeSpan.FromMinutes(1.0D);
+
+    protected Regex GetRegex(string key)
     {
-        if (upstreamTemplate.Substring(0, 2) == "/{" && placeholders.Count == 1 && upstreamTemplate.Length == postitionOfPlaceHolderClosingBracket + 1)
+        if (string.IsNullOrEmpty(key))
         {
-            return true;
+            return null;
         }
 
-        return false;
+        if (!_cache.TryGetValue(key, nameof(UpstreamPathTemplate), out var rgx))
+        {
+            rgx = RegexGlobal.New(key, RegexOptions.Singleline);
+            _cache.Add(key, rgx, RegexCachingTTL, nameof(UpstreamPathTemplate));
+        }
+
+        return rgx;
     }
 
+    protected UpstreamPathTemplate CreateTemplate(string template, int priority, bool containsQueryString, string originalValue)
+        => new(template, priority, containsQueryString, originalValue)
+        {
+            Pattern = GetRegex(template),
+        };
+
+    private static bool ForwardSlashAndOnePlaceHolder(string upstreamTemplate, List<string> placeholders, int postitionOfPlaceHolderClosingBracket)
+        => upstreamTemplate.Substring(0, 2) == "/{" &&
+            placeholders.Count == 1 &&
+            upstreamTemplate.Length == postitionOfPlaceHolderClosingBracket + 1;
+
     private static bool IsPlaceHolder(string upstreamTemplate, int i)
-    {
-        return upstreamTemplate[i] == '{';
-    }
+        => upstreamTemplate[i] == '{';
 }

--- a/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
@@ -89,7 +89,7 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
 
     /// <summary>Time-to-live for caching <see cref="Regex"/> to initialize the <see cref="UpstreamPathTemplate.Pattern"/> property.</summary>
     /// <value>A constant <see cref="TimeSpan"/> structure, default absolute value is 1 minute.</value>
-    public static TimeSpan RegexCachingTTL { get; } = TimeSpan.FromMinutes(1.0D);
+    public static TimeSpan RegexCachingTTL { get; set; } = TimeSpan.FromMinutes(1.0D);
 
     protected Regex GetRegex(string key)
     {

--- a/src/Ocelot/DependencyInjection/Features.cs
+++ b/src/Ocelot/DependencyInjection/Features.cs
@@ -30,6 +30,7 @@ public static class Features
     /// <param name="services">The services collection to add the feature to.</param>
     /// <returns>The same <see cref="IServiceCollection"/> object.</returns>
     public static IServiceCollection AddOcelotCache(this IServiceCollection services) => services
+        .AddSingleton<IOcelotCache<Regex>, DefaultMemoryCache<Regex>>()
         .AddSingleton<IOcelotCache<FileConfiguration>, DefaultMemoryCache<FileConfiguration>>()
         .AddSingleton<IOcelotCache<CachedResponse>, DefaultMemoryCache<CachedResponse>>()
         .AddSingleton<ICacheKeyGenerator, DefaultCacheKeyGenerator>()

--- a/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
+++ b/src/Ocelot/DownstreamRouteFinder/Finder/DownstreamRouteFinder.cs
@@ -37,8 +37,7 @@ public class DownstreamRouteFinder : IDownstreamRouteProvider
         {
             var urlMatch = _urlMatcher.Match(upstreamUrlPath, upstreamQueryString, route.UpstreamTemplatePattern);
             var headersMatch = _headerMatcher.Match(upstreamHeaders, route.UpstreamHeaderTemplates);
-
-            if (urlMatch.Data.Match && headersMatch)
+            if (urlMatch.Match && headersMatch)
             {
                 downstreamRoutes.Add(GetPlaceholderNamesAndValues(upstreamUrlPath, upstreamQueryString, route, upstreamHeaders));
             }

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/IUrlPathToUrlTemplateMatcher.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/IUrlPathToUrlTemplateMatcher.cs
@@ -1,9 +1,8 @@
-using Ocelot.Responses;
 using Ocelot.Values;
 
 namespace Ocelot.DownstreamRouteFinder.UrlMatcher;
 
 public interface IUrlPathToUrlTemplateMatcher
 {
-    Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate);
+    UrlMatch Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate);
 }

--- a/src/Ocelot/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcher.cs
+++ b/src/Ocelot/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcher.cs
@@ -1,21 +1,11 @@
-﻿using Ocelot.Responses;
-using Ocelot.Values;
+﻿using Ocelot.Values;
 
 namespace Ocelot.DownstreamRouteFinder.UrlMatcher;
 
 public class RegExUrlMatcher : IUrlPathToUrlTemplateMatcher
 {
-    public Response<UrlMatch> Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate)
-    {
-        if (!pathTemplate.ContainsQueryString)
-        {
-            return pathTemplate.Pattern.IsMatch(upstreamUrlPath)
-                ? new OkResponse<UrlMatch>(new UrlMatch(true))
-                : new OkResponse<UrlMatch>(new UrlMatch(false));
-        }
-
-        return pathTemplate.Pattern.IsMatch($"{upstreamUrlPath}{upstreamQueryString}")
-            ? new OkResponse<UrlMatch>(new UrlMatch(true))
-            : new OkResponse<UrlMatch>(new UrlMatch(false));
-    }
+    public UrlMatch Match(string upstreamUrlPath, string upstreamQueryString, UpstreamPathTemplate pathTemplate)
+        => !pathTemplate.ContainsQueryString
+            ? new(pathTemplate.Pattern.IsMatch(upstreamUrlPath))
+            : new(pathTemplate.Pattern.IsMatch($"{upstreamUrlPath}{upstreamQueryString}"));
 }

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
-using Ocelot.Infrastructure;
 using Ocelot.Logging;
 using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
@@ -83,7 +82,7 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
             }
             else
             {
-                RemoveQueryStringParametersThatHaveBeenUsedInTemplate2(downstreamRequest, placeholders);
+                RemoveQueryStringParametersThatHaveBeenUsedInTemplate(downstreamRequest, placeholders);
                 downstreamRequest.AbsolutePath = dsPath;
             }
         }
@@ -125,30 +124,6 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
     /// Added support for query string parameters in upstream path template.
     /// </summary>
     private static void RemoveQueryStringParametersThatHaveBeenUsedInTemplate(DownstreamRequest downstreamRequest, List<PlaceholderNameAndValue> templatePlaceholders)
-    {
-        foreach (var nAndV in templatePlaceholders)
-        {
-            var name = nAndV.Name.Trim(OpeningBrace, ClosingBrace);
-            var value = Regex.Escape(nAndV.Value); // to ensure a placeholder value containing special Regex characters from URL query parameters is safely used in a Regex constructor, it's necessary to escape the value
-            var pattern = $@"\b{name}={value}\b";
-            var rgx = _regex.AddOrUpdate(pattern,
-                        RegexGlobal.New(pattern),
-                        (key, oldValue) => oldValue);
-            if (rgx.IsMatch(downstreamRequest.Query))
-            {
-                var questionMarkOrAmpersand = downstreamRequest.Query.IndexOf(name, StringComparison.Ordinal);                    
-                downstreamRequest.Query = rgx.Replace(downstreamRequest.Query, string.Empty);
-                downstreamRequest.Query = downstreamRequest.Query.Remove(questionMarkOrAmpersand - 1, 1);
-
-                if (!string.IsNullOrEmpty(downstreamRequest.Query))
-                {
-                    downstreamRequest.Query = QuestionMark + downstreamRequest.Query[1..];
-                }
-            }
-        } 
-    }
-
-    private static void RemoveQueryStringParametersThatHaveBeenUsedInTemplate2(DownstreamRequest downstreamRequest, List<PlaceholderNameAndValue> templatePlaceholders)
     {
         var builder = new StringBuilder();
         foreach (var nAndV in templatePlaceholders)

--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -117,7 +117,6 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
     }
 
     private static string MapQueryParameter(KeyValuePair<string, string> pair) => $"{pair.Key}={pair.Value}";
-    private static readonly ConcurrentDictionary<string, Regex> _regex = new();
 
     /// <summary>
     /// Feature <see href="https://github.com/ThreeMammals/Ocelot/pull/467">467</see>:

--- a/src/Ocelot/Values/UpstreamPathTemplate.cs
+++ b/src/Ocelot/Values/UpstreamPathTemplate.cs
@@ -12,7 +12,6 @@ public partial class UpstreamPathTemplate
     private static readonly Regex _regexNoTemplate = RegexGlobal.New("$^", RegexOptions.Singleline);
     private static Regex RegexNoTemplate() => _regexNoTemplate;
 #endif
-    private static readonly ConcurrentDictionary<string, Regex> _regex = new();
 
     public UpstreamPathTemplate(string template, int priority, bool containsQueryString, string originalValue)
     {
@@ -20,19 +19,17 @@ public partial class UpstreamPathTemplate
         Priority = priority;
         ContainsQueryString = containsQueryString;
         OriginalValue = originalValue;
-        Pattern = template == null ? RegexNoTemplate() :
-            _regex.AddOrUpdate(template,
-                RegexGlobal.New(template, RegexOptions.Singleline),
-                (key, oldValue) => oldValue);
     }
 
     public string Template { get; }
-
     public int Priority { get; }
-
     public bool ContainsQueryString { get; }
-
     public string OriginalValue { get; }
 
-    public Regex Pattern { get; }
+    private Regex _pattern;
+    public Regex Pattern
+    {
+        get => _pattern;
+        set => _pattern = Template == null || value == null ? RegexNoTemplate() : value;
+    }
 }

--- a/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
+++ b/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
@@ -9,6 +9,7 @@ namespace Ocelot.AcceptanceTests.Core;
 /// TODO Move to separate Performance Testing (load testing) project.
 /// It requires the <see cref="Steps"/> class; therefore, both Steps-classes must be moved to the common Testing project.
 /// </summary>
+[Collection(nameof(SequentialTests))]
 public sealed class LoadTests : ConcurrentSteps, IDisposable
 {
     private readonly ServiceHandler _serviceHandler;

--- a/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
+++ b/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Configuration.File;
+using Ocelot.LoadBalancer.LoadBalancers;
+using System.Diagnostics;
+
+namespace Ocelot.AcceptanceTests.Core;
+
+public sealed class LoadTests : ConcurrentSteps, IDisposable
+{
+    private readonly ServiceHandler _serviceHandler;
+    private string _downstreamPath;
+    private string _downstreamQuery;
+
+    public LoadTests()
+    {
+        _serviceHandler = new();
+    }
+
+    public override void Dispose()
+    {
+        _serviceHandler.Dispose();
+        base.Dispose();
+    }
+
+    [Fact]
+    [Trait("Feat", "1348")]
+    [Trait("Bug", "2246")]
+    public async Task ShouldLoadRegexCachingHeavily_NoOutOfMemoryExceptions_NoMemoryLeaks()
+    {
+        var limit = Environment.GetEnvironmentVariable("DOTNET_GCHeapHardLimit");
+        var port = PortFinder.GetRandomPort();
+        var route = GivenRoute(port, "/my-gateway/order/{orderNumber}", "/order/{orderNumber}");
+        var configuration = GivenConfiguration(route);
+        GivenThereIsAConfiguration(configuration);
+        GivenOcelotIsRunning();
+        GivenThereIsAServiceRunningOn(port, "/order/", "Hello from Donny");
+
+        var currentProcess = Process.GetCurrentProcess();
+        long memoryUsage = currentProcess.WorkingSet64;
+        float memoryUsageMB = (float)memoryUsage / (1024 * 1024);
+
+        // Step 1: Measure memory consumption for constant upstream URL
+        GC.Collect();
+        var a = GC.GetGCMemoryInfo();
+        long step1TotalMemory = GC.GetTotalMemory(true);
+        long step1TotalBytes = GC.GetTotalAllocatedBytes();
+        long step1ThreadBytes = GC.GetAllocatedBytesForCurrentThread();
+
+        //.When(x => WhenIGetUrlOnTheApiGatewayConcurrently("/", 50))
+        //.When(x => RunParallelRequests(100_000, (i) => "/my-gateway/order/" + i))
+        await WhenIDoActionMultipleTimes(10_000, (i) => WhenIGetUrlOnTheApiGateway("/my-gateway/order/1")); // const url
+
+        GC.Collect();
+        step1TotalMemory = GC.GetTotalMemory(true);
+        step1TotalBytes = GC.GetTotalAllocatedBytes();
+        step1ThreadBytes = GC.GetAllocatedBytesForCurrentThread();
+        long memoryUsage1 = currentProcess.WorkingSet64;
+        float memoryUsageMB1 = (float)memoryUsage / (1024 * 1024);
+
+        await WhenIGetUrlOnTheApiGateway("/my-gateway/order/1");
+        ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+        ThenTheResponseBodyShouldBe("Hello from Donny");
+
+        // Step 2: Measure memory consumption for varying upstream URL
+        GC.Collect();
+        long step2TotalMemory = GC.GetTotalMemory(true);
+        long step2TotalBytes = GC.GetTotalAllocatedBytes();
+        long step2ThreadBytes = GC.GetAllocatedBytesForCurrentThread();
+
+        await WhenIDoActionMultipleTimes(10_000, (i) => WhenIGetUrlOnTheApiGateway("/my-gateway/order/" + i)); // varying url
+
+        GC.Collect();
+        step2TotalMemory = GC.GetTotalMemory(true);
+        step2TotalBytes = GC.GetTotalAllocatedBytes();
+        step2ThreadBytes = GC.GetAllocatedBytesForCurrentThread();
+        long memoryUsage2 = currentProcess.WorkingSet64;
+        float memoryUsageMB2 = (float)memoryUsage / (1024 * 1024);
+    }
+
+    private async Task WhenIGetUrlOnTheApiGatewaySequentially(int i)
+    {
+        //int count = i + 1;
+        await WhenIGetUrlOnTheApiGateway("/my-gateway/order/" + i);
+
+        //ThenTheStatusCodeShouldBe(HttpStatusCode.OK);
+        //ThenServiceShouldHaveBeenCalledTimes(0, count);
+        //ThenTheResponseBodyShouldBe($"{count}:{Bug2119ServiceNames[0]}", $"i is {i}");
+    }
+
+    private FileRoute GivenRoute(int port, string upstream, string downstream) => new()
+    {
+        DownstreamPathTemplate = string.IsNullOrEmpty(downstream) ? "/" : downstream,
+        DownstreamScheme = Uri.UriSchemeHttp,
+        UpstreamPathTemplate = string.IsNullOrEmpty(upstream) ? "/" : upstream,
+        UpstreamHttpMethod = new() { HttpMethods.Get },
+        LoadBalancerOptions = new() { Type = nameof(NoLoadBalancer) },
+        DownstreamHostAndPorts = new() { Localhost(port) },
+    };
+
+    private void GivenThereIsAServiceRunningOn(int port, string basePath, string responseBody)
+    {
+        var baseUrl = DownstreamUrl(port);
+        _serviceHandler.GivenThereIsAServiceRunningOn(baseUrl, basePath, MapGet);
+
+        async Task MapGet(HttpContext context)
+        {
+            _downstreamPath = !string.IsNullOrEmpty(context.Request.PathBase.Value)
+                ? context.Request.PathBase.Value + context.Request.Path.Value
+                : context.Request.Path.Value;
+            _downstreamQuery = context.Request.QueryString.HasValue ? context.Request.QueryString.Value : string.Empty;
+            var isOK = _downstreamPath.StartsWith(basePath);
+            context.Response.StatusCode = isOK ? (int)HttpStatusCode.OK : (int)HttpStatusCode.NotFound;
+            await context.Response.WriteAsync(isOK ? responseBody : nameof(HttpStatusCode.NotFound));
+        }
+    }
+}

--- a/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
+++ b/test/Ocelot.AcceptanceTests/Core/LoadTests.cs
@@ -27,7 +27,7 @@ public sealed class LoadTests : ConcurrentSteps, IDisposable
         base.Dispose();
     }
 
-    [Fact]
+    [Fact(Skip = "It should be moved to a separate project. It should be run during release only as an extra check for quality gates.")]
     [Trait("Feat", "1348")]
     [Trait("Bug", "2246")]
     public async Task ShouldLoadRegexCachingHeavily_NoMemoryLeaks()

--- a/test/Ocelot.AcceptanceTests/Routing/RoutingWithQueryStringTests.cs
+++ b/test/Ocelot.AcceptanceTests/Routing/RoutingWithQueryStringTests.cs
@@ -161,6 +161,7 @@ public sealed class RoutingWithQueryStringTests : Steps, IDisposable
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public void Should_return_response_200_with_query_string_upstream_template()
     {
         var subscriptionId = Guid.NewGuid().ToString();
@@ -181,6 +182,7 @@ public sealed class RoutingWithQueryStringTests : Steps, IDisposable
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public void Should_return_response_404_with_query_string_upstream_template_no_query_string()
     {
         var subscriptionId = Guid.NewGuid().ToString();
@@ -200,6 +202,7 @@ public sealed class RoutingWithQueryStringTests : Steps, IDisposable
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public void Should_return_response_404_with_query_string_upstream_template_different_query_string()
     {
         var subscriptionId = Guid.NewGuid().ToString();
@@ -219,6 +222,7 @@ public sealed class RoutingWithQueryStringTests : Steps, IDisposable
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public void Should_return_response_200_with_query_string_upstream_template_multiple_params()
     {
         var subscriptionId = Guid.NewGuid().ToString();

--- a/test/Ocelot.AcceptanceTests/ServiceDiscovery/ConsulConfigurationInConsulTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscovery/ConsulConfigurationInConsulTests.cs
@@ -482,5 +482,6 @@ public sealed class ConsulConfigurationInConsulTests : RateLimitingSteps, IDispo
         public FileConfiguration Get(string key, string region) => throw new NotImplementedException();
         public void ClearRegion(string region) => throw new NotImplementedException();
         public void AddAndDelete(string key, FileConfiguration value, TimeSpan ttl, string region) => throw new NotImplementedException();
+        public bool TryGetValue(string key, string region, out FileConfiguration value) => throw new NotImplementedException();
     }
 }

--- a/test/Ocelot.AcceptanceTests/Steps.cs
+++ b/test/Ocelot.AcceptanceTests/Steps.cs
@@ -24,6 +24,7 @@ using Ocelot.Tracing.Butterfly;
 using Ocelot.Tracing.OpenTracing;
 using Serilog;
 using Serilog.Core;
+using System.Diagnostics;
 using System.IO.Compression;
 using System.Net.Http.Headers;
 using System.Text;
@@ -731,6 +732,15 @@ public class Steps : IDisposable
     {
         for (int i = 0; i < times; i++)
             await action.Invoke(i);
+    }
+    public static async Task WhenIDoActionForTime(TimeSpan time, Func<int, Task> action)
+    {
+        var watcher = Stopwatch.StartNew();
+        for (int i = 0; watcher.Elapsed < time; i++)
+        {
+            await action.Invoke(i);
+        }
+        watcher.Stop();
     }
 
     public async Task WhenIGetUrlOnTheApiGateway(string url, string requestId)

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -1,19 +1,23 @@
+using Ocelot.Cache;
 using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
 using Ocelot.Values;
+using System.Text.RegularExpressions;
 
 namespace Ocelot.UnitTests.Configuration;
 
 public class UpstreamTemplatePatternCreatorTests : UnitTest
 {
     private FileRoute _fileRoute;
+    private readonly Mock<IOcelotCache<Regex>> _cache;
     private readonly UpstreamTemplatePatternCreator _creator;
     private UpstreamPathTemplate _result;
     private const string MatchEverything = UpstreamTemplatePatternCreator.RegExMatchZeroOrMoreOfEverything;
 
     public UpstreamTemplatePatternCreatorTests()
     {
-        _creator = new UpstreamTemplatePatternCreator();
+        _cache = new();
+        _creator = new UpstreamTemplatePatternCreator(_cache.Object);
     }
 
     [Fact]

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -2,6 +2,7 @@ using Ocelot.Cache;
 using Ocelot.Configuration.Creator;
 using Ocelot.Configuration.File;
 using Ocelot.Values;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Ocelot.UnitTests.Configuration;
@@ -238,6 +239,36 @@ public class UpstreamTemplatePatternCreatorTests : UnitTest
             .And(x => ThenThePriorityIs(1))
             .BDDfy();
     }
+
+    [Fact]
+    [Trait("Feat", "1348")]
+    [Trait("Bug", "2246")]
+    public void GetRegex_NoKey_ReturnsNull()
+    {
+        // Act
+        var actual = GetRegex.Invoke(_creator, new object[] { string.Empty });
+
+        // Assert
+        actual.ShouldBeNull();
+    }
+
+    [Fact]
+    [Trait("Feat", "1348")]
+    [Trait("Bug", "2246")]
+    public void CreateTemplate_PatternProperty_NullChecks()
+    {
+        // Act
+        string nullTemplate = null;
+        var actual = CreateTemplate.Invoke(_creator, new object[] { nullTemplate, 0, false, null }) as UpstreamPathTemplate;
+
+        // Assert
+        actual.ShouldNotBeNull();
+        actual.Pattern.ShouldNotBeNull().ToString().ShouldBe("$^");
+    }
+
+    private static Type Me { get; } = typeof(UpstreamTemplatePatternCreator);
+    private static MethodInfo GetRegex { get; } = Me.GetMethod(nameof(GetRegex), BindingFlags.NonPublic | BindingFlags.Instance);
+    private static MethodInfo CreateTemplate { get; } = Me.GetMethod(nameof(CreateTemplate), BindingFlags.NonPublic | BindingFlags.Instance);
 
     private void GivenTheFollowingFileRoute(FileRoute fileRoute)
     {

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/DownstreamRouteFinderTests.cs
@@ -20,7 +20,7 @@ public class DownstreamRouteFinderTests : UnitTest
     private Response<DownstreamRouteHolder> _result;
     private List<Route> _routesConfig;
     private InternalConfiguration _config;
-    private Response<UrlMatch> _match;
+    private UrlMatch _match;
     private string _upstreamHttpMethod;
     private string _upstreamHost;
     private Dictionary<string, string> _upstreamHeaders;
@@ -65,7 +65,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .WithUpstreamPathTemplate(new UpstreamPathTemplate("test", 0, false, "someUpstreamPath"))
                     .Build(),
             }, string.Empty, serviceProviderConfig))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -113,7 +113,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .WithUpstreamPathTemplate(new UpstreamPathTemplate("test", 1, false, "someUpstreamPath"))
                     .Build(),
             }, string.Empty, serviceProviderConfig))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -154,7 +154,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -199,7 +199,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -244,7 +244,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
                 ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -296,7 +296,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
                 ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -334,7 +334,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
                  }, string.Empty, serviceProviderConfig
              ))
-             .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(false))))
+             .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(false)))
              .And(x => x.GivenTheHeadersMatcherReturns(true))
              .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
              .When(x => x.WhenICallTheFinder())
@@ -368,7 +368,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
                 ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -411,7 +411,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
                 ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -454,7 +454,7 @@ public class DownstreamRouteFinderTests : UnitTest
                     .Build(),
             }, string.Empty, serviceProviderConfig
                 ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Post"))
             .When(x => x.WhenICallTheFinder())
@@ -488,7 +488,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -533,7 +533,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -587,7 +587,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -619,7 +619,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -651,7 +651,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -693,7 +693,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
             ))
-            .And(x => x.GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true))))
+            .And(x => x.GivenTheUrlMatcherReturns(new UrlMatch(true)))
             .And(x => x.GivenTheHeadersMatcherReturns(true))
             .And(x => x.GivenTheUpstreamHttpMethodIs("Get"))
             .When(x => x.WhenICallTheFinder())
@@ -756,7 +756,7 @@ public class DownstreamRouteFinderTests : UnitTest
             },
             string.Empty,
             serviceProviderConfig);
-        GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true)));
+        GivenTheUrlMatcherReturns(new UrlMatch(true));
         GivenTheHeadersMatcherReturns(true);
         GivenTheUpstreamHttpMethodIs("Get");
 
@@ -820,7 +820,7 @@ public class DownstreamRouteFinderTests : UnitTest
                         .Build(),
                 }, string.Empty, serviceProviderConfig
         );
-        GivenTheUrlMatcherReturns(new OkResponse<UrlMatch>(new UrlMatch(true)));
+        GivenTheUrlMatcherReturns(new UrlMatch(true));
         GivenTheHeadersMatcherReturns(false);
         GivenTheUpstreamHttpMethodIs("Get");
 
@@ -889,7 +889,7 @@ public class DownstreamRouteFinderTests : UnitTest
             .Verify(x => x.Match(_upstreamUrlPath, _upstreamQuery, _routesConfig[0].UpstreamTemplatePattern), Times.Never);
     }
 
-    private void GivenTheUrlMatcherReturns(Response<UrlMatch> match)
+    private void GivenTheUrlMatcherReturns(UrlMatch match)
     {
         _match = match;
         _mockUrlMatcher

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
@@ -1,6 +1,6 @@
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
-using Ocelot.Responses;
 using Ocelot.Values;
+using System.Text.RegularExpressions;
 
 namespace Ocelot.UnitTests.DownstreamRouteFinder.UrlMatcher;
 
@@ -268,7 +268,11 @@ public class RegExUrlMatcherTests : UnitTest
 
     private void WhenIMatchThePaths()
     {
-        _result = _urlMatcher.Match(_path, _queryString, new UpstreamPathTemplate(_downstreamPathTemplate, 0, _containsQueryString, _downstreamPathTemplate));
+        var upt = new UpstreamPathTemplate(_downstreamPathTemplate, 0, _containsQueryString, _downstreamPathTemplate)
+        {
+            Pattern = new Regex(_downstreamPathTemplate),
+        };
+        _result = _urlMatcher.Match(_path, _queryString, upt);
     }
 
     private void ThenTheResultIsTrue()

--- a/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamRouteFinder/UrlMatcher/RegExUrlMatcherTests.cs
@@ -9,7 +9,7 @@ public class RegExUrlMatcherTests : UnitTest
     private readonly IUrlPathToUrlTemplateMatcher _urlMatcher;
     private string _path;
     private string _downstreamPathTemplate;
-    private Response<UrlMatch> _result;
+    private UrlMatch _result;
     private string _queryString;
     private bool _containsQueryString;
 
@@ -273,12 +273,12 @@ public class RegExUrlMatcherTests : UnitTest
 
     private void ThenTheResultIsTrue()
     {
-        _result.Data.Match.ShouldBeTrue();
+        _result.Match.ShouldBeTrue();
     }
 
     private void ThenTheResultIsFalse()
     {
-        _result.Data.Match.ShouldBeFalse();
+        _result.Match.ShouldBeFalse();
     }
 
     private void GivenThereIsAQueryInTemplate()

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -72,6 +72,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public async Task Should_replace_query_string()
     {
         // Arrange
@@ -106,6 +107,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public async Task Should_replace_query_string_but_leave_non_placeholder_queries()
     {
         // Arrange
@@ -140,6 +142,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
     }
 
     [Fact]
+    [Trait("Bug", "1288")]
     public async Task Should_replace_query_string_but_leave_non_placeholder_queries_2()
     {
         // Arrange
@@ -174,6 +177,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
     }
 
     [Fact]
+    [Trait("Feat", "467")]
     public async Task Should_replace_query_string_exact_match()
     {
         // Arrange


### PR DESCRIPTION
## Fixes #2246 
- #2246 

## Proposed Changes
- Added [new useful method](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-7949d38e4031bedef830aa9e66e90fa889d8a91f2dd721474afa44298fc19bc3) to the `IOcelotCache<T>` interface: `bool TryGetValue(string, string, out T)`.
  As a result, the `Ocelot.Cache.CacheManager` package must be released❗

- Refactored the `DefaultMemoryCache<T>` [class](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-39dba9f48feb2d777e320658cf4b78f7652473303ed759f20020387fe78d11bc) to use [concurrent collections](https://learn.microsoft.com/en-us/dotnet/standard/collections/thread-safe/) for regions, as the previous ones were not thread-safe.

- Proposed implementing a real cache in the `UpstreamTemplatePatternCreator` [class](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-611108f6b3268be0a8735448eb7b2b23e994a1bbf18b4a99794a9f720cdd121a) to initialize the `Pattern` property of the class with a cached `Regex` object when the `UpstreamPathTemplate` is being [created](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-611108f6b3268be0a8735448eb7b2b23e994a1bbf18b4a99794a9f720cdd121aR110).
 Note that the design with a [static concurrent dictionary](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-b1ed8ca396a12fce0c65f0ba5b9617ce4e8cabb7443d93fecb49ff0c16169fe3) was acceptable due to the constant number of routes (and `Regex` objects) in the collection. However, for dynamic routing scenarios, it is better to switch to a real caching design for future use.

- ❗Resolved memory leak in the `DownstreamUrlCreatorMiddleware` [class](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-f5a2c3a941a7f201a4cead9eb4f489229f0740cf4e1166d0b8ff1670e2ce30a5) by refactoring the `RemoveQueryStringParametersThatHaveBeenUsedInTemplate` method, where all `Regex` objects were saved into `_regex`, an internal static collection❗ This faulty design was unfortunately released in version [23.4.0](https://github.com/ThreeMammals/Ocelot/releases/tag/23.4.0) as PR #1348❗ We must learn from this incident because sometimes optimizations for CPU may adversely affect memory consumption 🙈 
  Ultimately, the algorithm was refactored to remove `Regex` in favor of `StringBuilder`.

- Refactored the `IUrlPathToUrlTemplateMatcher` [interface](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-3969c162a34a520c506b7d9cc25e486093ba63a43189da07c36502f6055e2eaa), the `UrlMatch` class, and the associated logic.

- Added [load test](https://github.com/ThreeMammals/Ocelot/pull/2251/files#diff-92523ee19c04c9317599750f155cba937dc1bc8664475e6229f24b4858516212) to reproduce the problem with a memory leak. It helped to develop the fix. It should not run in the CI/CD environment because it consumes high CPU resources; thus, the test is skipped.