### PR TITLE
#2143 Fix static upstream routes with regex metacharacters

### DIFF
--- a/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
+++ b/src/Ocelot/Configuration/Creator/UpstreamTemplatePatternCreator.cs
@@ -13,6 +13,7 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
     private const string RegExIgnoreCase = "(?i)";
     private const string RegExForwardSlashOnly = "^/$";
     private const string RegExForwardSlashAndOnePlaceHolder = "^/.*";
+    private const string QuerySeparatorPattern = @"(/$|/\?|\?|$)";
     private readonly IOcelotCache<Regex> _cache;
 
     public UpstreamTemplatePatternCreator(IOcelotCache<Regex> cache)
@@ -43,14 +44,15 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
         }
 
         var containsQueryString = false;
+        string querySeparator = null;
 
         if (upstreamTemplate.Contains('?'))
         {
             containsQueryString = true;
-            upstreamTemplate = upstreamTemplate.Replace(
-                upstreamTemplate.Contains("/?") ? "/?" : "?",
-                @"(/$|/\?|\?|$)");
+            querySeparator = upstreamTemplate.Contains("/?") ? "/?" : "?";
         }
+
+        upstreamTemplate = EscapeLiteralSegments(upstreamTemplate, placeholders, querySeparator);
 
         for (var i = 0; i < placeholders.Count; i++)
         {
@@ -72,7 +74,7 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
         }
 
         var index = upstreamTemplate.LastIndexOf('/'); // index of last forward slash
-        if (index < (upstreamTemplate.Length - 1) && upstreamTemplate[index + 1] == '.')
+        if (index < (upstreamTemplate.Length - 1) && StartsWithEscapedDot(upstreamTemplate, index))
         {
             upstreamTemplate = upstreamTemplate[..index] + "(?:|/" + upstreamTemplate[++index..] + ")";
         }
@@ -122,4 +124,76 @@ public class UpstreamTemplatePatternCreator : IUpstreamTemplatePatternCreator
 
     private static bool IsPlaceHolder(string upstreamTemplate, int i)
         => upstreamTemplate[i] == '{';
+
+    private static bool StartsWithEscapedDot(string upstreamTemplate, int slashIndex)
+        => upstreamTemplate[slashIndex + 1] == '.'
+           || (slashIndex < upstreamTemplate.Length - 2
+               && upstreamTemplate[slashIndex + 1] == '\\'
+               && upstreamTemplate[slashIndex + 2] == '.');
+
+    private static string EscapeLiteralSegments(string upstreamTemplate, List<string> placeholders, string querySeparator)
+    {
+        if (placeholders.Count == 0 && string.IsNullOrEmpty(querySeparator))
+        {
+            return Regex.Escape(upstreamTemplate);
+        }
+
+        var builder = new StringBuilder();
+        var index = 0;
+
+        while (index < upstreamTemplate.Length)
+        {
+            var (segmentIndex, segmentLength, segmentValue) = FindNextPreservedSegment(upstreamTemplate, placeholders, querySeparator, index);
+            if (segmentIndex < 0)
+            {
+                builder.Append(Regex.Escape(upstreamTemplate[index..]));
+                break;
+            }
+
+            if (segmentIndex > index)
+            {
+                builder.Append(Regex.Escape(upstreamTemplate[index..segmentIndex]));
+            }
+
+            builder.Append(segmentValue);
+            index = segmentIndex + segmentLength;
+        }
+
+        return builder.ToString();
+    }
+
+    private static (int Index, int Length, string Value) FindNextPreservedSegment(
+        string upstreamTemplate,
+        List<string> placeholders,
+        string querySeparator,
+        int startIndex)
+    {
+        var segmentIndex = -1;
+        var segmentLength = 0;
+        var segmentValue = string.Empty;
+
+        foreach (var candidate in placeholders)
+        {
+            var index = upstreamTemplate.IndexOf(candidate, startIndex, StringComparison.Ordinal);
+            if (index >= 0 && (segmentIndex < 0 || index < segmentIndex))
+            {
+                segmentIndex = index;
+                segmentLength = candidate.Length;
+                segmentValue = candidate;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(querySeparator))
+        {
+            var index = upstreamTemplate.IndexOf(querySeparator, startIndex, StringComparison.Ordinal);
+            if (index >= 0 && (segmentIndex < 0 || index < segmentIndex))
+            {
+                segmentIndex = index;
+                segmentLength = querySeparator.Length;
+                segmentValue = QuerySeparatorPattern;
+            }
+        }
+
+        return (segmentIndex, segmentLength, segmentValue);
+    }
 }

--- a/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/UpstreamTemplatePatternCreatorTests.cs
@@ -306,6 +306,41 @@ public class UpstreamTemplatePatternCreatorTests : UnitTest
         result.ShouldMatchWithRegex(requestPath, shouldMatch);
     }
 
+    [Theory]
+    [Trait("Bug", "2143")]
+    [InlineData("/v3/Orders/$query", "/v3/Orders/$query", true)]
+    [InlineData("/v3/Orders/$query", "/v3/Orders/query", false)]
+    [InlineData("/api/debug()", "/api/debug()", true)]
+    [InlineData("/api/debug()", "/api/debug", false)]
+    [InlineData("/api/products+orders", "/api/products+orders", true)]
+    [InlineData("/api/products+orders", "/api/productsorders", false)]
+    [InlineData("/api/v1.0/items", "/api/v1.0/items", true)]
+    [InlineData("/api/v1.0/items", "/api/v110/items", false)]
+    [InlineData("/api/v{version}/$metadata", "/api/v1/$metadata", true)]
+    [InlineData("/api/v{version}/$metadata", "/api/v1/metadata", false)]
+    [InlineData("/api/products?$filter={filter}", "/api/products?$filter=a/b", true)]
+    [InlineData("/api/products?$filter={filter}", "/api/products?xfilter=a/b", false)]
+    [InlineData("/orders/$metadata/{everything}", "/orders/$metadata", true)]
+    [InlineData("/orders/$metadata/{everything}", "/orders/$metadata/a/b", true)]
+    [InlineData("/orders/$metadata/{everything}", "/orders/metadata/a", false)]
+    [InlineData("/api/$metadata/.json", "/api/$metadata", true)]
+    [InlineData("/api/$metadata/.json", "/api/$metadata/.json", true)]
+    [InlineData("/api/$metadata/.json", "/api/metadata/.json", false)]
+    public void Should_treat_static_route_special_regex_chars_as_literals(string urlPathTemplate, string requestPath, bool shouldMatch)
+    {
+        // Arrange
+        var fileRoute = new FileRoute
+        {
+            UpstreamPathTemplate = urlPathTemplate,
+        };
+
+        // Act
+        var result = _creator.Create(fileRoute);
+
+        // Assert
+        result.ShouldMatchWithRegex(requestPath, shouldMatch);
+    }
+
     [Fact]
     [Trait("Feat", "1348")]
     [Trait("Bug", "2246")]


### PR DESCRIPTION
## Fixes #2143
- #2143 

## Proposed Changes

- Escape literal upstream path template segments before compiling them into route-matching regexes, so static characters such as `$`, `+`, `(`, `)`, and `.` are matched literally.
- Preserve existing placeholder, catch-all, query-string, and optional `/.format` behavior while escaping only static text.
- Add regression coverage for static regex metacharacters, metacharacters near placeholders, query keys such as `$filter`, catch-all paths, and optional format suffixes.

## Verification

- `git diff --check` passed.
- `dotnet test --project test\Ocelot.UnitTests\Ocelot.UnitTests.csproj --framework net10.0 --filter "FullyQualifiedName~Should_treat_static_route_special_regex_chars_as_literals|FullyQualifiedName~Should_not_match_with_query_param_wildcard"` passed: 20 succeeded.
- `dotnet test --project test\Ocelot.UnitTests\Ocelot.UnitTests.csproj --framework net10.0 --filter-class Ocelot.UnitTests.Configuration.UpstreamTemplatePatternCreatorTests` passed: 38 succeeded.
- `dotnet test --project test\Ocelot.UnitTests\Ocelot.UnitTests.csproj --framework net10.0` executed the full unit suite with 1777 succeeded, 2 skipped, and 0 failed, then returned exit code 1 because foreground threads were still running after test completion.

Not run locally:

- `net8.0` and `net9.0`, because this workstation currently only has .NET 10 runtimes/SDK installed.