### PR TITLE
#679 Fix URL claim type authorization

### DIFF
--- a/src/Ocelot/Authorization/RouteClaimsRequirementPostConfigureOptions.cs
+++ b/src/Ocelot/Authorization/RouteClaimsRequirementPostConfigureOptions.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Ocelot.Configuration.File;
+
+namespace Ocelot.Authorization;
+
+public sealed class RouteClaimsRequirementPostConfigureOptions : IPostConfigureOptions<FileConfiguration>
+{
+    private readonly IConfiguration _configuration;
+
+    public RouteClaimsRequirementPostConfigureOptions(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public void PostConfigure(string name, FileConfiguration options)
+    {
+        if (options?.Routes == null)
+        {
+            return;
+        }
+
+        var routes = _configuration.GetSection(nameof(FileConfiguration.Routes));
+        for (var i = 0; i < options.Routes.Count; i++)
+        {
+            var route = options.Routes[i];
+            var routeClaims = routes.GetSection(i.ToString())
+                .GetSection(nameof(FileRoute.RouteClaimsRequirement));
+            var requirements = ReadRequirements(routeClaims);
+
+            if (requirements.Count > 0)
+            {
+                route.RouteClaimsRequirement = requirements;
+            }
+        }
+    }
+
+    private static Dictionary<string, string> ReadRequirements(IConfigurationSection section)
+    {
+        var requirements = new Dictionary<string, string>();
+        foreach (var child in section.GetChildren())
+        {
+            ReadRequirements(child, child.Key, requirements);
+        }
+
+        return requirements;
+    }
+
+    private static void ReadRequirements(IConfigurationSection section, string key, Dictionary<string, string> requirements)
+    {
+        if (section.Value != null)
+        {
+            requirements[key] = section.Value;
+        }
+
+        foreach (var child in section.GetChildren())
+        {
+            ReadRequirements(child, ConfigurationPath.Combine(key, child.Key), requirements);
+        }
+    }
+}

--- a/src/Ocelot/DependencyInjection/OcelotBuilder.cs
+++ b/src/Ocelot/DependencyInjection/OcelotBuilder.cs
@@ -51,6 +51,7 @@ public class OcelotBuilder : IOcelotBuilder
         Configuration = configurationRoot;
         Services = services;
         Services.Configure<FileConfiguration>(configurationRoot);
+        Services.AddSingleton<IPostConfigureOptions<FileConfiguration>>(new RouteClaimsRequirementPostConfigureOptions(configurationRoot));
         Services.Configure<FileGlobalConfiguration>(configurationRoot.GetSection(nameof(FileConfiguration.GlobalConfiguration)));
         Services.AddConfigurationValidators(); // based on the AbstractValidator<FileModel> interface
 

--- a/test/Ocelot.UnitTests/Authorization/ClaimsAuthorizerTests.cs
+++ b/test/Ocelot.UnitTests/Authorization/ClaimsAuthorizerTests.cs
@@ -109,6 +109,27 @@ public class ClaimsAuthorizerTests : UnitTest
     }
 
     [Fact]
+    [Trait("Bug", "679")]
+    public void Should_authorize_user_with_url_claim_type()
+    {
+        // Arrange
+        GivenAClaimsPrincipal(new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+        {
+            new(ClaimTypes.Role, "Admin"),
+        })));
+        GivenARouteClaimsRequirement(new Dictionary<string, string>
+        {
+            { ClaimTypes.Role, "Admin" },
+        });
+
+        // Act
+        WhenICallTheAuthorizer();
+
+        // Assert
+        ThenTheUserIsAuthorized();
+    }
+
+    [Fact]
     public void Should_not_authorize_user()
     {
         // Arrange

--- a/test/Ocelot.UnitTests/Authorization/RouteClaimsRequirementPostConfigureOptionsTests.cs
+++ b/test/Ocelot.UnitTests/Authorization/RouteClaimsRequirementPostConfigureOptionsTests.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Ocelot.Configuration.File;
+using Ocelot.DependencyInjection;
+using System.Security.Claims;
+using System.Text;
+
+namespace Ocelot.UnitTests.Authorization;
+
+public sealed class RouteClaimsRequirementPostConfigureOptionsTests : UnitTest
+{
+    [Fact]
+    [Trait("Bug", "679")]
+    public void Should_bind_route_claim_requirement_key_containing_url_claim_type()
+    {
+        // Arrange
+        var configuration = GivenConfiguration(new()
+        {
+            { "Role", "User" },
+            { ClaimTypes.Role, "Admin" },
+        });
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddOcelot(configuration);
+        using var provider = services.BuildServiceProvider(true);
+        var fileConfiguration = provider.GetRequiredService<IOptions<FileConfiguration>>().Value;
+        var requirements = fileConfiguration.Routes[0].RouteClaimsRequirement;
+
+        // Assert
+        requirements.Count.ShouldBe(2);
+        requirements["Role"].ShouldBe("User");
+        requirements[ClaimTypes.Role].ShouldBe("Admin");
+        requirements.ContainsKey("http").ShouldBeFalse();
+    }
+
+    private static IConfiguration GivenConfiguration(Dictionary<string, string> routeClaimsRequirement)
+    {
+        var fileConfiguration = new FileConfiguration
+        {
+            Routes = new()
+            {
+                new()
+                {
+                    RouteClaimsRequirement = routeClaimsRequirement,
+                },
+            },
+        };
+        var json = JsonConvert.SerializeObject(fileConfiguration);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return new ConfigurationBuilder()
+            .AddJsonStream(new MemoryStream(bytes))
+            .Build();
+    }
+}


### PR DESCRIPTION
## Fixes #679 
- #679 

## Summary
- Preserve URL-shaped `RouteClaimsRequirement` keys such as `ClaimTypes.Role` when binding Ocelot JSON configuration.
- Add a post-configure pass that reconstructs nested configuration sections into their original claim-type keys before route authorization uses them.
- Cover direct authorization with URL claim types and configuration binding for mixed plain/URL claim keys.

## Checks

- `git diff HEAD~1 HEAD --check`
- Static search confirmed the post-configure hook is registered and both regression tests are present.

I did not run `dotnet test` locally because the workstation had active `dotnet` processes and sustained 100% CPU during this pass.