### PR TITLE
Follow-up #2363 #2364: Exclude `Ocelot.Testing` from Cobertura coverage via Coverlet `.runsettings`

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -32,9 +32,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
       - name: Unit Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
       - name: Acceptance Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   build-macos:
     needs: build-windows
@@ -68,9 +68,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
       - name: Unit Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
       - name: Acceptance Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   build-linux:
     needs: build-macos
@@ -111,9 +111,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ./Ocelot.slnx --framework net${{ matrix.dotnet-version }}.0
     - name: Unit Tests
-      run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+      run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
     - name: Acceptance Tests
-      run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+      run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   build-cake:
     needs: build-linux

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,9 +42,9 @@ jobs:
 #     - name: Build
 #       run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
 #     - name: Unit Tests
-#       run: dotnet test --no-restore --no-build --verbosity normal --framework net10.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+#       run: dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
 #     - name: Acceptance Tests
-#       run: dotnet test --no-restore --no-build --verbosity normal --framework net10.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+#       run: dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
 #   build-macos:
 #     runs-on: macos-latest
@@ -78,9 +78,9 @@ jobs:
 #       - name: Build
 #         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
 #       - name: Unit Tests
-#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
 #       - name: Acceptance Tests
-#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
 #   build-windows:
 #     runs-on: windows-latest
@@ -110,9 +110,9 @@ jobs:
 #       - name: Build
 #         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
 #       - name: Unit Tests
-#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
 #       - name: Acceptance Tests
-#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+#         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
 #   build-success:
 #     needs: [build-linux, build-macos, build-windows]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.Release.sln --framework net${{ matrix.dotnet-version }}.0
       - name: Unit Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
       - name: Acceptance Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   build-macos:
     needs: build-windows
@@ -74,9 +74,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.Release.sln --framework net${{ matrix.dotnet-version }}.0
       - name: Unit Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
       - name: Acceptance Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   build-linux:
     needs: build-macos
@@ -117,9 +117,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.Release.sln --framework net${{ matrix.dotnet-version }}.0
       - name: Unit Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
       - name: Acceptance Tests
-        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
+        run: dotnet test --no-restore --no-build --verbosity minimal --framework net${{ matrix.dotnet-version }}.0 --settings coverlet.runsettings ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
   release-cake:
     needs: build-linux

--- a/build.cake
+++ b/build.cake
@@ -521,6 +521,7 @@ Task("UnitTests")
 					.Append("--no-restore")
 					.Append("--no-build")
 					.Append("--collect:\"XPlat Code Coverage\"") // this create the code coverage report
+					.Append("--settings coverlet.runsettings") // exclude Ocelot.Testing assembly from coverage
 					.Append("--verbosity:" + verbosity)
 					.Append("--consoleLoggerParameters:ErrorsOnly"),
 				Framework = tfm,

--- a/build.cake
+++ b/build.cake
@@ -758,6 +758,7 @@ private void GenerateReport(Cake.Core.IO.FilePath coverageSummaryFile)
 	var reportSettings = new ProcessArgumentBuilder();
 	reportSettings.Append($"-targetdir:" + $"{dir}/{artifactsForUnitTestsDir}");
 	reportSettings.Append($"-reports:" + coverageSummaryFile);
+	reportSettings.Append($"-filefilters:-*.g.cs"); // silence warnings for source-generated files (e.g. RegexGenerator.g.cs) that are deleted after build
 
 	Information($"GenerateReport: Resolving net9.0/ReportGenerator.dll ...");
 	var toolpath = Context.Tools.Resolve("net9.0/ReportGenerator.dll");

--- a/build.cake
+++ b/build.cake
@@ -760,8 +760,8 @@ private void GenerateReport(Cake.Core.IO.FilePath coverageSummaryFile)
 	reportSettings.Append($"-reports:" + coverageSummaryFile);
 	reportSettings.Append($"-filefilters:-*.g.cs"); // silence warnings for source-generated files (e.g. RegexGenerator.g.cs) that are deleted after build
 
-	Information($"GenerateReport: Resolving net9.0/ReportGenerator.dll ...");
-	var toolpath = Context.Tools.Resolve("net9.0/ReportGenerator.dll");
+	Information($"GenerateReport: Resolving net10.0/ReportGenerator.dll ...");
+	var toolpath = Context.Tools.Resolve("net10.0/ReportGenerator.dll");
 	Information($"GenerateReport: Tool Path: {toolpath.ToString()}" + NL);
 
 	DotNetExecute(toolpath, reportSettings);

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- Exclude the Ocelot.Testing assembly (shared testing library, not a product under test) -->
+          <Exclude>[Ocelot.Testing*]*</Exclude>
+          <!-- Do not count the test assemblies themselves toward coverage -->
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <!-- Exclude assemblies that have no matching source files (e.g. generated or third-party) -->
+          <ExcludeAssembliesWithoutSources>MissingAll</ExcludeAssembliesWithoutSources>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Follow-up #2363 #2364
  - #2363 
  - #2364 
