### PR TITLE
fix: prioritise service instance address over Consul node address in GetDownstreamHost

### DIFF
--- a/src/Ocelot.Provider.Consul/DefaultConsulServiceBuilder.cs
+++ b/src/Ocelot.Provider.Consul/DefaultConsulServiceBuilder.cs
@@ -94,7 +94,9 @@ public class DefaultConsulServiceBuilder : IConsulServiceBuilder
             entry.Service.Port);
 
     protected virtual string GetDownstreamHost(ServiceEntry entry, Node node)
-        => node != null ? node.Name : entry.Service.Address;
+        => !string.IsNullOrEmpty(entry?.Service?.Address)
+            ? entry.Service.Address
+            : node?.Address ?? node?.Name;
 
     protected virtual string GetServiceId(ServiceEntry entry, Node node)
         => entry.Service.ID;

--- a/test/Ocelot.UnitTests/Consul/DefaultConsulServiceBuilderTests.cs
+++ b/test/Ocelot.UnitTests/Consul/DefaultConsulServiceBuilderTests.cs
@@ -114,23 +114,51 @@ public sealed class DefaultConsulServiceBuilderTests
     private static MethodInfo GetDownstreamHost { get; } = Me.GetMethod("GetDownstreamHost", BindingFlags.NonPublic | BindingFlags.Instance);
 
     [Fact]
-    public void GetDownstreamHost_BothBranches_NameOrAddress()
+    public void GetDownstreamHost_ServiceAddressPresent_ReturnsServiceAddress()
     {
+        // Issue #2325: service instance address should take priority over Consul node address
         Arrange();
 
-        // Arrange, Act, Assert: node branch
+        // Arrange, Act, Assert: service address is returned even when node is present
         ServiceEntry entry = new()
         {
-            Service = new() { Address = nameof(GetDownstreamHost_BothBranches_NameOrAddress) },
+            Service = new() { Address = "10.0.0.5" },
         };
-        var node = new Node { Name = "test1" };
+        var node = new Node { Name = "consul-node-1", Address = "192.168.1.1" };
         var actual = GetDownstreamHost.Invoke(sut, new object[] { entry, node }) as string;
-        actual.ShouldNotBeNull().ShouldBe("test1");
+        actual.ShouldNotBeNull().ShouldBe("10.0.0.5");
 
-        // Arrange, Act, Assert: entry branch
+        // Arrange, Act, Assert: service address is returned when node is null
         node = null;
         actual = GetDownstreamHost.Invoke(sut, new object[] { entry, node }) as string;
-        actual.ShouldNotBeNull().ShouldBe(nameof(GetDownstreamHost_BothBranches_NameOrAddress));
+        actual.ShouldNotBeNull().ShouldBe("10.0.0.5");
+    }
+
+    [Fact]
+    public void GetDownstreamHost_ServiceAddressEmpty_FallsBackToNodeAddressThenName()
+    {
+        // Issue #2325: fall back to node.Address, then node.Name when service address is unavailable
+        Arrange();
+
+        // Arrange, Act, Assert: empty service address falls back to node.Address
+        ServiceEntry entry = new()
+        {
+            Service = new() { Address = string.Empty },
+        };
+        var node = new Node { Name = "consul-node-1", Address = "192.168.1.1" };
+        var actual = GetDownstreamHost.Invoke(sut, new object[] { entry, node }) as string;
+        actual.ShouldNotBeNull().ShouldBe("192.168.1.1");
+
+        // Arrange, Act, Assert: empty service address with no node.Address falls back to node.Name
+        node = new Node { Name = "consul-node-1", Address = null };
+        actual = GetDownstreamHost.Invoke(sut, new object[] { entry, node }) as string;
+        actual.ShouldNotBeNull().ShouldBe("consul-node-1");
+
+        // Arrange, Act, Assert: null service address falls back to node.Address
+        entry.Service.Address = null;
+        node = new Node { Name = "consul-node-1", Address = "192.168.1.1" };
+        actual = GetDownstreamHost.Invoke(sut, new object[] { entry, node }) as string;
+        actual.ShouldNotBeNull().ShouldBe("192.168.1.1");
     }
 
     private static MethodInfo GetServiceVersion { get; } = Me.GetMethod("GetServiceVersion", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
## Fixes #2325 
- #2325 

Regression introduced in Ocelot 23.3 where `GetDownstreamHost` incorrectly used the Consul node's `Name` as the downstream host whenever a node was present, breaking environments (especially Kubernetes) where Consul nodes and service instances run on different hosts.

## Changes

- **`DefaultConsulServiceBuilder.GetDownstreamHost`**: Reversed the priority logic to use `entry.Service.Address` first (the actual service instance address), falling back to `node.Address` then `node.Name` only when the service address is unavailable.
- **Unit tests**: Replaced the existing `GetDownstreamHost_BothBranches_NameOrAddress` test (which validated the broken behaviour) with two new tests covering all branches of the corrected logic.

### Before (broken, 23.3+)
```csharp
protected virtual string GetDownstreamHost(ServiceEntry entry, Node node)
    => node != null ? node.Name : entry.Service.Address;
```

### After (fixed)
```csharp
protected virtual string GetDownstreamHost(ServiceEntry entry, Node node)
    => !string.IsNullOrEmpty(entry?.Service?.Address)
        ? entry.Service.Address
        : node?.Address ?? node?.Name;
```

## Test plan

- [ ] `GetDownstreamHost_ServiceAddressPresent_ReturnsServiceAddress` — verifies service address is used even when a node is present
- [ ] `GetDownstreamHost_ServiceAddressEmpty_FallsBackToNodeAddressThenName` — verifies fallback to `node.Address` then `node.Name` when service address is empty/null
- [ ] All existing `DefaultConsulServiceBuilderTests` pass
- [ ] Full unit test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)