### PR TITLE
Upgrade to KubeClient v3 and log failed Kubernetes API requests

### DIFF
--- a/docs/features/kubernetes.rst
+++ b/docs/features/kubernetes.rst
@@ -36,7 +36,7 @@ The first thing you need to do is install the `package`_ that provides |kubernet
     Install-Package Ocelot.Provider.Kubernetes
 
 ``AddKubernetes(bool)`` method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------
 
 .. code-block:: csharp
   :emphasize-lines: 3
@@ -84,19 +84,40 @@ If you have services deployed in Kubernetes, you will normally use the naming se
      };
      builder.Services
          .AddOptions<KubeClientOptions>()
-         .Configure(configureKubeClient); // mannual binding options via IOptions<KubeClientOptions>
+         .Configure(configureKubeClient); // manual binding options via IOptions<KubeClientOptions>
      builder.Services
          .AddOcelot(builder.Configuration)
          .AddKubernetes(false); // don't use pod service account, and IOptions<KubeClientOptions> is reused
 
+   .. _break: http://break.do
+
+      **Note**, this could also be written like this (shortened version):
+
+      .. code-block:: csharp
+        :emphasize-lines: 2, 10
+
+        builder.Services
+            .AddKubeClientOptions(opts =>
+            {
+                opts.ApiEndPoint = new UriBuilder("https", "my-host", 443).Uri;
+                opts.AuthStrategy = KubeAuthStrategy.BearerToken;
+                opts.AccessToken = "my-token";
+                opts.AllowInsecure = true;
+            })
+            .AddOcelot(builder.Configuration)
+            .AddKubernetes(false); // don't use pod service account, and client options provided via AddKubeClientOptions
+
    Finally, it creates the `KubeClient`_ from your options.
 
-     **Note**: For understanding the ``IOptions<TOptions>`` interface, please refer to the Microsoft Learn documentation: `Options pattern in .NET <https://learn.microsoft.com/en-us/dotnet/core/extensions/options>`_.
+    **Note 1**: For understanding the ``IOptions<TOptions>`` interface, please refer to the Microsoft Learn documentation: `Options pattern in .NET <https://learn.microsoft.com/en-us/dotnet/core/extensions/options>`_.
+
+    **Note 2**: Please consider this Case 2 as an example of manual setup when you **do not** use a pod service account.
+    We recommend using our official extension method, which receives an ``Action<KubeClientOptions>`` argument with your options: refer to the :ref:`k8s-addkubernetes-action-method` below.
 
 .. _k8s-addkubernetes-action-method:
 
 ``AddKubernetes(Action<KubeClientOptions>)`` method [#f2]_
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------------------
 
 .. code-block:: csharp
   :emphasize-lines: 3

--- a/samples/Kubernetes/ApiGateway/Program.cs
+++ b/samples/Kubernetes/ApiGateway/Program.cs
@@ -10,7 +10,7 @@ builder.Configuration
     .SetBasePath(builder.Environment.ContentRootPath)
     .AddOcelot();
 
-goto Case4; // Your case should be selected here!!!
+goto Case5; // Your case should be selected here!!!
 
 // Link: https://github.com/ThreeMammals/Ocelot/blob/develop/docs/features/kubernetes.rst#addkubernetes-bool-method
 Case1: // Use a pod service account
@@ -36,7 +36,7 @@ builder.Services
 goto Start;
 
 // Link: https://github.com/ThreeMammals/Ocelot/blob/develop/docs/features/kubernetes.rst#addkubernetes-action-kubeclientoptions-method
-Case3: // Use global ServiceDiscoveryProvider json-options
+Case3: // Don't use a pod service account, manually bind options, ignore global ServiceDiscoveryProvider json-options
 Action<KubeClientOptions> myOptions = opts =>
 {
     opts.ApiEndPoint = new UriBuilder(Uri.UriSchemeHttps, "my-host", 443).Uri;
@@ -49,8 +49,21 @@ builder.Services
     .AddKubernetes(myOptions); // configure options with action, without optional args
 goto Start;
 
+Case4: // Don't use a pod service account, manually bind options, ignore global ServiceDiscoveryProvider json-options
+builder.Services
+    .AddKubeClientOptions(opts =>
+    {
+        opts.ApiEndPoint = new UriBuilder("https", "my-host", 443).Uri;
+        opts.AuthStrategy = KubeAuthStrategy.BearerToken;
+        opts.AccessToken = "my-token";
+        opts.AllowInsecure = true;
+    })
+    .AddOcelot(builder.Configuration)
+    .AddKubernetes(false); // don't use pod service account, and client options provided via AddKubeClientOptions
+goto Start;
+
 // Link: https://github.com/ThreeMammals/Ocelot/blob/develop/docs/features/kubernetes.rst#addkubernetes-action-kubeclientoptions-method
-Case4: // Use global ServiceDiscoveryProvider json-options
+Case5: // Use global ServiceDiscoveryProvider json-options
 Action<KubeClientOptions>? none = null;
 builder.Services
     .AddOcelot(builder.Configuration)

--- a/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
+++ b/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
@@ -13,7 +13,7 @@ public class EndPointClientV1 : KubeResourceClient, IEndPointClient
     {
     }
 
-    public async Task<EndpointsV1> GetAsync(string serviceName, string kubeNamespace = null, CancellationToken cancellationToken = default)
+    public Task<EndpointsV1> GetAsync(string serviceName, string kubeNamespace = null, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(serviceName))
         {
@@ -27,7 +27,7 @@ public class EndPointClientV1 : KubeResourceClient, IEndPointClient
                 ServiceName = serviceName,
             });
 
-        return await Http.GetAsync(request, cancellationToken)
+        return Http.GetAsync(request, cancellationToken)
             .ReadContentAsObjectV1Async<EndpointsV1>(operationDescription: $"get {nameof(EndpointsV1)}");
     }
 }

--- a/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
+++ b/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
@@ -35,10 +35,10 @@ public class EndPointClientV1 : KubeResourceClient, IEndPointClient
 
         if (!response.IsSuccessStatusCode)
         {
-            StatusV1 errorResponse = await response.ReadContentAsAsync<StatusV1>();
-
             if (_logger.IsEnabled(LogLevel.Debug))
             {
+                StatusV1 errorResponse = await response.ReadContentAsAsync<StatusV1>();
+
                 (string resourceKind, string resourceApiVersion) = KubeObjectV1.GetKubeKind<EndpointsV1>();
                 _logger.LogDebug("Failed to retrieve {ResourceApiVersion}/{ResourceKind} {ResourceName} in namespace {ResourceNamespace} ({HttpStatusCode}/{Status}/{StatusReason}): {StatusMessage}",
                     resourceApiVersion,

--- a/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
+++ b/src/Ocelot.Provider.Kubernetes/EndPointClientV1.cs
@@ -1,7 +1,6 @@
 ﻿using KubeClient.Http;
 using KubeClient.Models;
 using KubeClient.ResourceClients;
-using Microsoft.Extensions.Logging;
 using Ocelot.Provider.Kubernetes.Interfaces;
 
 namespace Ocelot.Provider.Kubernetes;
@@ -10,11 +9,8 @@ public class EndPointClientV1 : KubeResourceClient, IEndPointClient
 {
     private static readonly HttpRequest Collection = KubeRequest.Create("api/v1/namespaces/{Namespace}/endpoints/{ServiceName}");
 
-    private readonly ILogger _logger;
-
     public EndPointClientV1(IKubeApiClient client) : base(client)
     {
-        _logger = client.LoggerFactory.CreateLogger<EndPointClientV1>();
     }
 
     public async Task<EndpointsV1> GetAsync(string serviceName, string kubeNamespace = null, CancellationToken cancellationToken = default)
@@ -31,30 +27,7 @@ public class EndPointClientV1 : KubeResourceClient, IEndPointClient
                 ServiceName = serviceName,
             });
 
-        var response = await Http.GetAsync(request, cancellationToken);
-
-        if (!response.IsSuccessStatusCode)
-        {
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                StatusV1 errorResponse = await response.ReadContentAsAsync<StatusV1>();
-
-                (string resourceKind, string resourceApiVersion) = KubeObjectV1.GetKubeKind<EndpointsV1>();
-                _logger.LogDebug("Failed to retrieve {ResourceApiVersion}/{ResourceKind} {ResourceName} in namespace {ResourceNamespace} ({HttpStatusCode}/{Status}/{StatusReason}): {StatusMessage}",
-                    resourceApiVersion,
-                    resourceKind,
-                    serviceName,
-                    kubeNamespace,
-                    response.StatusCode,
-                    errorResponse.Status,
-                    errorResponse.Reason,
-                    errorResponse.Message
-                );
-            }
-
-            return null;
-        }
-
-        return await response.ReadContentAsAsync<EndpointsV1>();
+        return await Http.GetAsync(request, cancellationToken)
+            .ReadContentAsObjectV1Async<EndpointsV1>(operationDescription: $"get {nameof(EndpointsV1)}");
     }
 }

--- a/src/Ocelot.Provider.Kubernetes/Kube.cs
+++ b/src/Ocelot.Provider.Kubernetes/Kube.cs
@@ -70,16 +70,16 @@ public class Kube : IServiceDiscoveryProvider
                     httpStatusCode = httpRequestError.StatusCode.ToString();
                 }
 
-                return $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} {serviceName} in namespace {kubeNamespace} ({httpStatusCode}/{errorResponse.Status}/{errorResponse.Reason}): {errorResponse.Message}";
+                return $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} '{serviceName}' in namespace '{kubeNamespace}' (HTTP.{httpStatusCode}/{errorResponse.Status}/{errorResponse.Reason}): {errorResponse.Message}";
             }, kubeApiError);
         }
         catch (HttpRequestException unexpectedRequestError)
         {
-            _logger.LogError(() => $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} {serviceName} in namespace {kubeNamespace} ({unexpectedRequestError.HttpRequestError}/{unexpectedRequestError.StatusCode}).", unexpectedRequestError);
+            _logger.LogError(() => $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} '{serviceName}' in namespace '{kubeNamespace}' ({unexpectedRequestError.HttpRequestError}/HTTP.{unexpectedRequestError.StatusCode}).", unexpectedRequestError);
         }
         catch (Exception unexpectedError)
         {
-            _logger.LogError(() => $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} {serviceName} in namespace {kubeNamespace} (an unexpected error occurred).", unexpectedError);
+            _logger.LogError(() => $"Failed to retrieve {EndPointsKubeKind.ResourceApiVersion}/{EndPointsKubeKind.ResourceKind} '{serviceName}' in namespace '{kubeNamespace}' (an unexpected error occurred).", unexpectedError);
         }
 
         return null;

--- a/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
+++ b/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
@@ -25,8 +25,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="KubeClient" Version="2.5.12" />
-    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="2.5.12" />
+    <PackageReference Include="KubeClient" Version="3.0.0" />
+    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
+++ b/src/Ocelot.Provider.Kubernetes/Ocelot.Provider.Kubernetes.csproj
@@ -25,8 +25,8 @@
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="KubeClient" Version="3.0.0" />
-    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="KubeClient" Version="3.0.1" />
+    <PackageReference Include="KubeClient.Extensions.DependencyInjection" Version="3.0.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+++ b/test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
@@ -73,14 +73,14 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
@@ -88,6 +88,6 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 9.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.3" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubernetesServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubernetesServiceDiscoveryTests.cs
@@ -1,5 +1,6 @@
 ﻿using KubeClient;
 using KubeClient.Models;
+using KubeClient.ResourceClients;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -324,7 +325,7 @@ public sealed class KubernetesServiceDiscoveryTests : ConcurrentSteps, IDisposab
                     }
 
                     endpoints.Metadata.Generation = _k8sServiceGeneration;
-                    json = JsonConvert.SerializeObject(endpoints);
+                    json = JsonConvert.SerializeObject(endpoints, KubeResourceClient.SerializerSettings);
                 }
 
                 if (context.Request.Headers.TryGetValue("Authorization", out var values))

--- a/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubernetesServiceDiscoveryTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubernetesServiceDiscoveryTests.cs
@@ -1,5 +1,6 @@
 ﻿using KubeClient;
 using KubeClient.Models;
+using KubeClient.ResourceClients;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -147,7 +148,7 @@ public sealed class KubernetesServiceDiscoveryTests : ConcurrentSteps, IDisposab
     {
         int failPerThreads = (totalRequests / k8sGeneration) - 1; // k8sGeneration means number of offline services
         var (endpoints, servicePorts) = ArrangeHighLoadOnKubeProviderAndRoundRobinBalancer(totalServices);
-        GivenThereIsAFakeKubernetesProvider(endpoints, false, k8sGeneration, failPerThreads); // false means unstable, k8sGeneration services will be removed from the list
+        GivenThereIsAFakeKubernetesProvider(endpoints, HttpStatusCode.OK, false, k8sGeneration, failPerThreads); // false means unstable, k8sGeneration services will be removed from the list
 
         HighlyLoadOnKubeProviderAndRoundRobinBalancer(totalRequests, k8sGeneration);
 
@@ -293,9 +294,13 @@ public sealed class KubernetesServiceDiscoveryTests : ConcurrentSteps, IDisposab
 
     private void GivenThereIsAFakeKubernetesProvider(EndpointsV1 endpoints,
         [CallerMemberName] string serviceName = nameof(KubernetesServiceDiscoveryTests), string namespaces = nameof(KubernetesServiceDiscoveryTests))
-        => GivenThereIsAFakeKubernetesProvider(endpoints, true, 0, 0, serviceName, namespaces);
+        => GivenThereIsAFakeKubernetesProvider(endpoints, responseStatusCode: HttpStatusCode.OK, serviceName, namespaces);
 
-    private void GivenThereIsAFakeKubernetesProvider(EndpointsV1 endpoints, bool isStable, int offlineServicesNo, int offlinePerThreads,
+    private void GivenThereIsAFakeKubernetesProvider(EndpointsV1 endpoints, HttpStatusCode responseStatusCode,
+        [CallerMemberName] string serviceName = nameof(KubernetesServiceDiscoveryTests), string namespaces = nameof(KubernetesServiceDiscoveryTests))
+        => GivenThereIsAFakeKubernetesProvider(endpoints, responseStatusCode, isStable: true, offlineServicesNo: 0, offlinePerThreads: 0, serviceName, namespaces);
+
+    private void GivenThereIsAFakeKubernetesProvider(EndpointsV1 endpoints, HttpStatusCode responseStatusCode, bool isStable, int offlineServicesNo, int offlinePerThreads,
         [CallerMemberName] string serviceName = nameof(KubernetesServiceDiscoveryTests), string namespaces = nameof(KubernetesServiceDiscoveryTests))
     {
         _k8sCounter = 0;
@@ -308,23 +313,38 @@ public sealed class KubernetesServiceDiscoveryTests : ConcurrentSteps, IDisposab
                 lock (K8sCounterLocker)
                 {
                     _k8sCounter++;
-                    var subset = endpoints.Subsets[0];
 
-                    // Each offlinePerThreads-th request to integrated K8s endpoint should fail
-                    if (!isStable && _k8sCounter % offlinePerThreads == 0 && _k8sCounter >= offlinePerThreads)
+                    if (responseStatusCode == HttpStatusCode.OK)
                     {
-                        while (offlineServicesNo-- > 0)
+                        var subset = endpoints.Subsets[0];
+
+                        // Each offlinePerThreads-th request to integrated K8s endpoint should fail
+                        if (!isStable && _k8sCounter % offlinePerThreads == 0 && _k8sCounter >= offlinePerThreads)
                         {
-                            int index = subset.Addresses.Count - 1; // Random.Shared.Next(0, subset.Addresses.Count - 1);
-                            subset.Addresses.RemoveAt(index);
-                            subset.Ports.RemoveAt(index);
+                            while (offlineServicesNo-- > 0)
+                            {
+                                int index = subset.Addresses.Count - 1; // Random.Shared.Next(0, subset.Addresses.Count - 1);
+                                subset.Addresses.RemoveAt(index);
+                                subset.Ports.RemoveAt(index);
+                            }
+
+                            _k8sServiceGeneration++;
                         }
 
-                        _k8sServiceGeneration++;
+                        endpoints.Metadata.Generation = _k8sServiceGeneration;
+                        json = JsonConvert.SerializeObject(endpoints, KubeResourceClient.SerializerSettings);
                     }
-
-                    endpoints.Metadata.Generation = _k8sServiceGeneration;
-                    json = JsonConvert.SerializeObject(endpoints);
+                    else
+                    {
+                        StatusV1 errorResponse = new()
+                        {
+                            Code = context.Response.StatusCode,
+                            Reason = responseStatusCode.ToString(),
+                            Message = "This is an error response from the fake Kubernetes API.",
+                            Status = StatusV1.FailureStatus,
+                        };
+                        json = JsonConvert.SerializeObject(_k8sServiceGeneration, KubeResourceClient.SerializerSettings);
+                    }
                 }
 
                 if (context.Request.Headers.TryGetValue("Authorization", out var values))
@@ -332,6 +352,7 @@ public sealed class KubernetesServiceDiscoveryTests : ConcurrentSteps, IDisposab
                     _receivedToken = values.First();
                 }
 
+                context.Response.StatusCode = (int)responseStatusCode;
                 context.Response.Headers.Append("Content-Type", "application/json");
                 await context.Response.WriteAsync(json);
             }

--- a/test/Ocelot.IntegrationTests/Ocelot.IntegrationTests.csproj
+++ b/test/Ocelot.IntegrationTests/Ocelot.IntegrationTests.csproj
@@ -54,14 +54,14 @@
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="IdentityServer4" Version="4.1.2" />
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Data.SQLite" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Data.SQLite" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
   </ItemGroup>
 </Project>

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -7,7 +7,6 @@ using Newtonsoft.Json;
 using Ocelot.Logging;
 using Ocelot.Provider.Kubernetes;
 using Ocelot.Provider.Kubernetes.Interfaces;
-using Ocelot.Testing;
 using Ocelot.Values;
 using System.Runtime.CompilerServices;
 
@@ -19,6 +18,8 @@ namespace Ocelot.UnitTests.Kubernetes;
 /// </summary>
 public class KubeTests : FileUnitTest
 {
+    static JsonSerializerSettings JsonSerializerSettings => KubeClient.ResourceClients.KubeResourceClient.SerializerSettings;
+
     private readonly Mock<IOcelotLoggerFactory> _factory;
     private readonly Mock<IOcelotLogger> _logger;
 
@@ -43,6 +44,7 @@ public class KubeTests : FileUnitTest
             given.ClientOptions.ApiEndPoint.ToString(),
             given.ProviderOptions.KubeNamespace,
             given.ProviderOptions.KeyOfServiceInK8s,
+            responseStatusCode: HttpStatusCode.OK,
             endpoints,
             out Lazy<string> receivedToken);
 
@@ -52,6 +54,66 @@ public class KubeTests : FileUnitTest
         // Assert
         services.ShouldNotBeNull().Count.ShouldBe(1);
         receivedToken.Value.ShouldBe($"Bearer {nameof(Should_return_service_from_k8s)}");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [Trait("Feat", "345")]
+    public async Task Should_not_return_service_from_k8s_when_k8s_api_returns_error_response(HttpStatusCode expectedStatusCode)
+    {
+        // Arrange
+        var given = GivenClientAndProvider(out var serviceBuilder);
+        serviceBuilder.Setup(x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()))
+            .Returns(new Service[] { new(nameof(Should_return_service_from_k8s), new("localhost", 80), string.Empty, string.Empty, Array.Empty<string>()) });
+
+        var endpoints = GivenEndpoints();
+        using var kubernetes = GivenThereIsAFakeKubeServiceDiscoveryProvider(
+            given.ClientOptions.ApiEndPoint.ToString(),
+            given.ProviderOptions.KubeNamespace,
+            given.ProviderOptions.KeyOfServiceInK8s,
+            expectedStatusCode,
+            endpoints,
+            out Lazy<string> receivedToken);
+
+        string expectedKubeApiErrorMessage = GetKubeApiErrorMessage(serviceName: given.ProviderOptions.KeyOfServiceInK8s, given.ProviderOptions.KubeNamespace, expectedStatusCode);
+        string expectedLogMessage = $"Failed to retrieve v1/Endpoints '{given.ProviderOptions.KeyOfServiceInK8s}' in namespace '{given.ProviderOptions.KubeNamespace}' (HTTP.{expectedStatusCode}/Failure/{expectedStatusCode}): {expectedKubeApiErrorMessage}";
+        _logger.Setup(logger => logger.LogError(It.IsAny<Func<string>>(), It.IsAny<Exception>()))
+            .Callback((Func<string> messageFactory, Exception exception) =>
+            {
+                messageFactory.ShouldNotBeNull();
+
+                string logMessage = messageFactory();
+                logMessage.ShouldNotBeNullOrWhiteSpace();
+
+                // This is a little fragile, as it may change if other entries are logged due to implementation changes.
+                // Unfortunately, the use of a factory delegate for the log message, combined with reuse of Kube's logger for Retry.OperationAsync makes this tricky to test any other way so this is probably the best we can do for now.
+                if (logMessage.StartsWith("Ocelot Retry strategy"))
+                {
+                    return;
+                }
+
+                logMessage.ShouldBe(expectedLogMessage);
+
+                exception.ShouldNotBeNull();
+                KubeApiException kubeApiException = exception.ShouldBeOfType<KubeApiException>();
+                StatusV1 errorResponse = kubeApiException.Status;
+                errorResponse.Status.ShouldBe(StatusV1.FailureStatus);
+                errorResponse.Code.ShouldBe((int)expectedStatusCode);
+                errorResponse.Reason.ShouldBe(expectedStatusCode.ToString());
+                errorResponse.Message.ShouldNotBeNullOrWhiteSpace();
+            })
+            .Verifiable($"IOcelotLogger.LogError() was not called.");
+
+        // Act
+        var services = await given.Provider.GetAsync();
+
+        // Assert
+        services.ShouldNotBeNull().Count.ShouldBe(0);
+        receivedToken.Value.ShouldBe($"Bearer {nameof(Should_not_return_service_from_k8s_when_k8s_api_returns_error_response)}");
+        _logger.Verify();
     }
 
     [Fact] // This is not unit test! LoL :) This should be an integration test or even an acceptance test...
@@ -148,6 +210,12 @@ public class KubeTests : FileUnitTest
     protected IWebHost GivenThereIsAFakeKubeServiceDiscoveryProvider(string url, string namespaces, string serviceName,
         EndpointsV1 endpointEntries, out Lazy<string> receivedToken)
     {
+        return GivenThereIsAFakeKubeServiceDiscoveryProvider(url, namespaces, serviceName, HttpStatusCode.OK, endpointEntries, out receivedToken);
+    }
+
+    protected IWebHost GivenThereIsAFakeKubeServiceDiscoveryProvider(string url, string namespaces, string serviceName,
+        HttpStatusCode responseStatusCode, EndpointsV1 endpointEntries, out Lazy<string> receivedToken)
+    {
         var token = string.Empty;
         receivedToken = new(() => token);
 
@@ -155,14 +223,33 @@ public class KubeTests : FileUnitTest
         {
             if (context.Request.Path.Value == $"/api/v1/namespaces/{namespaces}/endpoints/{serviceName}")
             {
+                string responseBody;
+
                 if (context.Request.Headers.TryGetValue("Authorization", out var values))
                 {
                     token = values.First();
                 }
 
-                var json = JsonConvert.SerializeObject(endpointEntries);
+                if (responseStatusCode == HttpStatusCode.OK)
+                {
+                    responseBody = JsonConvert.SerializeObject(endpointEntries, JsonSerializerSettings);
+                }
+                else
+                {
+                    responseBody = JsonConvert.SerializeObject(new StatusV1
+                    {
+                        Message = GetKubeApiErrorMessage(serviceName, namespaces, responseStatusCode),
+                        Reason = responseStatusCode.ToString(),
+                        Code = (int)responseStatusCode,
+                        Status = StatusV1.FailureStatus,
+
+                    }, JsonSerializerSettings);
+                }
+
+                context.Response.StatusCode = (int)responseStatusCode;
                 context.Response.Headers.Append("Content-Type", "application/json");
-                return context.Response.WriteAsync(json);
+
+                return context.Response.WriteAsync(responseBody);
             }
 
             return Task.CompletedTask;
@@ -178,5 +265,10 @@ public class KubeTests : FileUnitTest
             .Build();
         host.Start();
         return host;
+    }
+
+    private static string GetKubeApiErrorMessage(string serviceName, string kubeNamespace, HttpStatusCode responseStatusCode)
+    {
+        return $"Failed to retrieve v1/Endpoints '{serviceName}' in namespace '{kubeNamespace}' (HTTP.{responseStatusCode}/Failure/{responseStatusCode}): This is an error response for HTTP status code {(int)responseStatusCode} ('{responseStatusCode}') from the fake Kubernetes API.";
     }
 }

--- a/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+++ b/test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
@@ -77,14 +77,14 @@
     <PackageReference Include="CacheManager.Microsoft.Extensions.Logging" Version="2.0.0-beta-1629" />
     <PackageReference Include="Polly" Version="8.5.1" />
     <PackageReference Include="Polly.Testing" Version="8.5.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.3" />
   </ItemGroup>
   <!-- Conditionally obtain references for the net 8.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
@@ -92,6 +92,6 @@
   </ItemGroup>
   <!-- Conditionally obtain references for the net 9.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="9.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
KubeClient v3 should simplify dependency-management, from Ocelot's perspective:

- KubeClient no longer has an external dependency (HTTPlease) for its HttpClient support. The internalised version of this support is now located in the `KubeClient.Http` namespace.
- KubeClient v3 is multi-targeted for `net9.0`, as well as a couple of older versions that some consumers are still using (support for these older versions will be tailed off over the next couple of minor releases)

Related discussion at:

tintoy/dotnet-kube-client#166
tintoy/dotnet-kube-client#167

CC: @raman-m (as previously discussed; sorry for the extended delay!)

## Proposed Changes

  - Update `KubeClient` packages to `v3.0.0`
  - Add support for logging detailed error responses from the Kubernetes API, in case of failure (only enabled at the Debug log level, or higher)
