### PR TITLE
Removed ambiguity from ISecurityPolicy.

### DIFF
--- a/src/Ocelot/Security/ISecurityPolicy.cs
+++ b/src/Ocelot/Security/ISecurityPolicy.cs
@@ -6,6 +6,5 @@ namespace Ocelot.Security;
 
 public interface ISecurityPolicy
 {
-    Response Security(DownstreamRoute downstreamRoute, HttpContext context);
-    Task<Response> SecurityAsync(DownstreamRoute downstreamRoute, HttpContext context);
+    ValueTask<Response> SecurityAsync(DownstreamRoute downstreamRoute, HttpContext context);
 }

--- a/src/Ocelot/Security/Middleware/SecurityMiddleware.cs
+++ b/src/Ocelot/Security/Middleware/SecurityMiddleware.cs
@@ -26,7 +26,7 @@ public class SecurityMiddleware : OcelotMiddleware
         {
             foreach (var policy in _securityPolicies)
             {
-                var result = policy.Security(downstreamRoute, httpContext);
+                var result = await policy.SecurityAsync(downstreamRoute, httpContext);
                 if (!result.IsError)
                 {
                     continue;

--- a/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
+++ b/test/Ocelot.UnitTests/Security/IPSecurityPolicyTests.cs
@@ -28,360 +28,360 @@ public sealed class IPSecurityPolicyTests : UnitTest
     }
 
     [Fact]
-    public void Should_No_blocked_Ip_and_allowed_Ip()
+    public async Task Should_No_blocked_Ip_and_allowed_Ip()
     {
         // Arrange, Act
-        var actual = WhenTheSecurityPolicy(new());
+        var actual = await WhenTheSecurityPolicy(new());
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_blockedIp_clientIp_block()
+    public async Task Should_blockedIp_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.1");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_blockedIp_clientIp_Not_block()
+    public async Task Should_blockedIp_clientIp_Not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.1");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_allowedIp_clientIp_block()
+    public async Task Should_allowedIp_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
         var options = new FileSecurityOptions("192.168.1.1");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_allowedIp_clientIp_Not_block()
+    public async Task Should_allowedIp_clientIp_Not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.2")[0];
         var options = new FileSecurityOptions("192.168.1.1");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_cidrNotation_allowed24_clientIp_block()
+    public async Task Should_cidrNotation_allowed24_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.5")[0];
         var options = new FileSecurityOptions("192.168.1.0/24");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_cidrNotation_allowed24_clientIp_not_block()
+    public async Task Should_cidrNotation_allowed24_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
         var options = new FileSecurityOptions("192.168.1.0/24");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_cidrNotation_allowed29_clientIp_block()
+    public async Task Should_cidrNotation_allowed29_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
         var options = new FileSecurityOptions("192.168.1.0/29");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_cidrNotation_blocked24_clientIp_block()
+    public async Task Should_cidrNotation_blocked24_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.1")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/24");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_cidrNotation_blocked24_clientIp_not_block()
+    public async Task Should_cidrNotation_blocked24_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/24");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_range_allowed_clientIp_block()
+    public async Task Should_range_allowed_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions("192.168.1.0-192.168.1.10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_range_allowed_clientIp_not_block()
+    public async Task Should_range_allowed_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
         var options = new FileSecurityOptions("192.168.1.0-192.168.1.10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_range_blocked_clientIp_block()
+    public async Task Should_range_blocked_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_range_blocked_clientIp_not_block()
+    public async Task Should_range_blocked_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-192.168.1.10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_shortRange_allowed_clientIp_block()
+    public async Task Should_shortRange_allowed_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions("192.168.1.0-10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_shortRange_allowed_clientIp_not_block()
+    public async Task Should_shortRange_allowed_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.8")[0];
         var options = new FileSecurityOptions("192.168.1.0-10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_shortRange_blocked_clientIp_block()
+    public async Task Should_shortRange_blocked_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.5")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_shortRange_blocked_clientIp_not_block()
+    public async Task Should_shortRange_blocked_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0-10");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_ipSubnet_allowed_clientIp_block()
+    public async Task Should_ipSubnet_allowed_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.15")[0];
         var options = new FileSecurityOptions("192.168.1.0/255.255.255.0");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_ipSubnet_allowed_clientIp_not_block()
+    public async Task Should_ipSubnet_allowed_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions("192.168.1.0/255.255.255.0");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_ipSubnet_blocked_clientIp_block()
+    public async Task Should_ipSubnet_blocked_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.15")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_ipSubnet_blocked_clientIp_not_block()
+    public async Task Should_ipSubnet_blocked_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.10.1")[0];
         var options = new FileSecurityOptions(blockedIPs: "192.168.1.0/255.255.255.0");
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
+    public async Task Should_exludeAllowedFromBlocked_moreAllowed_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
         var options = new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", false);
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
+    public async Task Should_exludeAllowedFromBlocked_moreAllowed_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.150")[0];
         var options = new FileSecurityOptions("192.168.0.0/255.255.0.0", "192.168.1.100-200", true);
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
     [Fact]
-    public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
+    public async Task Should_exludeAllowedFromBlocked_moreBlocked_clientIp_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
         var options = new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", false);
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.True(actual.IsError);
     }
 
     [Fact]
-    public void Should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
+    public async Task Should_exludeAllowedFromBlocked_moreBlocked_clientIp_not_block()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
         var options = new FileSecurityOptions("192.168.1.10-20", "192.168.1.0/23", true);
 
         // Act
-        var actual = WhenTheSecurityPolicy(options);
+        var actual = await WhenTheSecurityPolicy(options);
 
         // Assert
         Assert.False(actual.IsError);
@@ -389,7 +389,7 @@ public sealed class IPSecurityPolicyTests : UnitTest
 
     [Fact]
     [Trait("Feat", "2170")]
-    public void Should_route_config_overrides_global_config()
+    public async Task Should_route_config_overrides_global_config()
     {
         // Arrange
         _context.Connection.RemoteIpAddress = Dns.GetHostAddresses("192.168.1.10")[0];
@@ -400,13 +400,13 @@ public sealed class IPSecurityPolicyTests : UnitTest
         var localConfig = new FileSecurityOptions("192.168.1.10", "", false);
 
         // Act
-        var actual = WhenTheSecurityPolicy(localConfig, globalConfig);
+        var actual = await WhenTheSecurityPolicy(localConfig, globalConfig);
 
         // Assert
         Assert.False(actual.IsError);
     }
 
-    private Response WhenTheSecurityPolicy(FileSecurityOptions options, FileGlobalConfiguration global = null)
+    private ValueTask<Response> WhenTheSecurityPolicy(FileSecurityOptions options, FileGlobalConfiguration global = null)
     {
         // Arrange
         var securityOptions = _securityOptionsCreator.Create(options, global ?? Empty);
@@ -414,6 +414,6 @@ public sealed class IPSecurityPolicyTests : UnitTest
         _context.Items.UpsertDownstreamRoute(_downstreamRouteBuilder.Build());
 
         // Act
-        return _policy.Security(_context.Items.DownstreamRoute(), _context);
+        return _policy.SecurityAsync(_context.Items.DownstreamRoute(), _context);
     }
 }

--- a/test/Ocelot.UnitTests/Security/SecurityMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/Security/SecurityMiddlewareTests.cs
@@ -64,8 +64,8 @@ public sealed class SecurityMiddlewareTests : UnitTest
     {
         foreach (var item in _securityPolicyList)
         {
-            Response response = new OkResponse();
-            item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
+            ValueTask<Response> responseTask = ValueTask.FromResult<Response>(new OkResponse());
+            item.Setup(x => x.SecurityAsync(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(responseTask);
         }
     }
 
@@ -77,13 +77,13 @@ public sealed class SecurityMiddlewareTests : UnitTest
             if (i == 0)
             {
                 Error error = new UnauthenticatedError("Not passing security verification");
-                Response response = new ErrorResponse(error);
-                item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
+                ValueTask<Response> responseTask = ValueTask.FromResult<Response>(new ErrorResponse(error));
+                item.Setup(x => x.SecurityAsync(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(responseTask);
             }
             else
             {
-                Response response = new OkResponse();
-                item.Setup(x => x.Security(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(response);
+                ValueTask<Response> responseTask = ValueTask.FromResult<Response>(new OkResponse());
+                item.Setup(x => x.SecurityAsync(_httpContext.Items.DownstreamRoute(), _httpContext)).Returns(responseTask);
             }
         }
     }


### PR DESCRIPTION
# Streamlined ISecurityPolicy interface

## Proposed Changes

  - Removes synchronous function from ISecurityPolicy for clarity.
  - Adjusts implementation in IPSecurityPolicy class accordingly.
  - Updates affected unit tests.
