### PR TITLE
Allow service discovery providers to specify a path prefix

### DIFF
--- a/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/Middleware/DownstreamUrlCreatorMiddleware.cs
@@ -37,7 +37,7 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
         var placeholders = httpContext.Items.TemplatePlaceholderNameAndValues();
         var response = _replacer.Replace(downstreamRoute.DownstreamPathTemplate.Value, placeholders);
         var downstreamRequest = httpContext.Items.DownstreamRequest();
-        var upstreamPath = downstreamRequest.AbsolutePath;
+        var upstreamPath = downstreamRequest.Path;
 
         if (response.IsError)
         {
@@ -67,14 +67,14 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
             var (path, query) = CreateServiceFabricUri(downstreamRequest, downstreamRoute, placeholders, response);
 
             // TODO Check this works again hope there is a test..
-            downstreamRequest.AbsolutePath = path;
+            downstreamRequest.Path = path;
             downstreamRequest.Query = query;
         }
         else
         {
             if (dsPath.Contains(QuestionMark))
             {
-                downstreamRequest.AbsolutePath = GetPath(dsPath);
+                downstreamRequest.Path = GetPath(dsPath);
                 var newQuery = GetQueryString(dsPath);
                 downstreamRequest.Query = string.IsNullOrEmpty(downstreamRequest.Query)
                     ? newQuery
@@ -83,7 +83,7 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
             else
             {
                 RemoveQueryStringParametersThatHaveBeenUsedInTemplate(downstreamRequest, placeholders);
-                downstreamRequest.AbsolutePath = dsPath;
+                downstreamRequest.Path = dsPath;
             }
         }
 

--- a/src/Ocelot/LoadBalancer/Middleware/LoadBalancingMiddleware.cs
+++ b/src/Ocelot/LoadBalancer/Middleware/LoadBalancingMiddleware.cs
@@ -46,6 +46,7 @@ public class LoadBalancingMiddleware : OcelotMiddleware
 
         //todo check downstreamRequest is ok
         downstreamRequest.Host = hostAndPort.Data.DownstreamHost;
+        downstreamRequest.ServicePathPrefix = hostAndPort.Data.PathPrefix;
 
         if (hostAndPort.Data.DownstreamPort > 0)
         {

--- a/src/Ocelot/Request/Middleware/DownstreamRequest.cs
+++ b/src/Ocelot/Request/Middleware/DownstreamRequest.cs
@@ -16,7 +16,7 @@ public class DownstreamRequest
         Scheme = _request.RequestUri.Scheme;
         Host = _request.RequestUri.Host;
         Port = _request.RequestUri.Port;
-        AbsolutePath = _request.RequestUri.AbsolutePath;
+        Path = _request.RequestUri.AbsolutePath;
         Query = _request.RequestUri.Query;
     }
 
@@ -32,7 +32,9 @@ public class DownstreamRequest
 
     public int Port { get; set; }
 
-    public string AbsolutePath { get; set; }
+    public string Path { get; set; }
+
+    public string ServicePathPrefix { get; set; } = string.Empty;
 
     public string Query { get; set; }
 
@@ -42,37 +44,35 @@ public class DownstreamRequest
 
     public HttpRequestMessage ToHttpRequestMessage()
     {
-        var uriBuilder = new UriBuilder
-        {
-            Port = Port,
-            Host = Host,
-            Path = AbsolutePath,
-            Query = RemoveLeadingQuestionMark(Query),
-            Scheme = Scheme,
-        };
-
-        _request.RequestUri = uriBuilder.Uri;
+        var uri = CreateUri();
+        
+        _request.RequestUri = uri;
         _request.Method = new HttpMethod(Method);
         return _request;
     }
 
     public string ToUri()
     {
-        var uriBuilder = new UriBuilder
-        {
-            Port = Port,
-            Host = Host,
-            Path = AbsolutePath,
-            Query = RemoveLeadingQuestionMark(Query),
-            Scheme = Scheme,
-        };
-
-        return uriBuilder.Uri.AbsoluteUri;
+        return CreateUri().AbsoluteUri;
     }
 
     public override string ToString()
     {
         return ToUri();
+    }
+
+    private Uri CreateUri()
+    {
+        var uriBuilder = new UriBuilder
+        {
+            Port = Port,
+            Host = Host,
+            Path = string.IsNullOrEmpty(ServicePathPrefix) ? Path : $"{ServicePathPrefix.TrimEnd('/')}/{Path.TrimStart('/')}",
+            Query = RemoveLeadingQuestionMark(Query),
+            Scheme = Scheme,
+        };
+
+        return uriBuilder.Uri;
     }
 
     private static string RemoveLeadingQuestionMark(string query)

--- a/src/Ocelot/Values/ServiceHostAndPort.cs
+++ b/src/Ocelot/Values/ServiceHostAndPort.cs
@@ -18,9 +18,13 @@ public class ServiceHostAndPort : IEquatable<ServiceHostAndPort>
     public ServiceHostAndPort(string downstreamHost, int downstreamPort, string scheme)
         : this(downstreamHost, downstreamPort) => Scheme = scheme;
 
+    public ServiceHostAndPort(string downstreamHost, int downstreamPort, string scheme, string pathPrefix)
+        : this(downstreamHost, downstreamPort, scheme) => PathPrefix = pathPrefix;
+
     public string DownstreamHost { get; }
     public int DownstreamPort { get; }
     public string Scheme { get; }
+    public string PathPrefix { get; } = string.Empty;
 
     public override string ToString()
         => $"{Scheme}:{DownstreamHost}:{DownstreamPort}";


### PR DESCRIPTION
## New Feature
This allows service discovery provider implementations to specify a path prefix.

## Proposed changes
We need this for cases where services run behind a reverse proxy and are exposed like `https://reverse.proxy/someService/endpoints`. `someService` would be the "path prefix" in this case.