### PR TITLE
#1687 Return gateway timeout for request timeouts

### DIFF
--- a/docs/features/errorcodes.rst
+++ b/docs/features/errorcodes.rst
@@ -65,19 +65,21 @@ Server Error Responses
 ----------------------
 .. _502 Bad Gateway: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/502
 .. _503 Service Unavailable: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503
+.. _504 Gateway Timeout: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
 
 - `500 Internal Server Error`_: If unable to complete the HTTP request to the downstream service, and the exception is not ``OperationCanceledException`` or ``HttpRequestException``.
 - `502 Bad Gateway`_: If unable to connect to the downstream service.
-- `503 Service Unavailable`_: Returned when the downstream request times out.
+- `503 Service Unavailable`_: If the built-in QoS circuit breaker is open and rejects the request without calling the downstream service.
+- `504 Gateway Timeout`_: Returned when the downstream request times out.
 
     | Ocelot Error: `RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot+RequestTimedOutError&type=code>`_
     | Ocelot Code: `OcelotErrorCode.RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20OcelotErrorCode.RequestTimedOutError&type=code>`_
 
-  According to Ocelot Core's design, status code ``503`` is produced in the following ``TimeoutException`` scenarios:
+  According to Ocelot Core's design, status code ``504`` is produced in the following ``TimeoutException`` scenarios:
 
   1. By ``TimeoutDelegatingHandler`` from the ``IMessageInvokerPool`` service, when an ``OperationCanceledException`` is thrown and the context's cancellation token is not in the “cancellation requested” state.
      Ocelot does not log an error with the exception body, but the ``IExceptionToErrorMapper`` service generates the internal `OcelotErrorCode.RequestTimedOutError`_.
-  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected `OcelotErrorCode.RequestTimedOutError`_ to status ``503``.
+  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected `OcelotErrorCode.RequestTimedOutError`_ to status ``504``.
      This error code is produced by the ``IExceptionToErrorMapper`` service when a ``TimeoutException`` is thrown by other middlewares—especially by ``TimeoutDelegatingHandler``.
 
 .. _eh-error-mapper:

--- a/docs/features/qualityofservice.rst
+++ b/docs/features/qualityofservice.rst
@@ -173,7 +173,7 @@ An optional per-request timeout can be configured independently of or alongside 
   }
 
 When a request exceeds ``Timeout`` milliseconds, it is cancelled.
-A ``503 Service Unavailable`` response is returned, and the event is recorded as a circuit-breaker failure.
+A ``504 Gateway Timeout`` response is returned, and the event is recorded as a circuit-breaker failure.
 
 Setting ``Timeout`` to ``0`` or a negative value disables the timeout.
 To disable the per-request timeout entirely, omit the ``Timeout`` option or set it to ``0``.

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -442,6 +442,7 @@ Errors and Gotchas
 .. _Show and tell: https://github.com/ThreeMammals/Ocelot/discussions/categories/show-and-tell
 .. _499 (Client Closed Request): https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.statuscodes.status499clientclosedrequest
 .. _503 (Service Unavailable): https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503
+.. _504 (Gateway Timeout): https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
 
 In this section, Ocelot team has gathered user scenarios where routing behavior was unclear or errors appeared in the logs.
 Please note that the failed routing cases listed below do not represent all application configurations.
@@ -458,15 +459,15 @@ If your case is not included, feel free to open a "`Show and tell`_" discussion.
   As a quick recipe, the Ocelot team recommends ensuring client stability and, if necessary, adjusting the :ref:`config-timeout` strategy:
   either increasing or decreasing the route :ref:`config-timeout` depending on your usage scenario and the behavior of the downstream service.
 
-* **Timeout errors aka 503 status**.
-  According to Ocelot Core's design, HTTP status code `503 (Service Unavailable)`_ is returned in cases involving a ``TimeoutException``.
+* **Timeout errors aka 504 status**.
+  According to Ocelot Core's design, HTTP status code `504 (Gateway Timeout)`_ is returned in cases involving a ``TimeoutException``.
   This status is typically caused by:
 
   A) Slow downstream services that may fail to respond
   B) Large requests forwarded to slow downstream services
 
   As a quick recipe, the Ocelot team recommends increasing the route :ref:`config-timeout` in your configuration.
-  This adjustment can help resolve timeout-related issues with sluggish downstream services, ultimately reducing occurrences of `503 (Service Unavailable)`_.
+  This adjustment can help resolve timeout-related issues with sluggish downstream services, ultimately reducing occurrences of `504 (Gateway Timeout)`_.
 
 .. _break: http://break.do
 

--- a/src/Ocelot/Errors/RequestTimedOutError.cs
+++ b/src/Ocelot/Errors/RequestTimedOutError.cs
@@ -6,6 +6,6 @@ public class RequestTimedOutError : Error
 {
     public RequestTimedOutError(Exception exception)
         : base($"Timeout making http request, exception: {exception}",
-            OcelotErrorCode.RequestTimedOutError, StatusCodes.Status503ServiceUnavailable)
+            OcelotErrorCode.RequestTimedOutError, StatusCodes.Status504GatewayTimeout)
     { }
 }

--- a/src/Ocelot/QualityOfService/CircuitBreakerDelegatingHandler.cs
+++ b/src/Ocelot/QualityOfService/CircuitBreakerDelegatingHandler.cs
@@ -134,9 +134,9 @@ public class CircuitBreakerDelegatingHandler : DelegatingHandler
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
             // Our per-request timeout fired (not the outer cancellation token)
-            _logger.LogWarning(() => $"Request to '{request.RequestUri}' timed out after {_timeoutMs.Value}ms. Returning {HttpStatusCode.ServiceUnavailable} for route -> {_route.Name()}");
+            _logger.LogWarning(() => $"Request to '{request.RequestUri}' timed out after {_timeoutMs.Value}ms. Returning {HttpStatusCode.GatewayTimeout} for route -> {_route.Name()}");
             _circuitBreaker.RecordFailure();
-            return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            return new HttpResponseMessage(HttpStatusCode.GatewayTimeout)
             {
                 Content = new StringContent($"Request timeout for route -> {_route.Name()}"),
                 ReasonPhrase = "Request timeout",

--- a/src/Ocelot/Requester/HttpExceptionToErrorMapper.cs
+++ b/src/Ocelot/Requester/HttpExceptionToErrorMapper.cs
@@ -30,7 +30,7 @@ public class HttpExceptionToErrorMapper : IExceptionToErrorMapper
         // here are mapped the exceptions thrown from Ocelot core application
         if (type == typeof(TimeoutException))
         {
-            return new RequestTimedOutError(exception); // -> 503 Service Unavailable; TODO but it should actually be 504 Gateway Timeout
+            return new RequestTimedOutError(exception); // -> 504 Gateway Timeout
         }
 
         if (type == typeof(OperationCanceledException) || type.IsSubclassOf(typeof(OperationCanceledException)))

--- a/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
+++ b/src/Ocelot/Responder/ErrorsToHttpStatusCodeMapper.cs
@@ -28,7 +28,7 @@ public class ErrorsToHttpStatusCodeMapper : IErrorsToHttpStatusCodeMapper
 
         if (errors.Any(e => e.Code == OcelotErrorCode.RequestTimedOutError))
         {
-            return StatusCodes.Status503ServiceUnavailable;
+            return StatusCodes.Status504GatewayTimeout;
         }
 
         if (errors.Any(e => e.Code == OcelotErrorCode.RequestCanceled))

--- a/test/Ocelot.AcceptanceTests/Configuration/TimeoutTests.cs
+++ b/test/Ocelot.AcceptanceTests/Configuration/TimeoutTests.cs
@@ -18,12 +18,12 @@ public class TimeoutTests : TimeoutSteps
         var configuration = GivenConfiguration(port, RouteTimeoutSeconds, GlobalTimeoutSeconds); // !!!
         var body = Body();
         this
-            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
             .Then(x => ThenTimeoutIsInRange(_watcher, Ms(RouteTimeoutSeconds), Ms(RouteTimeoutSeconds) + 500)) // (2.0, 2.5) s
-            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             .And(x => ThenTheResponseBodyShouldBeAsync(string.Empty))
         .BDDfy();
     }
@@ -46,12 +46,12 @@ public class TimeoutTests : TimeoutSteps
         {
             ThenTimeoutIsInRange(watcher, globalTimeoutMs, Ms(DownstreamRoute.DefaultTimeoutSeconds)); // (2.0, 90) so assert roughly
             ThenTimeoutIsInRange(watcher, globalTimeoutMs, globalTimeoutMs + 500); // (2.0, 2.5) so assert precisely
-            ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable); // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout); // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             await ThenTheResponseBodyShouldBeAsync(string.Empty);
         };
         this
-            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
-            .And(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
+            .And(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingBothRoutesWhenIGetUrlOnTheApiGateway(route1, route2))
@@ -74,12 +74,12 @@ public class TimeoutTests : TimeoutSteps
         var configuration = GivenConfiguration(port, RouteTimeoutSeconds); // !!!
         var body = Body();
         this
-            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2.5s > 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2.5s > 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
             .Then(x => ThenTimeoutIsInRange(_watcher, Ms(RouteTimeoutSeconds), serviceTimeoutMs))
-            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             .And(x => ThenTheResponseBodyShouldBe(string.Empty))
         .BDDfy();
     }
@@ -100,12 +100,12 @@ public class TimeoutTests : TimeoutSteps
                 var configuration = GivenConfiguration(port, routeTimeout: null, globalTimeout: null); // !!! no route timeout -> DownstreamRoute.DefaultTimeoutSeconds
                 var body = Body();
                 this
-                    .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 3.5s > 3s -> ServiceUnavailable
+                    .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 3.5s > 3s -> GatewayTimeout
                     .And(x => GivenThereIsAConfiguration(configuration))
                     .And(x => GivenOcelotIsRunning())
                     .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
                     .Then(x => ThenTimeoutIsInRange(_watcher, Ms(DownstreamRoute.LowTimeout), serviceTimeoutMs))
-                    .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 3 secs -> TimeoutException by TimeoutDelegatingHandler
+                    .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 3 secs -> TimeoutException by TimeoutDelegatingHandler
                     .And(x => ThenTheResponseBodyShouldBe(string.Empty))
                 .BDDfy();
             }

--- a/test/Ocelot.AcceptanceTests/QualityOfService/QosSteps.cs
+++ b/test/Ocelot.AcceptanceTests/QualityOfService/QosSteps.cs
@@ -78,7 +78,7 @@ public class QosSteps : TimeoutSteps
             GivenThereIsAServiceRunningOn(ports[i], HttpStatusCode.OK, firstHasTimeout, notFailing);
         }
         await self.WhenIGetUrlOnTheApiGateway(upstreamPath);
-        self.ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable); // OnTimeout
+        self.ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout); // OnTimeout
         await self.WhenIGetUrlOnTheApiGateway(upstreamPath);
         await self.ThenTheResponseShouldBeAsync(HttpStatusCode.OK);
     }

--- a/test/Ocelot.AcceptanceTests/QualityOfService/QualityOfServiceTests.cs
+++ b/test/Ocelot.AcceptanceTests/QualityOfService/QualityOfServiceTests.cs
@@ -59,7 +59,7 @@ public sealed class QualityOfServiceTests : QosSteps
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunningAsync(WithQualityOfService))
             .When(x => WhenIPostUrlOnTheApiGateway("/", "postContent"))
-            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout))
         .BDDfy();
     }
 
@@ -146,7 +146,7 @@ public sealed class QualityOfServiceTests : QosSteps
             .When(x => WhenIGetUrlOnTheApiGateway("/")) // repeat same request because min MinimumThroughput is 2
             .Then(x => ThenTheResponseShouldBeAsync(HttpStatusCode.OK, "Hello from Laura"))
             .When(x => WhenIGetUrlOnTheApiGateway("/"))
-            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout))
             .When(x => WhenIGetUrlOnTheApiGateway("/"))
             .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable))
             .When(x => WhenIGetUrlOnTheApiGateway("/"))
@@ -204,7 +204,7 @@ public sealed class QualityOfServiceTests : QosSteps
             .Then(x => ThenTheStatusCodeShouldBeOk())
             .And(x => ThenTheResponseBodyShouldBe("Hello from Laura"))
             .When(x => WhenIGetUrlOnTheApiGateway("/"))
-            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable))
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout))
             .When(x => WhenIGetUrlOnTheApiGateway("/working"))
             .Then(x => ThenTheStatusCodeShouldBeOk())
             .And(x => ThenTheResponseBodyShouldBe("Hello from Tom"))
@@ -235,11 +235,11 @@ public sealed class QualityOfServiceTests : QosSteps
             var route = GivenRoute(port, new(new FileQoSOptions()));
             var configuration = GivenConfiguration(route);
             this
-                .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.Created, defTimeoutMs + 500, body)) // 3.5s > 3s -> ServiceUnavailable
+                .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.Created, defTimeoutMs + 500, body)) // 3.5s > 3s -> GatewayTimeout
                 .And(x => GivenThereIsAConfiguration(configuration))
                 .And(x => GivenOcelotIsRunningAsync(WithQualityOfService))
                 .When(x => WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 3 secs -> Timeout exception aka request cancellation
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 3 secs -> Timeout exception aka request cancellation
             .BDDfy();
         }
         finally
@@ -268,7 +268,7 @@ public sealed class QualityOfServiceTests : QosSteps
             .And(x => GivenOcelotIsRunningAsync(WithQualityOfService))
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
             .Then(x => ThenTimeoutIsInRange(_watcher, Ms(RouteTimeoutSeconds), Ms(RouteTimeoutSeconds) + 500)) // (2.0, 2.5) s
-            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable))
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout))
             .And(x => response.ReasonPhrase.ShouldBe("Request timeout", "Request timeout"))
             .And(x => ThenTheResponseBodyShouldBe("Request timeout for route -> /"))
         .BDDfy();
@@ -292,8 +292,8 @@ public sealed class QualityOfServiceTests : QosSteps
         int globalTimeoutMs = Ms(GlobalTimeoutSeconds);
         var responses = new HttpResponseMessage[2];
         this
-            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
-            .Given(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
+            .Given(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunningAsync(WithQualityOfService))
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway(
@@ -303,7 +303,7 @@ public sealed class QualityOfServiceTests : QosSteps
             .And(x => ThenTimeoutIsInRange(_watchers[0], globalTimeoutMs, globalTimeoutMs + 500)) // (2.0, 2.5) so assert precisely
             .Then(x => ThenTimeoutIsInRange(_watchers[1], globalTimeoutMs, Ms(DownstreamRoute.DefaultTimeoutSeconds))) // (2.0, 90) so assert roughly
             .And(x => ThenTimeoutIsInRange(_watchers[1], globalTimeoutMs, globalTimeoutMs + 500)) // (2.0, 2.5) so assert precisely
-            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             .And(x => response.ReasonPhrase.ShouldBe("Request timeout", "Request timeout"))
             // ThenTheResponseBodyShouldBeAsync("Request timeout for route -> /route2");
             .And(x => ResponseBodyShouldStartWith("Request timeout for route -> /route")) // route1 or route2 due to load balancing

--- a/test/Ocelot.UnitTests/QualityOfService/CircuitBreakerDelegatingHandlerTests.cs
+++ b/test/Ocelot.UnitTests/QualityOfService/CircuitBreakerDelegatingHandlerTests.cs
@@ -302,7 +302,7 @@ public class CircuitBreakerDelegatingHandlerTests : UnitTest
     }
 
     [Fact]
-    public async Task SendAsync_WithTimeout_ExceedsTimeout_Returns503AndRecordsFailure()
+    public async Task SendAsync_WithTimeout_ExceedsTimeout_Returns504AndRecordsFailure()
     {
         const int timeoutMs = 100, serviceDelayMs = 500;
         var opts = new QoSOptions(100, 5000) { Timeout = timeoutMs };
@@ -310,7 +310,7 @@ public class CircuitBreakerDelegatingHandlerTests : UnitTest
 
         var response = await SendAsync(handler, new HttpRequestMessage(HttpMethod.Get, "http://test/"), CancelMe);
 
-        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(HttpStatusCode.GatewayTimeout, response.StatusCode);
         Assert.Equal(1, handler.CircuitBreaker.FailureCount);
     }
 

--- a/test/Ocelot.UnitTests/Requester/HttpExceptionToErrorMapperTests.cs
+++ b/test/Ocelot.UnitTests/Requester/HttpExceptionToErrorMapperTests.cs
@@ -99,7 +99,7 @@ public class HttpExceptionToErrorMapperTests
         // Assert
         Assert.IsType<RequestTimedOutError>(error);
         Assert.Equal(25, (int)error.Code);
-        Assert.Equal(503, error.HttpStatusCode);
+        Assert.Equal(504, error.HttpStatusCode);
         Assert.Equal("Timeout making http request, exception: System.TimeoutException: test", error.Message);
     }
 

--- a/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/test/Ocelot.UnitTests/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -26,9 +26,9 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
 
     [Theory]
     [InlineData(OcelotErrorCode.RequestTimedOutError)]
-    public void Should_return_service_unavailable(OcelotErrorCode errorCode)
+    public void Should_return_gateway_timeout(OcelotErrorCode errorCode)
     {
-        ShouldMapErrorToStatusCode(errorCode, HttpStatusCode.ServiceUnavailable);
+        ShouldMapErrorToStatusCode(errorCode, HttpStatusCode.GatewayTimeout);
     }
 
     [Theory]
@@ -120,7 +120,7 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
     }
 
     [Fact]
-    public void ServiceUnavailableErrorsHaveThirdHighestPriority()
+    public void GatewayTimeoutErrorsHaveThirdHighestPriority()
     {
         var errors = new List<OcelotErrorCode>
         {
@@ -128,7 +128,7 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
             OcelotErrorCode.RequestTimedOutError,
         };
 
-        ShouldMapErrorsToStatusCode(errors, HttpStatusCode.ServiceUnavailable);
+        ShouldMapErrorsToStatusCode(errors, HttpStatusCode.GatewayTimeout);
     }
 
     [Fact]


### PR DESCRIPTION
## Fixes #1687 
- #1687 

Updates downstream request timeout handling from 503 Service Unavailable to 504 Gateway Timeout across the timeout error, status mapper, built-in QoS timeout response, tests, and docs.

Validation:
- `git diff --check HEAD~1 HEAD`
- static search confirmed timeout docs/tests now reference 504

Not run:
- full dotnet test, because local CPU was pinned at 100% during validation