### PR TITLE
#2191 Fix special query values in downstream URLs

### DIFF
--- a/src/Ocelot/DownstreamUrlCreator/DownstreamUrlCreatorMiddleware.cs
+++ b/src/Ocelot/DownstreamUrlCreator/DownstreamUrlCreatorMiddleware.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
 using Ocelot.Configuration;
 using Ocelot.DownstreamRouteFinder.UrlMatcher;
 using Ocelot.Infrastructure.Extensions;
@@ -8,7 +9,6 @@ using Ocelot.Middleware;
 using Ocelot.Request.Middleware;
 using Ocelot.ServiceDiscovery.Providers;
 using Ocelot.Values;
-using System.Web;
 
 namespace Ocelot.DownstreamUrlCreator;
 
@@ -95,26 +95,81 @@ public class DownstreamUrlCreatorMiddleware : OcelotMiddleware
     /// <returns>A <see cref="string"/> object.</returns>
     protected static string MergeQueryStringsWithoutDuplicateValues(string queryString, string newQueryString, List<PlaceholderNameAndValue> placeholders)
     {
-        newQueryString = newQueryString.Replace(QuestionMark, Ampersand);
-        var queries = HttpUtility.ParseQueryString(queryString);
-        var newQueries = HttpUtility.ParseQueryString(newQueryString);
+        var queries = ParseQueryStringPreservingPlus(queryString);
+        var newQueries = ParseQueryStringPreservingPlus(newQueryString);
 
         // Remove old replaced query parameters
         var placeholderKeys = new HashSet<string>(placeholders.Select(p => p.Key));
-        foreach (var queryKey in queries.AllKeys.Where(placeholderKeys.Contains))
+        foreach (var queryKey in queries.Keys.Where(placeholderKeys.Contains).ToArray())
         {
             queries.Remove(queryKey);
         }
 
-        var parameters = newQueries.AllKeys
-            .Where(key => key.IsNotEmpty())
-            .ToDictionary(key => key, key => newQueries[key]);
+        var parameters = newQueries
+            .Where(pair => pair.Key.IsNotEmpty())
+            .ToDictionary(pair => pair.Key, pair => pair.Value);
 
-        _ = queries.AllKeys
-            .Where(key => key.IsNotEmpty() && !parameters.ContainsKey(key))
-            .All(key => parameters.TryAdd(key, queries[key]));
+        foreach (var pair in queries.Where(pair => pair.Key.IsNotEmpty() && !parameters.ContainsKey(pair.Key)))
+        {
+            parameters.TryAdd(pair.Key, pair.Value);
+        }
 
         return QueryHelpers.AddQueryString(string.Empty, parameters);
+    }
+
+    private static Dictionary<string, StringValues> ParseQueryStringPreservingPlus(string queryString)
+    {
+        if (string.IsNullOrEmpty(queryString))
+        {
+            return new Dictionary<string, StringValues>();
+        }
+
+        var query = queryString.StartsWith(QuestionMark)
+            ? queryString[1..]
+            : queryString;
+
+        var result = new Dictionary<string, StringValues>();
+        foreach (var segment in query.Split(Ampersand, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var equalsIndex = segment.IndexOf('=');
+            var key = equalsIndex < 0
+                ? segment
+                : segment[..equalsIndex];
+            var value = equalsIndex < 0
+                ? string.Empty
+                : segment[(equalsIndex + 1)..];
+
+            key = UrlDecodePreservingPlus(key);
+            value = UrlDecodePreservingPlus(value);
+
+            if (result.TryGetValue(key, out var existing))
+            {
+                result[key] = StringValues.Concat(existing, value);
+            }
+            else
+            {
+                result.Add(key, value);
+            }
+        }
+
+        return result;
+    }
+
+    private static string UrlDecodePreservingPlus(string value)
+    {
+        if (!value.Contains('%'))
+        {
+            return value;
+        }
+
+        try
+        {
+            return Uri.UnescapeDataString(value);
+        }
+        catch (UriFormatException)
+        {
+            return value;
+        }
     }
 
     /// <summary>

--- a/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
+++ b/test/Ocelot.UnitTests/DownstreamUrlCreator/DownstreamUrlCreatorMiddlewareTests.cs
@@ -628,9 +628,11 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
 
     [Theory]
     [Trait("Bug", "2116")]
-    [InlineData("api/debug()")] // no query
-    [InlineData("api/debug%28%29")] // debug()
-    public async Task ShouldNotFailToHandleUrlWithSpecialRegexChars(string urlPath)
+    [InlineData("api/debug()", "api/debug()")] // no query
+    [InlineData("api/debug%28%29", "api/debug%28%29")] // debug()
+    [InlineData(@"api/debug()?special=(\,*,+,?,|,{,},[,],(,),^,$,.,#, ,)&2=(2)&3=[3]&4={4}",
+        @"api/debug()?special=(%5C,*,%2B,%3F,%7C,%7B,%7D,%5B,%5D,(,),%5E,$,.,%23,%20,)&2=(2)&3=%5B3%5D&4=%7B4%7D")] // query with special chars
+    public async Task ShouldNotFailToHandleUrlWithSpecialRegexChars(string urlPath, string expectedUrlPath)
     {
         // Arrange
         var withGetMethod = new List<string> { "Get" };
@@ -657,7 +659,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
         await _middleware.Invoke(_httpContext);
 
         // Assert
-        ThenTheDownstreamRequestUriIs($"http://localhost:5000/routed/{urlPath}");
+        ThenTheDownstreamRequestUriIs($"http://localhost:5000/routed/{expectedUrlPath}");
         Assert.Equal((int)HttpStatusCode.OK, _httpContext.Response.StatusCode);
     }
 
@@ -683,7 +685,7 @@ public sealed class DownstreamUrlCreatorMiddlewareTests : UnitTest
         var config = new ServiceProviderConfigurationBuilder()
             .Build();
         GivenTheDownStreamRouteIs(new DownstreamRouteHolder(
-            [ new(placeholder, "123") ],
+            [new(placeholder, "123")],
             new(downstreamRoute, HttpMethod.Get)
         ));
         GivenTheDownstreamRequestUriIs(url);


### PR DESCRIPTION
## Fixes #2191 
- #2191 

## Summary
- Replace `HttpUtility.ParseQueryString` in downstream query merging with a parser that preserves literal `+` values and only splits query pairs on `&`.
- Keep duplicate query values via `StringValues` before rebuilding with `QueryHelpers.AddQueryString`.
- Add regression coverage for #2191 with regex metacharacters and reserved URL characters in a query value.

## Testing
- `git diff --check`
- `dotnet format Ocelot.sln whitespace --verify-no-changes --include src\Ocelot\DownstreamUrlCreator\DownstreamUrlCreatorMiddleware.cs test\Ocelot.UnitTests\DownstreamUrlCreator\DownstreamUrlCreatorMiddlewareTests.cs --no-restore -v minimal`
- `dotnet test --project test\Ocelot.UnitTests\Ocelot.UnitTests.csproj --framework net10.0 --filter "FullyQualifiedName~Ocelot.UnitTests.DownstreamUrlCreator.DownstreamUrlCreatorMiddlewareTests" -v minimal` (43 passed)
- `dotnet test --project test\Ocelot.AcceptanceTests\Ocelot.AcceptanceTests.csproj --framework net10.0 --filter "FullyQualifiedName~Ocelot.AcceptanceTests.Routing.RoutingWithQueryStringTests" -v minimal` (24 passed)
- `dotnet test --project test\Ocelot.UnitTests\Ocelot.UnitTests.csproj --framework net10.0 -v minimal` currently exits with Microsoft Testing Platform error `Foreground threads were left running` despite zero failed assertions; reproduced on a clean `origin/develop` worktree as well, so this appears unrelated to this change.