### PR TITLE
Harden the `Kube` provider, repository `FileConfigurationPoller`, and infrastructure `InMemoryBus`, and stabilize their tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -52,24 +52,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore ./Ocelot.slnx --framework ${{ matrix.framework }}.0          
     - name: Unit Tests
-      run: |
-        dotnet test --no-restore --no-build --verbosity normal --framework ${{ matrix.framework }}.0 \
-          --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj > test_output.txt 2>&1 || true
-        if grep -q "failed: 0" test_output.txt && grep -q "succeeded:" test_output.txt; then
-          echo "✓ Test run successful"
-          echo "::group::------- Test Output -------"
-          cat test_output.txt
-          echo "::endgroup::"
-          echo "✓ Test run successful"
-          exit 0
-        else
-          echo "✗ Test run failed"
-          echo "::group::------- Test Output -------"
-          cat test_output.txt
-          echo "::endgroup::"
-          echo "✗ Test run failed"
-          exit 1
-        fi
+      run: dotnet test --no-restore --no-build --verbosity normal --framework ${{ matrix.framework }}.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj
     - name: Acceptance Tests
       run: dotnet test --no-restore --no-build --verbosity minimal --framework ${{ matrix.framework }}.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
 
@@ -108,22 +91,7 @@ jobs:
       - name: Unit Tests
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
-            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*" > test_output.txt 2>&1 || true
-          if grep -q "failed: 0" test_output.txt && grep -q "succeeded:" test_output.txt; then
-            echo "✓ Test run successful"
-            echo "::group::------- Test Output -------"
-            cat test_output.txt
-            echo "::endgroup::"
-            echo "✓ Test run successful"
-            exit 0
-          else
-            echo "✗ Test run failed"
-            echo "::group::------- Test Output -------"
-            cat test_output.txt
-            echo "::endgroup::"
-            echo "✗ Test run failed"
-            exit 1
-          fi
+            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
       # - name: Acceptance Tests
       #   run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -239,21 +239,21 @@ jobs:
       - name: Unit Tests
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
-            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*" \
-            --report-xunit-trx --report-xunit-trx-filename=unit-tests.trx | tee test_output.txt
-          if grep -q "failed: 0" test_output.txt; then
-            echo "✓ Test run successful"
-            exit 0
-          else
-            echo "✗ Test run failed: No 'failed: 0' found"
-            exit 1
-          fi
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-tests-trx
-          path: "test/Ocelot.UnitTests/bin/Debug/**/unit-tests.trx"
+            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
+          # --report-xunit-trx --report-xunit-trx-filename=unit-tests.trx | tee test_output.txt
+          # if grep -q "failed: 0" test_output.txt; then
+          #   echo "✓ Test run successful"
+          #   exit 0
+          # else
+          #   echo "✗ Test run failed: No 'failed: 0' found"
+          #   exit 1
+          # fi
+      # - name: Upload Test Results
+      #   if: always()
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: unit-tests-trx
+      #     path: "test/Ocelot.UnitTests/bin/Debug/**/unit-tests.trx"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -237,6 +237,8 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
       - name: Unit Tests
+        env:
+          COVERLET_ENABLE_SUMMARY: true
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
             --coverlet --coverlet-output-format cobertura --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -239,21 +239,7 @@ jobs:
       - name: Unit Tests
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
-            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
-          # --report-xunit-trx --report-xunit-trx-filename=unit-tests.trx | tee test_output.txt
-          # if grep -q "failed: 0" test_output.txt; then
-          #   echo "✓ Test run successful"
-          #   exit 0
-          # else
-          #   echo "✗ Test run failed: No 'failed: 0' found"
-          #   exit 1
-          # fi
-      # - name: Upload Test Results
-      #   if: always()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: unit-tests-trx
-      #     path: "test/Ocelot.UnitTests/bin/Debug/**/unit-tests.trx"
+            --coverlet --coverlet-output-format cobertura --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -237,11 +237,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./Ocelot.slnx --framework net10.0
       - name: Unit Tests
-        env:
-          COVERLET_ENABLE_SUMMARY: true
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
-            --coverlet --coverlet-output-format cobertura --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
+            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -240,7 +240,7 @@ jobs:
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
             --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*" \
-            --logger "trx;LogFileName=unit-tests.trx" | tee test_output.txt
+            --report-xunit-trx --report-xunit-trx-filename=unit-tests.trx | tee test_output.txt
           if grep -q "failed: 0" test_output.txt; then
             echo "✓ Test run successful"
             exit 0
@@ -253,7 +253,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: unit-test-results-net10
-          path: "**/*.trx"
+          path: "test/Ocelot.UnitTests/bin/Debug/net10.0/unit-tests.trx"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -239,7 +239,8 @@ jobs:
       - name: Unit Tests
         run: |
           dotnet test --no-restore --no-build --verbosity normal --framework net10.0 --project ./test/Ocelot.UnitTests/Ocelot.UnitTests.csproj \
-            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*" | tee test_output.txt
+            --coverlet --coverlet-include "[Ocelot*]*" --coverlet-exclude "[Ocelot.Testing]*" \
+            --logger "trx;LogFileName=unit-tests.trx" | tee test_output.txt
           if grep -q "failed: 0" test_output.txt; then
             echo "✓ Test run successful"
             exit 0
@@ -247,6 +248,12 @@ jobs:
             echo "✗ Test run failed: No 'failed: 0' found"
             exit 1
           fi
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results-net10
+          path: "**/*.trx"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -252,8 +252,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: unit-test-results-net10
-          path: "test/Ocelot.UnitTests/bin/Debug/net10.0/unit-tests.trx"
+          name: unit-tests-trx
+          path: "test/Ocelot.UnitTests/bin/Debug/**/unit-tests.trx"
       - name: Acceptance Tests
         run: dotnet test --no-restore --no-build --verbosity minimal --framework net10.0 --project ./test/Ocelot.AcceptanceTests/Ocelot.AcceptanceTests.csproj
       - name: Coverage files

--- a/src/Ocelot.Provider.Kubernetes/Kube.cs
+++ b/src/Ocelot.Provider.Kubernetes/Kube.cs
@@ -65,12 +65,10 @@ public class Kube : IServiceDiscoveryProvider, IDisposable
                 .EndpointsV1()
                 .GetAsync(_configuration.KeyOfServiceInK8s, _configuration.KubeNamespace);
         }
-        catch (ObjectDisposedException ex)
-        {
-            // The _kubeApi was disposed while this operation was in progress.
-            // This can occur during shutdown when Dispose() is called while async operations are still running.
-            _logger.LogError(() => Message($"(provider was disposed during operation)."), ex);
-        }
+        // The _kubeApi was disposed while this operation was in progress.
+        // This can occur during shutdown when Dispose() is called while async operations are still running.
+        catch (ObjectDisposedException)
+        { } // return null;
         catch (KubeApiException ex)
         {
             string Msg()

--- a/src/Ocelot.Provider.Kubernetes/Kube.cs
+++ b/src/Ocelot.Provider.Kubernetes/Kube.cs
@@ -65,6 +65,12 @@ public class Kube : IServiceDiscoveryProvider, IDisposable
                 .EndpointsV1()
                 .GetAsync(_configuration.KeyOfServiceInK8s, _configuration.KubeNamespace);
         }
+        catch (ObjectDisposedException ex)
+        {
+            // The _kubeApi was disposed while this operation was in progress.
+            // This can occur during shutdown when Dispose() is called while async operations are still running.
+            _logger.LogError(() => Message($"(provider was disposed during operation)."), ex);
+        }
         catch (KubeApiException ex)
         {
             string Msg()

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -67,9 +67,8 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
         timer.Change(Timeout.Infinite, Timeout.Infinite); // Stop the timer to prevent new callbacks
 
         // timer.Dispose(WaitHandle) signals the WaitHandle once all pending callbacks complete.
-        // Do NOT use 'using': if WaitOne times out while a callback is still in-flight, the timer
-        // will attempt to signal the handle when the callback eventually finishes. Disposing the
-        // handle early causes an ObjectDisposedException on the ThreadPool thread.
+        // Do NOT use 'using': if WaitOne times out while a callback is still in-flight, the timer will attempt to signal the handle when the callback eventually finishes.
+        // Disposing the handle early causes an ObjectDisposedException on the ThreadPool thread.
         var timerStopped = new ManualResetEvent(false);
         timer.Dispose(timerStopped);
 
@@ -83,20 +82,30 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
         {
             _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Timer disposal did not complete within timeout.");
 
-            // Keep timerStopped alive until the timer signals it (when the callback finishes),
-            // to prevent ObjectDisposedException on the ThreadPool thread.
-            _ = Task.Run(() =>
-            {
-                try { timerStopped.WaitOne(); }
-                catch (Exception ex) { _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Unexpected error waiting for timer cleanup: {ex}."); }
-                finally { timerStopped.Dispose(); }
-            });
+            // Keep timerStopped alive until the timer signals it (when the callback finishes), to prevent ObjectDisposedException on the ThreadPool thread.
+            _ = Task.Run(() => SafeDisposeManualResetEvent(timerStopped));
         }
         else
         {
             timerStopped.Dispose();
         }
     }
+
+    private void SafeDisposeManualResetEvent(ManualResetEvent @event)
+    {
+        try
+        {
+            @event.WaitOne();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Unexpected error waiting for timer cleanup: {ex}.");
+        }
+        finally
+        {
+            @event.Dispose();
+        }
+    }   
 
     public void Poll()
     {

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -65,6 +65,7 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
 
         _logger.LogInformation(() => $"{nameof(FileConfigurationPoller)} is stopping.");
         timer.Change(Timeout.Infinite, Timeout.Infinite); // Stop the timer to prevent new callbacks
+        timer.Dispose(); // Dispose to release the background thread
     }
 
     public void Poll()

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -88,6 +88,7 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
             _ = Task.Run(() =>
             {
                 try { timerStopped.WaitOne(); }
+                catch (Exception ex) { _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Unexpected error waiting for timer cleanup: {ex}."); }
                 finally { timerStopped.Dispose(); }
             });
         }

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -66,13 +66,34 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
         _logger.LogInformation(() => $"{nameof(FileConfigurationPoller)} is stopping.");
         timer.Change(Timeout.Infinite, Timeout.Infinite); // Stop the timer to prevent new callbacks
 
-        // Use a WaitHandle to ensure all pending callbacks complete before disposal
-        using var timerStopped = new ManualResetEvent(false);
+        // timer.Dispose(WaitHandle) signals the WaitHandle once all pending callbacks complete.
+        // Do NOT use 'using': if WaitOne times out while a callback is still in-flight, the timer
+        // will attempt to signal the handle when the callback eventually finishes. Disposing the
+        // handle early causes an ObjectDisposedException on the ThreadPool thread.
+        var timerStopped = new ManualResetEvent(false);
         timer.Dispose(timerStopped);
-        // Wait for any in-flight callbacks to finish (with a reasonable timeout)
-        if (!timerStopped.WaitOne(TimeSpan.FromSeconds(5)))
+
+        // Await asynchronously so callers are not blocked while waiting for in-flight callbacks.
+        var completed = await Task.Run(
+            () => timerStopped.WaitOne(TimeSpan.FromSeconds(5)),
+            CancellationToken.None) // do not cancel the wait; we must always let cleanup run
+            .ConfigureAwait(false);
+
+        if (!completed)
         {
             _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Timer disposal did not complete within timeout.");
+
+            // Keep timerStopped alive until the timer signals it (when the callback finishes),
+            // to prevent ObjectDisposedException on the ThreadPool thread.
+            _ = Task.Run(() =>
+            {
+                try { timerStopped.WaitOne(); }
+                finally { timerStopped.Dispose(); }
+            });
+        }
+        else
+        {
+            timerStopped.Dispose();
         }
     }
 

--- a/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
+++ b/src/Ocelot/Configuration/Repository/FileConfigurationPoller.cs
@@ -65,7 +65,15 @@ public class FileConfigurationPoller : IFileConfigurationPoller, IHostedService,
 
         _logger.LogInformation(() => $"{nameof(FileConfigurationPoller)} is stopping.");
         timer.Change(Timeout.Infinite, Timeout.Infinite); // Stop the timer to prevent new callbacks
-        timer.Dispose(); // Dispose to release the background thread
+
+        // Use a WaitHandle to ensure all pending callbacks complete before disposal
+        using var timerStopped = new ManualResetEvent(false);
+        timer.Dispose(timerStopped);
+        // Wait for any in-flight callbacks to finish (with a reasonable timeout)
+        if (!timerStopped.WaitOne(TimeSpan.FromSeconds(5)))
+        {
+            _logger.LogWarning(() => $"{nameof(FileConfigurationPoller)}: Timer disposal did not complete within timeout.");
+        }
     }
 
     public void Poll()

--- a/src/Ocelot/Infrastructure/InMemoryBus.cs
+++ b/src/Ocelot/Infrastructure/InMemoryBus.cs
@@ -10,7 +10,7 @@ public class InMemoryBus<T> : IBus<T>
     {
         _queue = new BlockingCollection<DelayedMessage<T>>();
         _subscriptions = new List<Action<T>>();
-        _processing = new Thread(async () => await Process())
+        _processing = new Thread(StartProcessing)
         {
             IsBackground = true
         };
@@ -28,12 +28,15 @@ public class InMemoryBus<T> : IBus<T>
         _queue.Add(delayed);
     }
 
-    private async Task Process()
-    {
-        foreach (var delayedMessage in _queue.GetConsumingEnumerable())
-        {
-            await Task.Delay(delayedMessage.Delay);
+    // For delegate void ThreadStart();
+    private void StartProcessing()
+        => Process(CancellationToken.None).GetAwaiter().GetResult();
 
+    private async Task Process(CancellationToken token = default)
+    {
+        foreach (var delayedMessage in _queue.GetConsumingEnumerable(token))
+        {
+            await Task.Delay(delayedMessage.Delay, token);
             foreach (var subscription in _subscriptions)
             {
                 subscription(delayedMessage.Message);

--- a/src/Ocelot/Infrastructure/InMemoryBus.cs
+++ b/src/Ocelot/Infrastructure/InMemoryBus.cs
@@ -10,7 +10,10 @@ public class InMemoryBus<T> : IBus<T>
     {
         _queue = new BlockingCollection<DelayedMessage<T>>();
         _subscriptions = new List<Action<T>>();
-        _processing = new Thread(async () => await Process());
+        _processing = new Thread(async () => await Process())
+        {
+            IsBackground = true
+        };
         _processing.Start();
     }
 

--- a/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubeErrorHandlingTests.cs
+++ b/test/Ocelot.AcceptanceTests/ServiceDiscovery/KubeErrorHandlingTests.cs
@@ -1,0 +1,85 @@
+using KubeClient;
+using KubeClient.Models;
+using Ocelot.Logging;
+using Ocelot.Provider.Kubernetes;
+using Ocelot.Provider.Kubernetes.Interfaces;
+using Ocelot.Values;
+
+namespace Ocelot.AcceptanceTests.ServiceDiscovery;
+
+/// <summary>
+/// Tests for Kube service discovery provider error handling, particularly around 
+/// ObjectDisposedException scenarios that occur during shutdown.
+/// </summary>
+[Trait("Milestone", ".NET 10")]
+[Trait("Release", "25.0.0")]
+public class KubeErrorHandlingTests : IDisposable
+{
+    private readonly Mock<IOcelotLoggerFactory> _factory = new();
+    private readonly Mock<IOcelotLogger> _logger = new();
+    private readonly Mock<IKubeServiceBuilder> _serviceBuilder = new();
+    private readonly KubeRegistryConfiguration _configuration;
+
+    public KubeErrorHandlingTests()
+    {
+        _factory.Setup(x => x.CreateLogger<Kube>()).Returns(_logger.Object);
+        _configuration = new KubeRegistryConfiguration
+        {
+            KeyOfServiceInK8s = "test-service",
+            KubeNamespace = "default"
+        };
+    }
+
+    public void Dispose()
+    {
+        _logger?.Invocations.Clear();
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_return_empty_list_when_disposed()
+    {
+        // Arrange
+        var mockKubeApi = new Mock<IKubeApiClient>();
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        provider.Dispose();
+        var result = await provider.GetAsync();
+
+        // Assert - should return empty list when already disposed
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public void Dispose_Should_release_resources_without_throwing()
+    {
+        // Arrange
+        var mockKubeApi = new Mock<IKubeApiClient>();
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act & Assert - multiple disposes should not throw
+        provider.Dispose();
+        provider.Dispose(); // Should not throw
+
+        _logger.Verify(x => x.Dispose(), Times.Once);
+        mockKubeApi.Verify(x => x.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public void Dispose_Should_dispose_logger_and_kubeapi()
+    {
+        // Arrange
+        var mockKubeApi = new Mock<IKubeApiClient>();
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        provider.Dispose();
+
+        // Assert
+        _logger.Verify(x => x.Dispose(), Times.Once, "Logger should be disposed");
+        mockKubeApi.Verify(x => x.Dispose(), Times.Once, "KubeApi should be disposed");
+    }
+}

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -14,29 +14,22 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     private const int PollingDelayInMs = 100;
     private const int LongRunningPollDelayInMs = PollingDelayInMs + 50;
 
-    private readonly FileConfigurationPoller _poller;
-    private readonly Mock<IOcelotLoggerFactory> _factory;
-    private readonly Mock<IFileConfigurationRepository> _repo;
-    private readonly FileConfiguration _initialFileConfig;
-    private readonly Mock<IFileConfigurationPollerOptions> _config;
-    private readonly Mock<IInternalConfigurationRepository> _internalConfigRepo;
-    private readonly Mock<IInternalConfigurationCreator> _internalConfigCreator;
-    private readonly Mock<IInternalConfiguration> _internalConfig;
+    private readonly Mock<IOcelotLogger> _logger = new();
+    private readonly Mock<IOcelotLoggerFactory> _factory = new();
+    private readonly Mock<IFileConfigurationRepository> _repo = new();
+    private readonly Mock<IFileConfigurationPollerOptions> _config = new();
+    private readonly Mock<IInternalConfigurationRepository> _internalConfigRepo = new();
+    private readonly Mock<IInternalConfigurationCreator> _internalConfigCreator = new();
+    private readonly Mock<IInternalConfiguration> _internalConfig = new();
+    private readonly FileConfiguration _initialFileConfig = new();
+    private readonly FileConfigurationPoller _poller; // service under test
 
     public FileConfigurationPollerTests()
     {
-        var logger = new Mock<IOcelotLogger>();
-        _factory = new Mock<IOcelotLoggerFactory>();
-        _factory.Setup(x => x.CreateLogger<FileConfigurationPoller>()).Returns(logger.Object);
-        _repo = new Mock<IFileConfigurationRepository>();
-        _initialFileConfig = new FileConfiguration();
-        _config = new Mock<IFileConfigurationPollerOptions>();
+        _factory.Setup(x => x.CreateLogger<FileConfigurationPoller>()).Returns(_logger.Object);
         _repo.Setup(x => x.Get()).Returns(_initialFileConfig);
         _config.Setup(x => x.Delay()).Returns(PollingDelayInMs);
         _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(PollingDelayInMs);
-        _internalConfig = new Mock<IInternalConfiguration>();
-        _internalConfigRepo = new Mock<IInternalConfigurationRepository>();
-        _internalConfigCreator = new Mock<IInternalConfigurationCreator>();
         _internalConfigCreator.Setup(x => x.Create(It.IsAny<FileConfiguration>())).ReturnsAsync(new OkResponse<IInternalConfiguration>(_internalConfig.Object));
         _poller = new FileConfigurationPoller(_factory.Object, _repo.Object, _config.Object, _internalConfigRepo.Object, _internalConfigCreator.Object);
     }
@@ -63,8 +56,8 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         var timerAfterSecondStart = CurrentTimer();
 
         // Assert
-        timerAfterFirstStart.ShouldNotBeNull();
-        timerAfterSecondStart.ShouldBeSameAs(timerAfterFirstStart);
+        Assert.NotNull(timerAfterFirstStart);
+        Assert.Same(timerAfterFirstStart, timerAfterSecondStart);
     }
 
     [Fact]
@@ -75,7 +68,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         await Task.Delay(PollingDelayInMs * 2, CancelMe);
 
         // Assert
-        NumberOfGetInvocations().ShouldBe(0);
+        Assert.Equal(0, NumberOfGetInvocations());
     }
 
     [Fact]
@@ -182,10 +175,11 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 
         // Assert
         ThenTheSetterIsCalled(_initialFileConfig, 1);
-        NumberOfGetInvocations().ShouldBe(afterStopSettled);
+        Assert.Equal(afterStopSettled, NumberOfGetInvocations());
     }
 
-    [Fact(Skip = "To Dispose or not to Dispose in StopAsync?")]
+    [Fact]
+    //[Fact(Skip = "To Dispose or not to Dispose in StopAsync?")]
     public async Task StopAsync_Should_wait_for_running_timer_callback_to_complete()
     {
         // Arrange
@@ -227,7 +221,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         timer.Dispose();
         var timerField = typeof(FileConfigurationPoller)
             .GetField("_timer", BindingFlags.Instance | BindingFlags.NonPublic);
-        timerField!.SetValue(_poller, timer);
+        timerField.SetValue(_poller, timer);
 
         // Act, Assert
         _poller.Dispose();
@@ -244,7 +238,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         // Act: invoke the private OnTimer method directly
         var onTimerMethod = typeof(FileConfigurationPoller)
             .GetMethod("OnTimer", BindingFlags.Instance | BindingFlags.NonPublic);
-        onTimerMethod!.Invoke(_poller, [null]);
+        onTimerMethod.Invoke(_poller, [null]);
 
         // Assert: Get() was never called because polling was already in progress
         _repo.Verify(x => x.Get(), Times.Never);
@@ -392,9 +386,10 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 
         // Assert - no exception and timer is null
         var timer = CurrentTimer();
-        timer.ShouldBeNull();
+        Assert.Null(timer);
     }
 
+    #region StopAsync
     [Fact]
     public async Task StopAsync_Should_dispose_timer_to_release_background_thread()
     {
@@ -402,14 +397,14 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10000); // long delay
         await _poller.StartAsync(CancelMe);
         var timerBefore = CurrentTimer();
-        timerBefore.ShouldNotBeNull();
+        Assert.NotNull(timerBefore);
 
         // Act - stop the poller, which should dispose the timer
         await _poller.StopAsync(CancelMe);
 
         // Assert - timer should be null (disposed) and no exception should be thrown
         var timerAfter = CurrentTimer();
-        timerAfter.ShouldBeNull();
+        Assert.Null(timerAfter);
     }
 
     [Fact]
@@ -425,8 +420,316 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 
         // Assert - timer should remain null
         var timer = CurrentTimer();
-        timer.ShouldBeNull();
+        Assert.Null(timer);
     }
+
+    [Fact]
+    public async Task StopAsync_Should_atomically_swap_timer_to_null_before_disposal()
+    {
+        // Arrange
+        await _poller.StartAsync(CancelMe);
+        var timerBeforeStop = CurrentTimer();
+        Assert.NotNull(timerBeforeStop);
+
+        // Act
+        await _poller.StopAsync(CancelMe);
+
+        // Assert - timer field should be null after stop
+        var timerAfterStop = CurrentTimer();
+        Assert.Null(timerAfterStop);
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_prevent_new_timer_callbacks_after_change()
+    {
+        // Arrange - set up a short polling interval to trigger callbacks
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(50);
+        int invocationCountBeforeStop = 0;
+        int invocationCountAfterStop = 0;
+
+        _repo.Setup(x => x.Get()).Returns(() =>
+        {
+            Interlocked.Increment(ref invocationCountBeforeStop);
+            return _initialFileConfig;
+        });
+
+        await _poller.StartAsync(CancelMe);
+        await Task.Delay(150, CancelMe); // allow a few callbacks
+
+        // Act
+        invocationCountBeforeStop = Volatile.Read(ref invocationCountBeforeStop);
+        await _poller.StopAsync(CancelMe);
+
+        await Task.Delay(150, CancelMe); // wait to see if more callbacks occur
+
+        // Assert - no new callbacks should fire after stop
+        var v = Volatile.Read(ref invocationCountAfterStop);
+        Assert.Equal(0, v);
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_prevent_new_callbacks_and_complete()
+    {
+        // Arrange - start with a reasonable polling interval
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(100);
+        var pollCount = 0;
+
+        _repo.Setup(x => x.Get()).Returns(() =>
+        {
+            Interlocked.Increment(ref pollCount);
+            return _initialFileConfig;
+        });
+
+        await _poller.StartAsync(CancelMe);
+        await Task.Delay(200, CancelMe); // let several polls happen
+        var countBefore = Volatile.Read(ref pollCount);
+
+        // Act
+        await _poller.StopAsync(CancelMe);
+
+        await Task.Delay(200, CancelMe); // wait to verify no new polls occur
+
+        // Assert
+        var v = Volatile.Read(ref pollCount);
+        Assert.Equal(countBefore, v); // No new polls should occur after StopAsync
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_handle_null_timer_gracefully()
+    {
+        // Arrange - don't start, so timer is null
+
+        // Act - calling stop on unstarted poller should not throw
+        await _poller.StopAsync(CancelMe);
+
+        // Assert - timer should still be null
+        var t = CurrentTimer();
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public async Task StopAsync_Called_multiple_times_should_only_dispose_once()
+    {
+        // Arrange
+        await _poller.StartAsync(CancelMe);
+        var initialTimer = CurrentTimer();
+
+        // Act - stop multiple times
+        await _poller.StopAsync(CancelMe);
+        await _poller.StopAsync(CancelMe);
+        await _poller.StopAsync(CancelMe);
+
+        // Assert - timer should be null and no exception thrown
+        var t = CurrentTimer();
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_prevent_use_of_disposed_timer_from_callbacks()
+    {
+        // Arrange
+        await _poller.StartAsync(CancelMe);
+        var timerBefore = CurrentTimer();
+        Assert.NotNull(timerBefore);
+
+        // Act
+        await _poller.StopAsync(CancelMe);
+        await Task.Delay(100, CancelMe); // allow any in-flight callbacks to complete
+
+        // Assert - timer field should be null, preventing ObjectDisposedException
+        var t = CurrentTimer();
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_complete_synchronously_when_no_callbacks_pending()
+    {
+        // Arrange
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10000); // very long delay
+        await _poller.StartAsync(CancelMe);
+
+        // Act
+        var stopTask = _poller.StopAsync(CancelMe);
+        var completedInTime = await Task.WhenAny(
+            stopTask,
+            Task.Delay(TimeSpan.FromSeconds(1), CancelMe)) == stopTask;
+
+        // Assert - should complete quickly when no pending callbacks
+        Assert.True(completedInTime); // StopAsync should complete quickly when no callbacks are pending
+    }
+
+    [Fact]
+    public async Task Dispose_Should_clean_up_timer_after_start()
+    {
+        // Arrange
+        await _poller.StartAsync(CancelMe);
+        var timerBefore = CurrentTimer();
+        Assert.NotNull(timerBefore);
+
+        // Act
+        _poller.Dispose();
+
+        // Assert - timer should be null after dispose
+        var t = CurrentTimer();
+        Assert.Null(t);
+    }
+
+    [Fact]
+    public async Task StopAsync_Then_Dispose_Should_not_throw()
+    {
+        // Arrange
+        await _poller.StartAsync(CancelMe);
+
+        // Act & Assert
+        await _poller.StopAsync(CancelMe); // should not throw
+        _poller.Dispose(); // should not throw
+    }
+
+    [Fact]
+    public async Task Multiple_Start_Stop_Cycles_Should_work_correctly()
+    {
+        // Arrange
+        var pollCount = 0;
+        _repo.Setup(x => x.Get()).Returns(() =>
+        {
+            Interlocked.Increment(ref pollCount);
+            return _initialFileConfig;
+        });
+
+        // Act & Assert - first cycle
+        await _poller.StartAsync(CancelMe);
+        await Task.Delay(100, CancelMe);
+        await _poller.StopAsync(CancelMe);
+        var countAfterFirstStop = Volatile.Read(ref pollCount);
+
+        // Act & Assert - second cycle (should work even after stop)
+        await _poller.StartAsync(CancelMe);
+        await Task.Delay(100, CancelMe);
+        await _poller.StopAsync(CancelMe);
+        var countAfterSecondStop = Volatile.Read(ref pollCount);
+
+        // Assert - both cycles should have incremented the counter
+        Assert.True(countAfterSecondStop > countAfterFirstStop);
+    }
+
+
+    [Fact]
+    public async Task StopAsync_Should_not_log_warning_when_timer_disposal_completes_within_timeout()
+    {
+        // Arrange
+        // Set up a quick callback that completes immediately
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10000); // long delay, no actual callbacks
+        await _poller.StartAsync(CancelMe);
+
+        // Act - StopAsync should complete the WaitHandle immediately since no callback is running
+        await _poller.StopAsync(CancelMe);
+
+        // Assert - LogWarning should NOT be called because WaitOne completed within timeout
+        _logger.Verify(
+            x => x.LogWarning(It.IsAny<Func<string>>()),
+            Times.Never, "LogWarning should NOT be called when timer disposal completes within timeout");
+    }
+
+    [Fact]
+    // [Fact(Timeout = 15000)] // 15 second timeout for the entire test
+    public async Task StopAsync_Should_log_warning_when_timer_disposal_exceeds_timeout()
+    {
+        // Arrange
+        // Set up a callback that takes longer than the 5-second timeout
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(500);
+        var pollCallCount = 0;
+        var pollStarted = new TaskCompletionSource<bool>();
+        var allowPollToComplete = new TaskCompletionSource<bool>();
+
+        _repo.Setup(x => x.Get()).Returns(() =>
+        {
+            var count = Interlocked.Increment(ref pollCallCount);
+            if (count == 1)
+            {
+                // Signal that first poll has started
+                pollStarted.TrySetResult(true);
+
+                // Block for 7 seconds (longer than the 5-second timeout in StopAsync)
+                // Use a task-based wait instead of ManualResetEvent to avoid WaitHandle disposal issues
+                try
+                {
+                    allowPollToComplete.Task.Wait(TimeSpan.FromSeconds(7));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Ignore cancellation
+                }
+            }
+            return _initialFileConfig;
+        });
+
+        try
+        {
+            await _poller.StartAsync(CancelMe);
+
+            // Wait for the first poll to start (with a 2-second timeout to prevent hanging)
+            var pollStartedInTime = await Task.WhenAny(
+                pollStarted.Task,
+                Task.Delay(TimeSpan.FromSeconds(2), CancelMe)) == pollStarted.Task;
+
+            if (!pollStartedInTime)
+            {
+                // If poll didn't start within 2 seconds, the timer interval might be too long
+                throw new TimeoutException("Poll callback did not start within 2 seconds");
+            }
+
+            // Act - StopAsync should timeout because the poll callback is still running
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var stopTask = _poller.StopAsync(CancelMe);
+
+            // Wait for StopAsync to complete (with 6 second timeout: 5 sec WaitHandle timeout + 1 sec buffer)
+            var stoppedInTime = await Task.WhenAny(
+                stopTask,
+                Task.Delay(TimeSpan.FromSeconds(6), CancelMe)) == stopTask;
+            stopwatch.Stop();
+
+            // Assert
+            Assert.True(stoppedInTime, "StopAsync should complete even if timeout occurs");
+            Assert.True(stopwatch.ElapsedMilliseconds >= 5000, "StopAsync should have waited at least 5 seconds for the WaitHandle");
+
+            // LogWarning should be called because WaitOne timed out
+            _logger.Verify(
+                x => x.LogWarning(It.IsAny<Func<string>>()),
+                Times.AtLeastOnce, "LogWarning should be called when timer disposal times out");
+        }
+        catch (Exception e)
+        {
+        }
+        finally
+        {
+            // Signal the poll to complete
+            allowPollToComplete.TrySetResult(true);
+            // Give the callback time to exit
+            await Task.Delay(500, CancelMe);
+        }
+    }
+
+    [Fact]
+    public async Task StopAsync_WaitHandle_Should_complete_quickly_with_no_pending_callbacks()
+    {
+        // Arrange
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(100000); // Very long delay
+        await _poller.StartAsync(CancelMe);
+
+        // Act - StopAsync should complete within 1 second since no callback is running
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await _poller.StopAsync(CancelMe);
+        stopwatch.Stop();
+
+        // Assert
+        Assert.True(stopwatch.ElapsedMilliseconds < 1000); // StopAsync should complete quickly when no callbacks are pending
+
+        // No warning should be logged
+        _logger.Verify(
+            x => x.LogWarning(It.IsAny<Func<string>>()),
+            Times.Never, "No warning should be logged when timer disposal completes quickly");
+    }
+    #endregion StopAsync
 
     private static FileConfiguration GivenConfiguration() => new()
     {
@@ -525,7 +828,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     private Timer CurrentTimer()
     {
         var timerField = typeof(FileConfigurationPoller)
-            .GetField("_timer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            .GetField("_timer", BindingFlags.Instance | BindingFlags.NonPublic);
 
         timerField.ShouldNotBeNull();
         return timerField.GetValue(_poller) as Timer;

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -179,7 +179,6 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     }
 
     [Fact]
-    //[Fact(Skip = "To Dispose or not to Dispose in StopAsync?")]
     public async Task StopAsync_Should_wait_for_running_timer_callback_to_complete()
     {
         // Arrange
@@ -189,21 +188,29 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         _repo.Setup(x => x.Get()).Returns(() =>
         {
             pollStarted.Set();
-            releasePoll.Wait();
+            releasePoll.Wait(TimeSpan.FromSeconds(10)); // safety timeout to avoid hanging
             return _initialFileConfig;
         });
 
         await _poller.StartAsync(CancelMe);
-        Assert.True(pollStarted.Wait(TimeSpan.FromSeconds(2), CancelMe));
+        Assert.True(pollStarted.Wait(TimeSpan.FromSeconds(2), CancelMe), "Poll should have started within 2 seconds.");
 
-        // Act
-        var stopTask = _poller.StopAsync(CancelMe);
-        await Task.Delay(50, CancelMe);
+        try
+        {
+            // Act: StopAsync is truly async (awaits Task.Run internally), so the returned task
+            // should still be in-progress while the timer callback is blocked.
+            var stopTask = _poller.StopAsync(CancelMe);
+            await Task.Delay(50, CancelMe);
 
-        // Assert
-        Assert.False(stopTask.IsCompleted);
-        releasePoll.Set();
-        await stopTask;
+            // Assert
+            Assert.False(stopTask.IsCompleted, "StopAsync should not complete while the timer callback is still running.");
+            releasePoll.Set();
+            await stopTask; // completes once the callback exits and the timer signals timerStopped
+        }
+        finally
+        {
+            releasePoll.Set(); // ensure the callback is always released even if the test fails early
+        }
     }
 
     [Fact]
@@ -588,7 +595,8 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     [Fact]
     public async Task Multiple_Start_Stop_Cycles_Should_work_correctly()
     {
-        // Arrange
+        // Arrange: use a short interval so that at least several callbacks fire within the wait window
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10);
         var pollCount = 0;
         _repo.Setup(x => x.Get()).Returns(() =>
         {
@@ -598,18 +606,20 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 
         // Act & Assert - first cycle
         await _poller.StartAsync(CancelMe);
-        await Task.Delay(100, CancelMe);
+        await Task.Delay(200, CancelMe); // 200 ms >> 10 ms interval; guarantees multiple callbacks
         await _poller.StopAsync(CancelMe);
         var countAfterFirstStop = Volatile.Read(ref pollCount);
 
         // Act & Assert - second cycle (should work even after stop)
         await _poller.StartAsync(CancelMe);
-        await Task.Delay(100, CancelMe);
+        await Task.Delay(200, CancelMe);
         await _poller.StopAsync(CancelMe);
         var countAfterSecondStop = Volatile.Read(ref pollCount);
 
-        // Assert - both cycles should have incremented the counter
-        Assert.True(countAfterSecondStop > countAfterFirstStop);
+        // Assert - second cycle must have produced at least one additional poll
+        Assert.True(
+            countAfterSecondStop > countAfterFirstStop,
+            $"Second cycle should have more polls (after 1st stop: {countAfterFirstStop}, after 2nd stop: {countAfterSecondStop}).");
     }
 
 
@@ -631,81 +641,52 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     }
 
     [Fact]
-    // [Fact(Timeout = 15000)] // 15 second timeout for the entire test
     public async Task StopAsync_Should_log_warning_when_timer_disposal_exceeds_timeout()
     {
-        // Arrange
-        // Set up a callback that takes longer than the 5-second timeout
+        // Arrange: set up a callback that blocks longer than StopAsync's 5-second internal wait
         _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(500);
-        var pollCallCount = 0;
-        var pollStarted = new TaskCompletionSource<bool>();
-        var allowPollToComplete = new TaskCompletionSource<bool>();
+        var pollStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowPollToComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         _repo.Setup(x => x.Get()).Returns(() =>
         {
-            var count = Interlocked.Increment(ref pollCallCount);
-            if (count == 1)
-            {
-                // Signal that first poll has started
-                pollStarted.TrySetResult(true);
-
-                // Block for 7 seconds (longer than the 5-second timeout in StopAsync)
-                // Use a task-based wait instead of ManualResetEvent to avoid WaitHandle disposal issues
-                try
-                {
-                    allowPollToComplete.Task.Wait(TimeSpan.FromSeconds(7));
-                }
-                catch (OperationCanceledException)
-                {
-                    // Ignore cancellation
-                }
-            }
+            pollStarted.TrySetResult(true);
+            // Block for up to 7 seconds (longer than the 5-second timeout inside StopAsync)
+            allowPollToComplete.Task.Wait(TimeSpan.FromSeconds(7));
             return _initialFileConfig;
         });
 
+        await _poller.StartAsync(CancelMe);
+
+        // Wait for the first poll to start
+        Assert.True(
+            await Task.WhenAny(pollStarted.Task, Task.Delay(TimeSpan.FromSeconds(2), CancelMe)) == pollStarted.Task,
+            "Poll callback did not start within 2 seconds.");
+
         try
         {
-            await _poller.StartAsync(CancelMe);
-
-            // Wait for the first poll to start (with a 2-second timeout to prevent hanging)
-            var pollStartedInTime = await Task.WhenAny(
-                pollStarted.Task,
-                Task.Delay(TimeSpan.FromSeconds(2), CancelMe)) == pollStarted.Task;
-
-            if (!pollStartedInTime)
-            {
-                // If poll didn't start within 2 seconds, the timer interval might be too long
-                throw new TimeoutException("Poll callback did not start within 2 seconds");
-            }
-
-            // Act - StopAsync should timeout because the poll callback is still running
+            // Act: StopAsync should time out because the poll callback is still running
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
-            var stopTask = _poller.StopAsync(CancelMe);
-
-            // Wait for StopAsync to complete (with 6 second timeout: 5 sec WaitHandle timeout + 1 sec buffer)
-            var stoppedInTime = await Task.WhenAny(
-                stopTask,
-                Task.Delay(TimeSpan.FromSeconds(6), CancelMe)) == stopTask;
+            await _poller.StopAsync(CancelMe);
             stopwatch.Stop();
 
-            // Assert
-            Assert.True(stoppedInTime, "StopAsync should complete even if timeout occurs");
-            Assert.True(stopwatch.ElapsedMilliseconds >= 5000, "StopAsync should have waited at least 5 seconds for the WaitHandle");
+            // Assert: StopAsync should complete after roughly 5 seconds (its internal WaitOne timeout)
+            Assert.True(
+                stopwatch.ElapsedMilliseconds >= 4500,
+                $"StopAsync should have waited ~5 s for the timer callback, but elapsed only {stopwatch.ElapsedMilliseconds} ms.");
 
             // LogWarning should be called because WaitOne timed out
             _logger.Verify(
                 x => x.LogWarning(It.IsAny<Func<string>>()),
-                Times.AtLeastOnce, "LogWarning should be called when timer disposal times out");
-        }
-        catch (Exception e)
-        {
+                Times.AtLeastOnce, "LogWarning should be called when timer disposal times out.");
         }
         finally
         {
-            // Signal the poll to complete
+            // Release the blocked callback so its background thread can exit cleanly.
+            // This also allows the production-code background cleanup task to dispose timerStopped
+            // without ObjectDisposedException.
             allowPollToComplete.TrySetResult(true);
-            // Give the callback time to exit
-            await Task.Delay(500, CancelMe);
+            await Task.Delay(500, CancellationToken.None); // give background cleanup time to finish
         }
     }
 

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -714,6 +714,8 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     #endregion StopAsync
 
     #region SafeDisposeManualResetEvent
+    private MethodInfo SafeDisposeManualResetEvent()
+        => _poller.GetType().GetMethod(nameof(SafeDisposeManualResetEvent), BindingFlags.Instance | BindingFlags.NonPublic);
 
     [Fact]
     public void SafeDisposeManualResetEvent_Should_catch_and_log_exception_when_WaitOne_throws()
@@ -722,21 +724,14 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         var disposedEvent = new ManualResetEvent(false);
         disposedEvent.Dispose();
 
-        // Use reflection to invoke the private SafeDisposeManualResetEvent method
-        var safeDisposeMethod = typeof(FileConfigurationPoller)
-            .GetMethod("SafeDisposeManualResetEvent", 
-                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        Assert.NotNull(safeDisposeMethod);
-
         // Act: Invoke SafeDisposeManualResetEvent with the disposed event
-        safeDisposeMethod.Invoke(_poller, new object[] { disposedEvent });
+        SafeDisposeManualResetEvent().Invoke(_poller, [disposedEvent]);
 
         // Assert: Verify that LogWarning was called because WaitOne() threw ObjectDisposedException
         _logger.Verify(
             x => x.LogWarning(It.IsAny<Func<string>>()),
             Times.Once, "LogWarning should be called when WaitOne throws an exception");
     }
-
     #endregion SafeDisposeManualResetEvent
 
     private static FileConfiguration GivenConfiguration() => new()

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -713,6 +713,32 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     }
     #endregion StopAsync
 
+    #region SafeDisposeManualResetEvent
+
+    [Fact]
+    public void SafeDisposeManualResetEvent_Should_catch_and_log_exception_when_WaitOne_throws()
+    {
+        // Arrange: Create a ManualResetEvent and dispose it to trigger ObjectDisposedException
+        var disposedEvent = new ManualResetEvent(false);
+        disposedEvent.Dispose();
+
+        // Use reflection to invoke the private SafeDisposeManualResetEvent method
+        var safeDisposeMethod = typeof(FileConfigurationPoller)
+            .GetMethod("SafeDisposeManualResetEvent", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        safeDisposeMethod.ShouldNotBeNull();
+
+        // Act: Invoke SafeDisposeManualResetEvent with the disposed event
+        safeDisposeMethod.Invoke(_poller, new object[] { disposedEvent });
+
+        // Assert: Verify that LogWarning was called because WaitOne() threw ObjectDisposedException
+        _logger.Verify(
+            x => x.LogWarning(It.IsAny<Func<string>>()),
+            Times.Once, "LogWarning should be called when WaitOne throws an exception");
+    }
+
+    #endregion SafeDisposeManualResetEvent
+
     private static FileConfiguration GivenConfiguration() => new()
     {
         Routes = new()

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -726,7 +726,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         var safeDisposeMethod = typeof(FileConfigurationPoller)
             .GetMethod("SafeDisposeManualResetEvent", 
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        safeDisposeMethod.ShouldNotBeNull();
+        Assert.NotNull(safeDisposeMethod);
 
         // Act: Invoke SafeDisposeManualResetEvent with the disposed event
         safeDisposeMethod.Invoke(_poller, new object[] { disposedEvent });
@@ -838,7 +838,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         var timerField = typeof(FileConfigurationPoller)
             .GetField("_timer", BindingFlags.Instance | BindingFlags.NonPublic);
 
-        timerField.ShouldNotBeNull();
+        Assert.NotNull(timerField);
         return timerField.GetValue(_poller) as Timer;
     }
 

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -395,6 +395,39 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
         timer.ShouldBeNull();
     }
 
+    [Fact]
+    public async Task StopAsync_Should_dispose_timer_to_release_background_thread()
+    {
+        // Arrange - start the poller to create a timer
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10000); // long delay
+        await _poller.StartAsync(CancelMe);
+        var timerBefore = CurrentTimer();
+        timerBefore.ShouldNotBeNull();
+
+        // Act - stop the poller, which should dispose the timer
+        await _poller.StopAsync(CancelMe);
+
+        // Assert - timer should be null (disposed) and no exception should be thrown
+        var timerAfter = CurrentTimer();
+        timerAfter.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task StopAsync_Should_handle_multiple_calls()
+    {
+        // Arrange - start the poller to create a timer
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10000);
+        await _poller.StartAsync(CancelMe);
+
+        // Act - call StopAsync multiple times
+        await _poller.StopAsync(CancelMe);
+        await _poller.StopAsync(CancelMe); // Second call should not throw
+
+        // Assert - timer should remain null
+        var timer = CurrentTimer();
+        timer.ShouldBeNull();
+    }
+
     private static FileConfiguration GivenConfiguration() => new()
     {
         Routes = new()

--- a/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
+++ b/test/Ocelot.UnitTests/Configuration/Repository/FileConfigurationPollerTests.cs
@@ -13,6 +13,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 {
     private const int PollingDelayInMs = 100;
     private const int LongRunningPollDelayInMs = PollingDelayInMs + 50;
+    private const int ShortPollingIntervalInMs = 10; // fast interval for tests that need reliable callbacks
 
     private readonly Mock<IOcelotLogger> _logger = new();
     private readonly Mock<IOcelotLoggerFactory> _factory = new();
@@ -596,7 +597,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
     public async Task Multiple_Start_Stop_Cycles_Should_work_correctly()
     {
         // Arrange: use a short interval so that at least several callbacks fire within the wait window
-        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(10);
+        _config.Setup(x => x.DelayAsync(It.IsAny<CancellationToken>())).ReturnsAsync(ShortPollingIntervalInMs);
         var pollCount = 0;
         _repo.Setup(x => x.Get()).Returns(() =>
         {
@@ -606,7 +607,7 @@ public sealed class FileConfigurationPollerTests : UnitTest, IDisposable
 
         // Act & Assert - first cycle
         await _poller.StartAsync(CancelMe);
-        await Task.Delay(200, CancelMe); // 200 ms >> 10 ms interval; guarantees multiple callbacks
+        await Task.Delay(200, CancelMe); // 200 ms >> ShortPollingIntervalInMs; guarantees multiple callbacks
         await _poller.StopAsync(CancelMe);
         var countAfterFirstStop = Volatile.Read(ref pollCount);
 

--- a/test/Ocelot.UnitTests/Infrastructure/InMemoryBusTests.cs
+++ b/test/Ocelot.UnitTests/Infrastructure/InMemoryBusTests.cs
@@ -1,4 +1,5 @@
 using Ocelot.Infrastructure;
+using System.Reflection;
 
 namespace Ocelot.UnitTests.Infrastructure;
 
@@ -33,5 +34,21 @@ public class InMemoryBusTests
 
         // Assert
         called.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_create_processing_thread_as_background_thread()
+    {
+        // Arrange
+        var bus = new InMemoryBus<object>();
+
+        // Act - Get the processing thread via reflection
+        var processingField = typeof(InMemoryBus<object>).GetField("_processing", 
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var thread = processingField?.GetValue(bus) as Thread;
+
+        // Assert - the thread should be marked as background
+        thread.ShouldNotBeNull();
+        thread.IsBackground.ShouldBeTrue();
     }
 }

--- a/test/Ocelot.UnitTests/Infrastructure/InMemoryBusTests.cs
+++ b/test/Ocelot.UnitTests/Infrastructure/InMemoryBusTests.cs
@@ -3,12 +3,12 @@ using System.Reflection;
 
 namespace Ocelot.UnitTests.Infrastructure;
 
-public class InMemoryBusTests
+public class InMemoryBusTests : UnitTest
 {
     private readonly InMemoryBus<object> _bus = new();
 
     [Fact]
-    public async Task Should_publish_with_delay()
+    public async Task Publish_WithDelay_Published()
     {
         // Arrange
         var called = false;
@@ -16,14 +16,14 @@ public class InMemoryBusTests
 
         // Act
         _bus.Publish(new object(), 1);
-        await Task.Delay(100, TestContext.Current.CancellationToken);
+        await Task.Delay(100, CancelMe);
 
         // Assert
-        called.ShouldBeTrue();
+        Assert.True(called);
     }
 
     [Fact]
-    public void Should_not_be_publish_yet_as_no_delay_in_caller()
+    public void Publish_WithoutDelay_NotYetPublished()
     {
         // Arrange
         var called = false;
@@ -33,22 +33,18 @@ public class InMemoryBusTests
         _bus.Publish(new object(), 1);
 
         // Assert
-        called.ShouldBeFalse();
+        Assert.False(called);
     }
 
     [Fact]
-    public void Should_create_processing_thread_as_background_thread()
+    public void Ctor_ViaReflection_CreatedProcessingThreadAsBackgroundThread()
     {
-        // Arrange
-        var bus = new InMemoryBus<object>();
-
-        // Act - Get the processing thread via reflection
-        var processingField = typeof(InMemoryBus<object>).GetField("_processing", 
-            BindingFlags.Instance | BindingFlags.NonPublic);
-        var thread = processingField?.GetValue(bus) as Thread;
+        // Arrange, Act - Get the processing thread via reflection
+        var processingField = typeof(InMemoryBus<object>).GetField("_processing", BindingFlags.Instance | BindingFlags.NonPublic);
+        var thread = processingField?.GetValue(_bus) as Thread;
 
         // Assert - the thread should be marked as background
-        thread.ShouldNotBeNull();
-        thread.IsBackground.ShouldBeTrue();
+        Assert.NotNull(thread);
+        Assert.True(thread.IsBackground);
     }
 }

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -13,6 +13,7 @@ namespace Ocelot.UnitTests.Kubernetes;
 /// </summary>
 [Trait("Milestone", ".NET 10")]
 [Trait("Release", "25.0.0")]
+[Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
 public sealed class KubeTests : IDisposable
 {
     private readonly Mock<IOcelotLoggerFactory> _factory = new();
@@ -46,7 +47,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_return_empty_list_when_disposed()
     {
         // Arrange
@@ -62,7 +62,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public void Dispose_Should_release_resources_without_throwing()
     {
         // Arrange
@@ -78,7 +77,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public void Dispose_Should_dispose_logger_and_kubeapi()
     {
         // Arrange
@@ -94,7 +92,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_handle_ObjectDisposedException_and_return_empty_list()
     {
         // Arrange
@@ -125,7 +122,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_handle_KubeApiException_and_return_empty_list()
     {
         // Arrange
@@ -153,7 +149,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_handle_HttpRequestException_and_return_empty_list()
     {
         // Arrange
@@ -180,7 +175,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_handle_general_Exception_and_return_empty_list()
     {
         // Arrange
@@ -207,7 +201,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_return_services_when_endpoint_is_valid()
     {
         // Arrange
@@ -245,7 +238,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_return_empty_list_when_endpoint_has_no_subsets()
     {
         // Arrange
@@ -275,7 +267,6 @@ public sealed class KubeTests : IDisposable
     }
 
     [Fact]
-    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task BuildServices_Should_return_empty_when_disposed()
     {
         // Arrange

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -5,7 +5,7 @@ using Ocelot.Provider.Kubernetes;
 using Ocelot.Provider.Kubernetes.Interfaces;
 using Ocelot.Values;
 
-namespace Ocelot.AcceptanceTests.ServiceDiscovery;
+namespace Ocelot.UnitTests.Kubernetes;
 
 /// <summary>
 /// Tests for Kube service discovery provider error handling, particularly around 
@@ -13,14 +13,14 @@ namespace Ocelot.AcceptanceTests.ServiceDiscovery;
 /// </summary>
 [Trait("Milestone", ".NET 10")]
 [Trait("Release", "25.0.0")]
-public class KubeErrorHandlingTests : IDisposable
+public sealed class KubeTests : IDisposable
 {
     private readonly Mock<IOcelotLoggerFactory> _factory = new();
     private readonly Mock<IOcelotLogger> _logger = new();
     private readonly Mock<IKubeServiceBuilder> _serviceBuilder = new();
     private readonly KubeRegistryConfiguration _configuration;
 
-    public KubeErrorHandlingTests()
+    public KubeTests()
     {
         _factory.Setup(x => x.CreateLogger<Kube>()).Returns(_logger.Object);
         _configuration = new KubeRegistryConfiguration

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -82,4 +82,276 @@ public sealed class KubeTests : IDisposable
         _logger.Verify(x => x.Dispose(), Times.Once, "Logger should be disposed");
         mockKubeApi.Verify(x => x.Dispose(), Times.Once, "KubeApi should be disposed");
     }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_handle_ObjectDisposedException_and_return_empty_list()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        // Configure mock to throw ObjectDisposedException every time GetAsync is called
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ObjectDisposedException("KubeApi", "The API client was disposed"));
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        
+        // Verify that LogError was called for each retry attempt (3 times total)
+        _logger.Verify(
+            x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<ObjectDisposedException>()),
+            Times.Exactly(3),
+            "LogError should be called 3 times for ObjectDisposedException retries");
+        
+        // Verify that LogWarning was called at the end
+        _logger.Verify(
+            x => x.LogWarning(It.IsAny<Func<string>>()),
+            Times.AtLeastOnce(),
+            "LogWarning should be called when no valid result is found");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_handle_KubeApiException_and_return_empty_list()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var status = new StatusV1 { Status = "Failure", Reason = "NotFound", Message = "Service not found" };
+        var kubeApiException = new KubeApiException("Service not found", status: status);
+
+        // Configure mock to throw KubeApiException every time GetAsync is called
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(kubeApiException);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        
+        // Verify that LogError was called for each retry attempt
+        _logger.Verify(
+            x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<KubeApiException>()),
+            Times.Exactly(3),
+            "LogError should be called 3 times for KubeApiException retries");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_handle_HttpRequestException_and_return_empty_list()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var httpException = new HttpRequestException("Connection failed", null, System.Net.HttpStatusCode.ServiceUnavailable);
+
+        // Configure mock to throw HttpRequestException every time GetAsync is called
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(httpException);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        
+        // Verify that LogError was called for each retry attempt
+        _logger.Verify(
+            x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<HttpRequestException>()),
+            Times.Exactly(3),
+            "LogError should be called 3 times for HttpRequestException retries");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_handle_general_Exception_and_return_empty_list()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var unexpectedException = new InvalidOperationException("Unexpected error");
+
+        // Configure mock to throw general Exception every time GetAsync is called
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(unexpectedException);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        
+        // Verify that LogError was called for each retry attempt
+        _logger.Verify(
+            x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<InvalidOperationException>()),
+            Times.Exactly(3),
+            "LogError should be called 3 times for general Exception retries");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_return_services_when_endpoint_is_valid()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var validEndpoint = new EndpointsV1
+        {
+            Metadata = new ObjectMetaV1 { Name = "test-service" },
+            Subsets = new[]
+            {
+                new EndpointSubsetV1
+                {
+                    Addresses = new[]
+                    {
+                        new EndpointAddressV1 { Ip = "192.168.1.1" }
+                    },
+                    Ports = new[]
+                    {
+                        new EndpointPortV1 { Name = "http", Port = 80 }
+                    }
+                }
+            }
+        };
+
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validEndpoint);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var expectedServices = new List<Service> { new Service { Name = "test-service", HostAndPort = new HostAndPort("192.168.1.1", 80) } };
+        _serviceBuilder
+            .Setup(x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()))
+            .Returns(expectedServices);
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldNotBeEmpty();
+        _serviceBuilder.Verify(
+            x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
+            Times.Once,
+            "BuildServices should be called once with valid endpoint");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task GetAsync_Should_return_empty_list_when_endpoint_has_no_subsets()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var emptyEndpoint = new EndpointsV1
+        {
+            Metadata = new ObjectMetaV1 { Name = "test-service" },
+            Subsets = null // No subsets
+        };
+
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyEndpoint);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        _serviceBuilder.Verify(
+            x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
+            Times.Never,
+            "BuildServices should not be called when endpoint has no subsets");
+    }
+
+    [Fact]
+    [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+    public async Task BuildServices_Should_return_empty_when_disposed()
+    {
+        // Arrange
+        var mockEndpointClient = new Mock<IEndPointClient>();
+        var mockKubeApi = new Mock<IKubeApiClient>();
+
+        var validEndpoint = new EndpointsV1
+        {
+            Metadata = new ObjectMetaV1 { Name = "test-service" },
+            Subsets = new[]
+            {
+                new EndpointSubsetV1
+                {
+                    Addresses = new[] { new EndpointAddressV1 { Ip = "192.168.1.1" } },
+                    Ports = new[] { new EndpointPortV1 { Name = "http", Port = 80 } }
+                }
+            }
+        };
+
+        mockEndpointClient
+            .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(validEndpoint);
+
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
+
+        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        provider.Dispose();
+
+        // Act
+        var result = await provider.GetAsync();
+
+        // Assert
+        result.ShouldBeEmpty();
+        _serviceBuilder.Verify(
+            x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
+            Times.Never,
+            "BuildServices should not be called when provider is disposed");
+    }
 }

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -18,6 +18,7 @@ public sealed class KubeTests : IDisposable
     private readonly Mock<IOcelotLoggerFactory> _factory = new();
     private readonly Mock<IOcelotLogger> _logger = new();
     private readonly Mock<IKubeServiceBuilder> _serviceBuilder = new();
+    private readonly Mock<IEndPointClient> _endpointClient = new();
     private readonly KubeRegistryConfiguration _configuration;
 
     public KubeTests()
@@ -35,12 +36,21 @@ public sealed class KubeTests : IDisposable
         _logger?.Invocations.Clear();
     }
 
+    private Mock<IKubeApiClient> CreateMockKubeApi()
+    {
+        var mockKubeApi = new Mock<IKubeApiClient>();
+        mockKubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => _endpointClient.Object);
+        return mockKubeApi;
+    }
+
     [Fact]
     [Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
     public async Task GetAsync_Should_return_empty_list_when_disposed()
     {
         // Arrange
-        var mockKubeApi = new Mock<IKubeApiClient>();
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -56,7 +66,7 @@ public sealed class KubeTests : IDisposable
     public void Dispose_Should_release_resources_without_throwing()
     {
         // Arrange
-        var mockKubeApi = new Mock<IKubeApiClient>();
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act & Assert - multiple disposes should not throw
@@ -72,7 +82,7 @@ public sealed class KubeTests : IDisposable
     public void Dispose_Should_dispose_logger_and_kubeapi()
     {
         // Arrange
-        var mockKubeApi = new Mock<IKubeApiClient>();
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -88,18 +98,11 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_handle_ObjectDisposedException_and_return_empty_list()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
-        // Configure mock to throw ObjectDisposedException every time GetAsync is called
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ObjectDisposedException("KubeApi", "The API client was disposed"));
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -108,13 +111,13 @@ public sealed class KubeTests : IDisposable
         // Assert
         result.ShouldBeEmpty();
         
-        // Verify that LogError was called for each retry attempt (3 times total)
+        // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<ObjectDisposedException>()),
-            Times.Exactly(3),
-            "LogError should be called 3 times for ObjectDisposedException retries");
+            Times.AtLeastOnce(),
+            "LogError should be called for ObjectDisposedException");
         
-        // Verify that LogWarning was called at the end
+        // Verify that LogWarning was called when no valid result is found
         _logger.Verify(
             x => x.LogWarning(It.IsAny<Func<string>>()),
             Times.AtLeastOnce(),
@@ -126,21 +129,14 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_handle_KubeApiException_and_return_empty_list()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
         var status = new StatusV1 { Status = "Failure", Reason = "NotFound", Message = "Service not found" };
         var kubeApiException = new KubeApiException("Service not found", status: status);
 
-        // Configure mock to throw KubeApiException every time GetAsync is called
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(kubeApiException);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -149,11 +145,11 @@ public sealed class KubeTests : IDisposable
         // Assert
         result.ShouldBeEmpty();
         
-        // Verify that LogError was called for each retry attempt
+        // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<KubeApiException>()),
-            Times.Exactly(3),
-            "LogError should be called 3 times for KubeApiException retries");
+            Times.AtLeastOnce(),
+            "LogError should be called for KubeApiException");
     }
 
     [Fact]
@@ -161,20 +157,13 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_handle_HttpRequestException_and_return_empty_list()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
         var httpException = new HttpRequestException("Connection failed", null, System.Net.HttpStatusCode.ServiceUnavailable);
 
-        // Configure mock to throw HttpRequestException every time GetAsync is called
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(httpException);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -183,11 +172,11 @@ public sealed class KubeTests : IDisposable
         // Assert
         result.ShouldBeEmpty();
         
-        // Verify that LogError was called for each retry attempt
+        // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<HttpRequestException>()),
-            Times.Exactly(3),
-            "LogError should be called 3 times for HttpRequestException retries");
+            Times.AtLeastOnce(),
+            "LogError should be called for HttpRequestException");
     }
 
     [Fact]
@@ -195,20 +184,13 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_handle_general_Exception_and_return_empty_list()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
         var unexpectedException = new InvalidOperationException("Unexpected error");
 
-        // Configure mock to throw general Exception every time GetAsync is called
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(unexpectedException);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -217,11 +199,11 @@ public sealed class KubeTests : IDisposable
         // Assert
         result.ShouldBeEmpty();
         
-        // Verify that LogError was called for each retry attempt
+        // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<InvalidOperationException>()),
-            Times.Exactly(3),
-            "LogError should be called 3 times for general Exception retries");
+            Times.AtLeastOnce(),
+            "LogError should be called for general Exception");
     }
 
     [Fact]
@@ -229,41 +211,26 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_return_services_when_endpoint_is_valid()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
+        // Create a valid endpoint with subsets
         var validEndpoint = new EndpointsV1
         {
-            Metadata = new ObjectMetaV1 { Name = "test-service" },
-            Subsets = new[]
-            {
-                new EndpointSubsetV1
-                {
-                    Addresses = new[]
-                    {
-                        new EndpointAddressV1 { Ip = "192.168.1.1" }
-                    },
-                    Ports = new[]
-                    {
-                        new EndpointPortV1 { Name = "http", Port = 80 }
-                    }
-                }
-            }
+            Metadata = new ObjectMetaV1 { Name = "test-service" }
         };
+        var subset = new EndpointSubsetV1();
+        subset.Addresses.Add(new EndpointAddressV1 { Ip = "192.168.1.1" });
+        subset.Ports.Add(new EndpointPortV1 { Port = 80 });
+        validEndpoint.Subsets.Add(subset);
 
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(validEndpoint);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
-        var expectedServices = new List<Service> { new Service { Name = "test-service", HostAndPort = new HostAndPort("192.168.1.1", 80) } };
+        var expectedServices = new List<Service> { new("test-service", new("192.168.1.1", 80), string.Empty, string.Empty, Array.Empty<string>()) };
         _serviceBuilder
             .Setup(x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()))
             .Returns(expectedServices);
 
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -282,23 +249,18 @@ public sealed class KubeTests : IDisposable
     public async Task GetAsync_Should_return_empty_list_when_endpoint_has_no_subsets()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
+        // Create an endpoint with no subsets (empty collection)
         var emptyEndpoint = new EndpointsV1
         {
-            Metadata = new ObjectMetaV1 { Name = "test-service" },
-            Subsets = null // No subsets
+            Metadata = new ObjectMetaV1 { Name = "test-service" }
+            // Subsets are empty by default
         };
 
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(emptyEndpoint);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
 
         // Act
@@ -317,30 +279,21 @@ public sealed class KubeTests : IDisposable
     public async Task BuildServices_Should_return_empty_when_disposed()
     {
         // Arrange
-        var mockEndpointClient = new Mock<IEndPointClient>();
-        var mockKubeApi = new Mock<IKubeApiClient>();
-
+        // Create a valid endpoint with subsets
         var validEndpoint = new EndpointsV1
         {
-            Metadata = new ObjectMetaV1 { Name = "test-service" },
-            Subsets = new[]
-            {
-                new EndpointSubsetV1
-                {
-                    Addresses = new[] { new EndpointAddressV1 { Ip = "192.168.1.1" } },
-                    Ports = new[] { new EndpointPortV1 { Name = "http", Port = 80 } }
-                }
-            }
+            Metadata = new ObjectMetaV1 { Name = "test-service" }
         };
+        var subset = new EndpointSubsetV1();
+        subset.Addresses.Add(new EndpointAddressV1 { Ip = "192.168.1.1" });
+        subset.Ports.Add(new EndpointPortV1 { Port = 80 });
+        validEndpoint.Subsets.Add(subset);
 
-        mockEndpointClient
+        _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(validEndpoint);
 
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => factory(mockKubeApi.Object));
-
+        var mockKubeApi = CreateMockKubeApi();
         var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
         provider.Dispose();
 

--- a/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
+++ b/test/Ocelot.UnitTests/Kubernetes/KubeTests.cs
@@ -4,6 +4,7 @@ using Ocelot.Logging;
 using Ocelot.Provider.Kubernetes;
 using Ocelot.Provider.Kubernetes.Interfaces;
 using Ocelot.Values;
+using System.Reflection;
 
 namespace Ocelot.UnitTests.Kubernetes;
 
@@ -11,20 +12,23 @@ namespace Ocelot.UnitTests.Kubernetes;
 /// Tests for Kube service discovery provider error handling, particularly around 
 /// ObjectDisposedException scenarios that occur during shutdown.
 /// </summary>
-[Trait("Milestone", ".NET 10")]
 [Trait("Release", "25.0.0")]
-[Trait("PR", "14")] // https://github.com/ocelotgateway/Ocelot/pull/14
+[Trait("PR", "2399")] // https://github.com/ThreeMammals/Ocelot/pull/2399
 public sealed class KubeTests : IDisposable
 {
     private readonly Mock<IOcelotLoggerFactory> _factory = new();
     private readonly Mock<IOcelotLogger> _logger = new();
     private readonly Mock<IKubeServiceBuilder> _serviceBuilder = new();
     private readonly Mock<IEndPointClient> _endpointClient = new();
+    private readonly Mock<IKubeApiClient> _kubeApi = new();
     private readonly KubeRegistryConfiguration _configuration;
 
     public KubeTests()
     {
         _factory.Setup(x => x.CreateLogger<Kube>()).Returns(_logger.Object);
+        _kubeApi
+            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
+            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => _endpointClient.Object);
         _configuration = new KubeRegistryConfiguration
         {
             KeyOfServiceInK8s = "test-service",
@@ -37,58 +41,46 @@ public sealed class KubeTests : IDisposable
         _logger?.Invocations.Clear();
     }
 
-    private Mock<IKubeApiClient> CreateMockKubeApi()
-    {
-        var mockKubeApi = new Mock<IKubeApiClient>();
-        mockKubeApi
-            .Setup(x => x.ResourceClient<IEndPointClient>(It.IsAny<Func<IKubeApiClient, IEndPointClient>>()))
-            .Returns((Func<IKubeApiClient, IEndPointClient> factory) => _endpointClient.Object);
-        return mockKubeApi;
-    }
-
     [Fact]
     public async Task GetAsync_Should_return_empty_list_when_disposed()
     {
         // Arrange
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
         provider.Dispose();
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert - should return empty list when already disposed
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
     }
 
     [Fact]
     public void Dispose_Should_release_resources_without_throwing()
     {
         // Arrange
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act & Assert - multiple disposes should not throw
         provider.Dispose();
         provider.Dispose(); // Should not throw
 
         _logger.Verify(x => x.Dispose(), Times.Once);
-        mockKubeApi.Verify(x => x.Dispose(), Times.Once);
+        _kubeApi.Verify(x => x.Dispose(), Times.Once);
     }
 
     [Fact]
     public void Dispose_Should_dispose_logger_and_kubeapi()
     {
         // Arrange
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
         provider.Dispose();
 
         // Assert
         _logger.Verify(x => x.Dispose(), Times.Once, "Logger should be disposed");
-        mockKubeApi.Verify(x => x.Dispose(), Times.Once, "KubeApi should be disposed");
+        _kubeApi.Verify(x => x.Dispose(), Times.Once, "KubeApi should be disposed");
     }
 
     [Fact]
@@ -98,27 +90,23 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ObjectDisposedException("KubeApi", "The API client was disposed"));
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         
         // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<ObjectDisposedException>()),
-            Times.AtLeastOnce(),
-            "LogError should be called for ObjectDisposedException");
+            Times.Never, "LogError should NOT be called for ObjectDisposedException");
         
         // Verify that LogWarning was called when no valid result is found
         _logger.Verify(
             x => x.LogWarning(It.IsAny<Func<string>>()),
-            Times.AtLeastOnce(),
-            "LogWarning should be called when no valid result is found");
+            Times.AtLeastOnce, "LogWarning should be called when no valid result is found");
     }
 
     [Fact]
@@ -131,21 +119,18 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(kubeApiException);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         
         // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<KubeApiException>()),
-            Times.AtLeastOnce(),
-            "LogError should be called for KubeApiException");
+            Times.AtLeastOnce, "LogError should be called for KubeApiException");
     }
 
     [Fact]
@@ -157,21 +142,18 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(httpException);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         
         // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<HttpRequestException>()),
-            Times.AtLeastOnce(),
-            "LogError should be called for HttpRequestException");
+            Times.AtLeastOnce, "LogError should be called for HttpRequestException");
     }
 
     [Fact]
@@ -183,21 +165,18 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(unexpectedException);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         
         // Verify that LogError was called for the exception
         _logger.Verify(
             x => x.LogError(It.IsAny<Func<string>>(), It.IsAny<InvalidOperationException>()),
-            Times.AtLeastOnce(),
-            "LogError should be called for general Exception");
+            Times.AtLeastOnce, "LogError should be called for general Exception");
     }
 
     [Fact]
@@ -222,19 +201,16 @@ public sealed class KubeTests : IDisposable
         _serviceBuilder
             .Setup(x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()))
             .Returns(expectedServices);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldNotBeEmpty();
+        Assert.NotEmpty(list);
         _serviceBuilder.Verify(
             x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
-            Times.Once,
-            "BuildServices should be called once with valid endpoint");
+            Times.Once, "BuildServices should be called once with valid endpoint");
     }
 
     [Fact]
@@ -251,23 +227,20 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(emptyEndpoint);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
 
         // Act
-        var result = await provider.GetAsync();
+        var list = await provider.GetAsync();
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         _serviceBuilder.Verify(
             x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
-            Times.Never,
-            "BuildServices should not be called when endpoint has no subsets");
+            Times.Never, "BuildServices should not be called when endpoint has no subsets");
     }
 
     [Fact]
-    public async Task BuildServices_Should_return_empty_when_disposed()
+    public void BuildServices_Should_return_empty_when_disposed()
     {
         // Arrange
         // Create a valid endpoint with subsets
@@ -283,19 +256,18 @@ public sealed class KubeTests : IDisposable
         _endpointClient
             .Setup(x => x.GetAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(validEndpoint);
-
-        var mockKubeApi = CreateMockKubeApi();
-        var provider = new Kube(_configuration, _factory.Object, mockKubeApi.Object, _serviceBuilder.Object);
+        var provider = new Kube(_configuration, _factory.Object, _kubeApi.Object, _serviceBuilder.Object);
         provider.Dispose();
 
         // Act
-        var result = await provider.GetAsync();
+        var list = BuildServices().Invoke(provider, [_configuration, validEndpoint]) as IEnumerable<Service>;
 
         // Assert
-        result.ShouldBeEmpty();
+        Assert.Empty(list);
         _serviceBuilder.Verify(
             x => x.BuildServices(It.IsAny<KubeRegistryConfiguration>(), It.IsAny<EndpointsV1>()),
-            Times.Never,
-            "BuildServices should not be called when provider is disposed");
+            Times.Never, "BuildServices should not be called when provider is disposed");
     }
+    private MethodInfo BuildServices()
+        => typeof(Kube).GetMethod(nameof(BuildServices), BindingFlags.Instance | BindingFlags.NonPublic);
 }


### PR DESCRIPTION

## Proposed Changes
  - Fixed exception logging issues in the CI build
  - Updated workflows with removal of the exit code workaround. Now testing process returns 0 exit code (success)
  - Wrote unit tests for the `Kube` provider
  
## Predecessors
- #2394 
- commit https://github.com/ThreeMammals/Ocelot/commit/c20325bcb6a4d080ed1172d5303811031e532b03