### PR TITLE
Use the appropriate class name as a type parameter to create a named logger through the factory in the ConfigurationMiddleware constructor

### DIFF
--- a/src/Ocelot/Middleware/ConfigurationMiddleware.cs
+++ b/src/Ocelot/Middleware/ConfigurationMiddleware.cs
@@ -11,7 +11,7 @@ public class ConfigurationMiddleware : OcelotMiddleware
     private readonly IInternalConfigurationRepository _configRepo;
 
     public ConfigurationMiddleware(RequestDelegate next, IOcelotLoggerFactory loggerFactory, IInternalConfigurationRepository configRepo)
-        : base(loggerFactory.CreateLogger<ExceptionHandlerMiddleware>())
+        : base(loggerFactory.CreateLogger<ConfigurationMiddleware>())
     {
         _next = next;
         _configRepo = configRepo;


### PR DESCRIPTION
## Proposed Changes
  - Use the appropriate class name as a type parameter to create a named logger through the factory in the `ConfigurationMiddleware` constructor
