### PR TITLE
#989 Hide Administration controllers from Swagger and OpenAPI

### DIFF
--- a/src/Administration/FileConfigurationController.cs
+++ b/src/Administration/FileConfigurationController.cs
@@ -8,6 +8,7 @@ using Ocelot.Errors;
 namespace Ocelot.Administration;
 
 // [ApiController] // TODO: Make it ApiController
+[ApiExplorerSettings(IgnoreApi = true)]
 [Authorize]
 [Route("configuration")]
 public class FileConfigurationController : Controller

--- a/src/Administration/OutputCacheController.cs
+++ b/src/Administration/OutputCacheController.cs
@@ -6,6 +6,7 @@ namespace Ocelot.Administration;
 
 // [ApiController] // TODO: Make it ApiController
 //[Authorize(Policy = "OcelotAdministration")]
+[ApiExplorerSettings(IgnoreApi = true)]
 [Authorize]
 [Route("outputcache")]
 public class OutputCacheController : Controller

--- a/unit/Controllers/FileConfigurationControllerTests.cs
+++ b/unit/Controllers/FileConfigurationControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Ocelot.Administration;
 using Ocelot.Configuration.File;
@@ -119,6 +120,18 @@ public class FileConfigurationControllerTests : UnitTest
         Assert.IsType<string>(actual.Value);
         var msg = actual.Value as string;
         Assert.Equal("Exception: Service failed" + NL, msg);
+    }
+
+    [Fact]
+    public void Should_have_ignore_api_attribute()
+    {
+        // Arrange
+        var attribute = typeof(FileConfigurationController)
+            .GetCustomAttribute<ApiExplorerSettingsAttribute>();
+
+        // Assert
+        attribute.ShouldNotBeNull();
+        attribute.IgnoreApi.ShouldBeTrue();
     }
 
     private class FakeError : Error

--- a/unit/Controllers/OutputCacheControllerTests.cs
+++ b/unit/Controllers/OutputCacheControllerTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
 using Ocelot.Administration;
 using Ocelot.Cache;
@@ -24,5 +25,17 @@ public class OutputCacheControllerTests : UnitTest
         // Assert
         result.ShouldBeOfType<NoContentResult>();
         _cache.Verify(x => x.ClearRegion("a"), Times.Once);
+    }
+
+    [Fact]
+    public void Should_have_ignore_api_attribute()
+    {
+        // Arrange
+        var attribute = typeof(OutputCacheController)
+            .GetCustomAttribute<ApiExplorerSettingsAttribute>();
+
+        // Assert
+        attribute.ShouldNotBeNull();
+        attribute.IgnoreApi.ShouldBeTrue();
     }
 }


### PR DESCRIPTION
## Fixes #989
- #989 

Add `[ApiExplorerSettings(IgnoreApi = true)]` to `FileConfigurationController` and `OutputCacheController` to prevent Swagger/OpenAPI from discovering and displaying these internal admin endpoints.

### Problem
Users who don't use the Administration feature see `/configuration` and `/outputcache/{region}` endpoints in their Swagger UI, which is confusing and clutters the documentation.

### Solution
Added the `ApiExplorerSettings` attribute with `IgnoreApi = true` to both controllers. This is the standard ASP.NET Core way to exclude endpoints from the API explorer (and thus from Swagger/OpenAPI docs).

### Prior art
- PR #1532 implemented the same fix and was approved by @raman-m and **Marusyk**, but was auto-closed because the contributor used the protected `develop` branch directly.
- This PR recreates that approved change on a proper feature branch.

### Changes
- `src/Administration/FileConfigurationController.cs`: Add `[ApiExplorerSettings(IgnoreApi = true)]`
- `src/Administration/OutputCacheController.cs`: Add `[ApiExplorerSettings(IgnoreApi = true)]`

### Testing
- Existing controller unit tests still pass (attribute doesn't affect controller behavior)
- The attribute is a metadata-only change that only affects API explorer/Swagger discovery