### PR TITLE
#2299 Encapsulate `ServiceAccountPath` as a protected property of the factory to stabilize `KubeApiClient` creation in the Kubernetes provider

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -2,9 +2,10 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 name: Develop
 on:
- push:
-   branches: [ "develop" ]
-
+  push:
+    branches:
+      - develop
+      - 'release/**'
 jobs:
   #1 Official required job to run utilizing GitHub Actions infrastructure
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,10 +84,6 @@ jobs:
         target: PullRequest
     - name: Prepare Coveralls
       run: |
-        # echo "GITHUB_REF is ${{ env.GITHUB_REF }}"
-        # echo "GITHUB_REF_NAME is ${{ env.GITHUB_REF_NAME }}"
-        # echo "GITHUB_SHA is ${{ env.GITHUB_SHA }}"
-        # echo "GITHUB BASE_REF is ${{ github.base_ref }}" # target branch
         echo "Listing environment variables:"
         env | sort
         echo ------------ Detect coverage file ------------ 
@@ -103,13 +99,8 @@ jobs:
           echo "Coverage file DOES NOT exist!"
           echo "COVERALLS_coverage_file_exists=false" >> $GITHUB_ENV
         fi
-        echo ------------ Detect target branch ------------ 
-        target_branch="${{ github.base_ref }}"
-        echo Compare_Ref is $target_branch
-        echo "COVERALLS_compare_ref=$target_branch" >> $GITHUB_ENV
     - name: Coveralls
       if: env.COVERALLS_coverage_file_exists == 'true'
       uses: coverallsapp/github-action@v2
       with:
         file: ${{ env.COVERALLS_coverage_file }}
-        # compare-ref: ${{ env.COVERALLS_compare_ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,9 +84,13 @@ jobs:
         target: PullRequest
     - name: Prepare Coveralls
       run: |
-        echo "GITHUB_REF is ${{ env.GITHUB_REF }}"
-        echo "GITHUB_REF_NAME is ${{ env.GITHUB_REF_NAME }}"
-        echo "GITHUB_SHA is ${{ env.GITHUB_SHA }}"
+        # echo "GITHUB_REF is ${{ env.GITHUB_REF }}"
+        # echo "GITHUB_REF_NAME is ${{ env.GITHUB_REF_NAME }}"
+        # echo "GITHUB_SHA is ${{ env.GITHUB_SHA }}"
+        # echo "GITHUB BASE_REF is ${{ github.base_ref }}" # target branch
+        echo "Listing environment variables:"
+        env | sort
+        echo ------------ Detect coverage file ------------ 
         coverage_1st_folder=$(ls -d /home/runner/work/Ocelot/Ocelot/artifacts/UnitTests/*/ | head -1)
         echo "Detected first folder : $coverage_1st_folder"
         coverage_file="${coverage_1st_folder%/}/coverage.cobertura.xml"
@@ -99,9 +103,13 @@ jobs:
           echo "Coverage file DOES NOT exist!"
           echo "COVERALLS_coverage_file_exists=false" >> $GITHUB_ENV
         fi
+        echo ------------ Detect target branch ------------ 
+        target_branch="${{ github.base_ref }}"
+        echo Compare_Ref is $target_branch
+        echo "COVERALLS_compare_ref=$target_branch" >> $GITHUB_ENV
     - name: Coveralls
       if: env.COVERALLS_coverage_file_exists == 'true'
       uses: coverallsapp/github-action@v2
       with:
         file: ${{ env.COVERALLS_coverage_file }}
-        compare-ref: develop
+        # compare-ref: ${{ env.COVERALLS_compare_ref }}

--- a/src/Ocelot.Provider.Kubernetes/Interfaces/IKubeApiClientFactory.cs
+++ b/src/Ocelot.Provider.Kubernetes/Interfaces/IKubeApiClientFactory.cs
@@ -2,6 +2,5 @@
 
 public interface IKubeApiClientFactory
 {
-    string ServiceAccountPath { get; set; }
     KubeApiClient Get(bool usePodServiceAccount);
 }

--- a/src/Ocelot.Provider.Kubernetes/KubeApiClientFactory.cs
+++ b/src/Ocelot.Provider.Kubernetes/KubeApiClientFactory.cs
@@ -8,14 +8,20 @@ public class KubeApiClientFactory : IKubeApiClientFactory
 {
     private readonly ILoggerFactory _logger;
     private readonly IOptions<KubeClientOptions> _options;
+    private string _serviceAccountPath;
 
     public KubeApiClientFactory(ILoggerFactory logger, IOptions<KubeClientOptions> options)
     {
         _logger = logger;
         _options = options;
+        _serviceAccountPath = KubeClientConstants.DefaultServiceAccountPath;
     }
 
-    public string ServiceAccountPath { get; set; }
+    protected string ServiceAccountPath
+    {
+        get => _serviceAccountPath;
+        set => _serviceAccountPath = string.IsNullOrEmpty(value) ? KubeClientConstants.DefaultServiceAccountPath : value;
+    }
 
     public virtual KubeApiClient Get(bool usePodServiceAccount)
     {

--- a/src/Ocelot.Provider.Kubernetes/KubeApiClientFactory.cs
+++ b/src/Ocelot.Provider.Kubernetes/KubeApiClientFactory.cs
@@ -22,7 +22,7 @@ public class KubeApiClientFactory : IKubeApiClientFactory
         var options = usePodServiceAccount
             ? KubeClientOptions.FromPodServiceAccount(ServiceAccountPath)
             : _options.Value;
-        options.LoggerFactory ??= _logger;
+        options.LoggerFactory = _logger;
         return KubeApiClient.Create(options);
     }
 }

--- a/test/Ocelot.UnitTests/Kubernetes/FakeKubeApiClientFactory.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/FakeKubeApiClientFactory.cs
@@ -1,0 +1,56 @@
+﻿using KubeClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Ocelot.Provider.Kubernetes;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Ocelot.UnitTests.Kubernetes;
+
+internal class FakeKubeApiClientFactory : KubeApiClientFactory
+{
+    public FakeKubeApiClientFactory(ILoggerFactory logger, IOptions<KubeClientOptions> options)
+        : base(logger, options) { }
+
+    public FakeKubeApiClientFactory(ILoggerFactory logger, IOptions<KubeClientOptions> options, string serviceAccountPath)
+        : base(logger, options)
+    {
+        ServiceAccountPath = serviceAccountPath;
+    }
+
+    public FakeKubeApiClientFactory(string serviceAccountPath)
+        : base(Mock.Of<ILoggerFactory>(), Mock.Of<IOptions<KubeClientOptions>>())
+    {
+        ServiceAccountPath = serviceAccountPath;
+    }
+
+    public string ActualServiceAccountPath => ServiceAccountPath;
+
+    public KubeApiClient Actual { get; private set; }
+
+    public override KubeApiClient Get(bool usePodServiceAccount)
+    {
+        return Actual = base.Get(usePodServiceAccount);
+    }
+
+    public static async Task CreateCertificate(string crtFile)
+    {
+        var certificate = CreateCertificate();
+        byte[] certBytes = certificate.Export(X509ContentType.Cert);
+        await File.WriteAllBytesAsync(crtFile, certBytes);
+    }
+
+    public static X509Certificate2 CreateCertificate()
+    {
+        // Generate a self-signed certificate
+        using RSA rsa = RSA.Create(2048);
+        var request = new CertificateRequest("CN=MyCertificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+
+        // Add extensions to the certificate (optional)
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
+
+        return request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+    }
+}

--- a/test/Ocelot.UnitTests/Kubernetes/KubeApiClientFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeApiClientFactoryTests.cs
@@ -1,0 +1,90 @@
+﻿using KubeClient;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Ocelot.Provider.Kubernetes;
+
+namespace Ocelot.UnitTests.Kubernetes;
+
+public sealed class KubeApiClientFactoryTests : KubeApiClientFactoryTestsBase
+{
+    [Theory]
+    [Trait("Bug", "2299")]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ServiceAccountPath_NoValue_FallbackedToDefValue(string serviceAccountPath)
+    {
+        // Arrange
+        var s = new FakeKubeApiClientFactory(serviceAccountPath);
+
+        // Act
+        var actual = s.ActualServiceAccountPath;
+
+        // Assert
+        actual.ShouldNotBeNullOrEmpty();
+        Assert.Equal(KubeClientConstants.DefaultServiceAccountPath, actual);
+    }
+}
+
+[Collection(nameof(SequentialTests))]
+public class KubeApiClientFactorySequentialTests : KubeApiClientFactoryTestsBase
+{
+    [Fact]
+    [Trait("Bug", "2299")]
+    public async Task Get_UsePodServiceAccount_ShouldCreateFromPodServiceAccount()
+    {
+        // Arrange
+        var serviceAccountPath = Path.Combine(AppContext.BaseDirectory, TestID);
+        var stub = new FakeKubeApiClientFactory(logger.Object, options.Object, serviceAccountPath);
+        var expectedHost = IPAddress.Loopback.ToString();
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_HOST", expectedHost);
+        int expectedPort = PortFinder.GetRandomPort();
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", expectedPort.ToString());
+
+        _folders.Add(serviceAccountPath);
+        if (!Directory.Exists(serviceAccountPath))
+        {
+            Directory.CreateDirectory(serviceAccountPath);
+        }
+
+        var path = Path.Combine(serviceAccountPath, "namespace");
+        await File.WriteAllTextAsync(path, nameof(Get_UsePodServiceAccount_ShouldCreateFromPodServiceAccount));
+        _files.Add(path);
+
+        path = Path.Combine(serviceAccountPath, "token");
+        await File.WriteAllTextAsync(path, TestID);
+        _files.Add(path);
+
+        path = Path.Combine(serviceAccountPath, "ca.crt");
+        await FakeKubeApiClientFactory.CreateCertificate(path);
+        _files.Add(path);
+
+        var log = new Mock<ILogger>();
+        logger.Setup(x => x.CreateLogger(It.IsAny<string>())).Returns(log.Object);
+
+        // Act
+        const bool UsePodServiceAccount = true;
+        var actual = stub.Get(UsePodServiceAccount); // !
+
+        // Assert
+        actual.ShouldNotBeNull().ShouldBeOfType<KubeApiClient>();
+        actual.ApiEndPoint.ShouldNotBeNull();
+        actual.ApiEndPoint.Host.ShouldBe(expectedHost);
+        actual.ApiEndPoint.Port.ShouldBe(expectedPort);
+        actual.DefaultNamespace.ShouldNotBeNull(nameof(Get_UsePodServiceAccount_ShouldCreateFromPodServiceAccount));
+        actual.LoggerFactory.ShouldNotBeNull();
+        actual.LoggerFactory.ShouldBe(logger.Object);
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", null);
+    }
+}
+
+public class KubeApiClientFactoryTestsBase : FileUnitTest
+{
+    protected readonly Mock<ILoggerFactory> logger = new();
+    protected readonly Mock<IOptions<KubeClientOptions>> options = new();
+    protected KubeApiClientFactory sut;
+
+    public KubeApiClientFactoryTestsBase()
+    {
+        sut = new(logger.Object, options.Object);
+    }
+}

--- a/test/Ocelot.UnitTests/Kubernetes/KubernetesProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubernetesProviderFactoryTests.cs
@@ -192,6 +192,25 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
         opts.Username.ShouldBe("myUser");
     }
 
+    [Fact]
+    [Trait("Bug", "2299")]
+    public void CreateProvider_StepsToReproduce()
+    {
+        // Arrange
+        _builder.AddKubernetes(); // !!!
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_HOST", "localhost");
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", PortFinder.GetRandomPort().ToString());
+
+        // Act
+        var ex = Assert.Throws<ArgumentNullException>(
+            () => CreateProvider(nameof(Kube)));
+
+        // Assert
+        ex.ParamName.ShouldBe("path1");
+        ex.StackTrace.ShouldContain("KubeClient.KubeClientOptions.FromPodServiceAccount(String serviceAccountPath)");
+        ex.Message.ShouldBe("Value cannot be null. (Parameter 'path1')");
+    }
+
     private static X509Certificate2 CreateCertificate()
     {
         // Generate a self-signed certificate

--- a/test/Ocelot.UnitTests/Kubernetes/KubernetesProviderFactoryTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubernetesProviderFactoryTests.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Ocelot.Configuration;
 using Ocelot.Configuration.Builder;
@@ -13,33 +12,11 @@ using Ocelot.Provider.Kubernetes.Interfaces;
 using Ocelot.ServiceDiscovery;
 using Ocelot.ServiceDiscovery.Providers;
 using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Ocelot.UnitTests.Kubernetes;
 
-public sealed class KubernetesProviderFactoryTests : FileUnitTest
+public sealed class KubernetesProviderFactoryTests : KubernetesProviderFactoryTestsBase
 {
-    private readonly IOcelotBuilder _builder;
-
-    public KubernetesProviderFactoryTests()
-    {
-        var config = new FileConfiguration();
-        config.GlobalConfiguration.ServiceDiscoveryProvider = new()
-        {
-            Scheme = Uri.UriSchemeHttp,
-            Host = "localhost",
-            Port = 888,
-            Namespace = nameof(KubernetesProviderFactoryTests),
-            Token = TestID,
-        };
-        var configuration = new ConfigurationBuilder()
-            .SetBasePath(AppContext.BaseDirectory)
-            .AddOcelot(config, null, MergeOcelotJson.ToMemory)
-            .Build();
-        _builder = new ServiceCollection().AddOcelot(configuration);
-    }
-
     [Theory]
     [Trait("Bug", "977")]
     [InlineData(typeof(Kube))]
@@ -82,67 +59,6 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
         actual.ShouldBeNull();
     }
 
-    class FakeKubeApiClientFactory : KubeApiClientFactory
-    {
-        public FakeKubeApiClientFactory(ILoggerFactory logger, IOptions<KubeClientOptions> options) : base(logger, options) { }
-        public KubeApiClient Actual { get; private set; }
-        public override KubeApiClient Get(bool usePodServiceAccount)
-        {
-            return Actual = base.Get(usePodServiceAccount);
-        }
-    }
-
-    [Fact]
-    [Trait("Feat", "2256")]
-    public async Task CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount()
-    {
-        // Arrange
-        _builder.AddKubernetes(true); // !!!
-        var serviceAccountPath = Path.Combine(AppContext.BaseDirectory, TestID);
-        var stub = new FakeKubeApiClientFactory(null, null)
-        {
-            ServiceAccountPath = serviceAccountPath,
-        };
-        var original = _builder.Services.First(x => x.ServiceType == typeof(IKubeApiClientFactory));
-        var descriptor = ServiceDescriptor.Describe(original.ServiceType, _ => stub, original.Lifetime);
-        _builder.Services.Replace(descriptor);
-
-        var expectedHost = IPAddress.Loopback.ToString();
-        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_HOST", expectedHost);
-        int expectedPort = PortFinder.GetRandomPort();
-        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", expectedPort.ToString());
-
-        _folders.Add(serviceAccountPath);
-        if (!Directory.Exists(serviceAccountPath))
-        {
-            Directory.CreateDirectory(serviceAccountPath);
-        }
-
-        var path = Path.Combine(serviceAccountPath, "namespace");
-        await File.WriteAllTextAsync(path, nameof(CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount));
-        _files.Add(path);
-
-        path = Path.Combine(serviceAccountPath, "token");
-        await File.WriteAllTextAsync(path, TestID);
-        _files.Add(path);
-
-        path = Path.Combine(serviceAccountPath, "ca.crt");
-        await CreateCertificate(path);
-        _files.Add(path);
-
-        // Act
-        var actualProvider = CreateProvider(nameof(Kube));
-
-        // Assert
-        actualProvider.ShouldNotBeNull().ShouldBeOfType<Kube>();
-        stub.ShouldNotBeNull();
-        stub.Actual.ShouldNotBeNull();
-        stub.Actual.ApiEndPoint.ShouldNotBeNull();
-        stub.Actual.ApiEndPoint.Host.ShouldBe(expectedHost);
-        stub.Actual.ApiEndPoint.Port.ShouldBe(expectedPort);
-        stub.Actual.DefaultNamespace.ShouldNotBeNull(nameof(CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount));
-    }
-
     [Fact]
     [Trait("Feat", "2256")]
     public void CreateProvider_KubeApiClientFactory_ShouldCreateFromOptions()
@@ -157,7 +73,7 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
         options.SetupGet(x => x.Value).Returns(new KubeClientOptions
         {
             ApiEndPoint = new UriBuilder(Uri.UriSchemeHttps, IPAddress.Loopback.ToString(), PortFinder.GetRandomPort()).Uri,
-            ClientCertificate = CreateCertificate(),
+            ClientCertificate = FakeKubeApiClientFactory.CreateCertificate(),
             KubeNamespace = nameof(CreateProvider_KubeApiClientFactory_ShouldCreateFromOptions),
         });
         _builder.Services.AddSingleton<IOptions<KubeClientOptions>>(options.Object);
@@ -191,10 +107,63 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
         configureOptions.Configure(opts);
         opts.Username.ShouldBe("myUser");
     }
+}
+
+[Collection(nameof(SequentialTests))]
+public sealed class KubernetesProviderFactorySequentialTests : KubernetesProviderFactoryTestsBase
+{
+    [Fact]
+    [Trait("Feat", "2256")]
+    public async Task CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount()
+    {
+        // Arrange
+        _builder.AddKubernetes(true); // !!!
+        var serviceAccountPath = Path.Combine(AppContext.BaseDirectory, TestID);
+        var stub = new FakeKubeApiClientFactory(null, null, serviceAccountPath);
+        var original = _builder.Services.First(x => x.ServiceType == typeof(IKubeApiClientFactory));
+        var descriptor = ServiceDescriptor.Describe(original.ServiceType, _ => stub, original.Lifetime);
+        _builder.Services.Replace(descriptor);
+
+        var expectedHost = IPAddress.Loopback.ToString();
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_HOST", expectedHost);
+        int expectedPort = PortFinder.GetRandomPort();
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", expectedPort.ToString());
+
+        _folders.Add(serviceAccountPath);
+        if (!Directory.Exists(serviceAccountPath))
+        {
+            Directory.CreateDirectory(serviceAccountPath);
+        }
+
+        var path = Path.Combine(serviceAccountPath, "namespace");
+        await File.WriteAllTextAsync(path, nameof(CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount));
+        _files.Add(path);
+
+        path = Path.Combine(serviceAccountPath, "token");
+        await File.WriteAllTextAsync(path, TestID);
+        _files.Add(path);
+
+        path = Path.Combine(serviceAccountPath, "ca.crt");
+        await FakeKubeApiClientFactory.CreateCertificate(path);
+        _files.Add(path);
+
+        // Act
+        var actualProvider = CreateProvider(nameof(Kube));
+
+        // Assert
+        actualProvider.ShouldNotBeNull().ShouldBeOfType<Kube>();
+        stub.ShouldNotBeNull();
+        stub.Actual.ShouldNotBeNull();
+        stub.Actual.ApiEndPoint.ShouldNotBeNull();
+        stub.Actual.ApiEndPoint.Host.ShouldBe(expectedHost);
+        stub.Actual.ApiEndPoint.Port.ShouldBe(expectedPort);
+        stub.Actual.DefaultNamespace.ShouldNotBeNull(nameof(CreateProvider_KubeApiClientFactory_ShouldCreateFromPodServiceAccount));
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", null);
+    }
 
     [Fact]
     [Trait("Bug", "2299")]
-    public void CreateProvider_StepsToReproduce()
+    public void Bug2299_StepsToReproduce_ShouldNotThrowExceptionByPathCombine()
     {
         // Arrange
         _builder.AddKubernetes(); // !!!
@@ -202,37 +171,42 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
         Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", PortFinder.GetRandomPort().ToString());
 
         // Act
-        var ex = Assert.Throws<ArgumentNullException>(
+        var ex = Assert.ThrowsAny<Exception>(
             () => CreateProvider(nameof(Kube)));
 
         // Assert
-        ex.ParamName.ShouldBe("path1");
-        ex.StackTrace.ShouldContain("KubeClient.KubeClientOptions.FromPodServiceAccount(String serviceAccountPath)");
-        ex.Message.ShouldBe("Value cannot be null. (Parameter 'path1')");
+        ex.ShouldNotBeOfType<ArgumentNullException>();
+        ex.ShouldBeOfType<DirectoryNotFoundException>();
+        ex.StackTrace.ShouldContain("at KubeClient.KubeClientOptions.FromPodServiceAccount(String serviceAccountPath)");
+        ex.StackTrace.ShouldNotContain("at System.IO.Path.Combine(String path1, String path2)");
+        ex.Message.ShouldNotBe("Value cannot be null. (Parameter 'path1')");
+        Environment.SetEnvironmentVariable("KUBERNETES_SERVICE_PORT", null);
     }
+}
 
-    private static X509Certificate2 CreateCertificate()
+public class KubernetesProviderFactoryTestsBase : FileUnitTest
+{
+    protected readonly IOcelotBuilder _builder;
+
+    public KubernetesProviderFactoryTestsBase()
     {
-        // Generate a self-signed certificate
-        using RSA rsa = RSA.Create(2048);
-        var request = new CertificateRequest("CN=MyCertificate", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-
-        // Add extensions to the certificate (optional)
-        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
-        request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature, false));
-        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
-
-        return request.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddYears(1));
+        var config = new FileConfiguration();
+        config.GlobalConfiguration.ServiceDiscoveryProvider = new()
+        {
+            Scheme = Uri.UriSchemeHttp,
+            Host = "localhost",
+            Port = 888,
+            Namespace = nameof(KubernetesProviderFactoryTests),
+            Token = TestID,
+        };
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddOcelot(config, null, MergeOcelotJson.ToMemory)
+            .Build();
+        _builder = new ServiceCollection().AddOcelot(configuration);
     }
 
-    private static async Task CreateCertificate(string crtFile)
-    {
-        var certificate = CreateCertificate();
-        byte[] certBytes = certificate.Export(X509ContentType.Cert);
-        await File.WriteAllBytesAsync(crtFile, certBytes);
-    }
-
-    private IServiceDiscoveryProvider CreateProvider(string providerType)
+    protected IServiceDiscoveryProvider CreateProvider(string providerType)
     {
         var serviceProvider = _builder.Services.BuildServiceProvider(true);
         var config = GivenServiceProvider(providerType);
@@ -242,7 +216,7 @@ public sealed class KubernetesProviderFactoryTests : FileUnitTest
             .Invoke(serviceProvider, config, route);
     }
 
-    private static ServiceProviderConfiguration GivenServiceProvider(string type) => new(
+    protected static ServiceProviderConfiguration GivenServiceProvider(string type) => new(
         type: type,
         scheme: string.Empty,
         host: string.Empty,


### PR DESCRIPTION
## Fixes #2299 
- #2299 

## Proposed Changes
- Added Steps to Reproduce as a unit test.
- Encapsulated the `KubeApiClientFactory.ServiceAccountPath` property as a protected property, removing it from the interface.
- Resolved a hidden issue where the abstract `NullLoggerFactory` was initialized with a non-null value, which prevented the `KubeClientOptions.LoggerFactory` property from being updated and caused Ocelot logger instances to be disregarded.
- Tests involving updates to required environment variables for `KubeApiClient` were refactored into sequential tests due to failures in parallel execution mode caused by static sharing of variables within the environment.