### PR TITLE
#989 Hide Administration controllers from Swagger and OpenAPI

### DIFF
--- a/src/Administration/FileConfigurationController.cs
+++ b/src/Administration/FileConfigurationController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Configuration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Repository;
@@ -8,6 +9,7 @@ using Ocelot.Errors;
 namespace Ocelot.Administration;
 
 // [ApiController] // TODO: Make it ApiController
+[ApiExplorerSettings(IgnoreApi = true)]
 [Authorize]
 [Route("configuration")]
 public class FileConfigurationController : Controller

--- a/src/Administration/FileConfigurationController.cs
+++ b/src/Administration/FileConfigurationController.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Configuration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Repository;

--- a/src/Administration/OutputCacheController.cs
+++ b/src/Administration/OutputCacheController.cs
@@ -1,12 +1,11 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Cache;
 
 namespace Ocelot.Administration;
 
 // [ApiController] // TODO: Make it ApiController
-//[Authorize(Policy = "OcelotAdministration")]
+// [Authorize(Policy = "OcelotAdministration")]
 [ApiExplorerSettings(IgnoreApi = true)]
 [Authorize]
 [Route("outputcache")]

--- a/src/Administration/OutputCacheController.cs
+++ b/src/Administration/OutputCacheController.cs
@@ -1,11 +1,13 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Cache;
 
 namespace Ocelot.Administration;
 
 // [ApiController] // TODO: Make it ApiController
 //[Authorize(Policy = "OcelotAdministration")]
+[ApiExplorerSettings(IgnoreApi = true)]
 [Authorize]
 [Route("outputcache")]
 public class OutputCacheController : Controller

--- a/unit/Controllers/FileConfigurationControllerTests.cs
+++ b/unit/Controllers/FileConfigurationControllerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Administration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Repository;
@@ -123,11 +122,14 @@ public class FileConfigurationControllerTests : UnitTest
     }
 
     [Fact]
-    public void Should_have_ignore_api_attribute()
+    [Trait("Bug", "989")] // https://github.com/ThreeMammals/Ocelot/issues/989
+    [Trait("PR", "2412")] // https://github.com/ThreeMammals/Ocelot/pull/2412
+    public void Should_have_ignore_api_attribute_to_hide_in_swagger()
     {
-        var attr = Attribute.GetCustomAttribute(
-            typeof(FileConfigurationController),
-            typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+        // Arrange, Act
+        var attr = Attribute.GetCustomAttribute(typeof(FileConfigurationController), typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+
+        // Assert
         Assert.NotNull(attr);
         Assert.True(attr.IgnoreApi);
     }

--- a/unit/Controllers/FileConfigurationControllerTests.cs
+++ b/unit/Controllers/FileConfigurationControllerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Administration;
 using Ocelot.Configuration.File;
 using Ocelot.Configuration.Repository;
@@ -119,6 +120,16 @@ public class FileConfigurationControllerTests : UnitTest
         Assert.IsType<string>(actual.Value);
         var msg = actual.Value as string;
         Assert.Equal("Exception: Service failed" + NL, msg);
+    }
+
+    [Fact]
+    public void Should_have_ignore_api_attribute()
+    {
+        var attr = Attribute.GetCustomAttribute(
+            typeof(FileConfigurationController),
+            typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+        Assert.NotNull(attr);
+        Assert.True(attr.IgnoreApi);
     }
 
     private class FakeError : Error

--- a/unit/Controllers/OutputCacheControllerTests.cs
+++ b/unit/Controllers/OutputCacheControllerTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Administration;
 using Ocelot.Cache;
 
@@ -28,11 +27,14 @@ public class OutputCacheControllerTests : UnitTest
     }
 
     [Fact]
-    public void Should_have_ignore_api_attribute()
+    [Trait("Bug", "989")] // https://github.com/ThreeMammals/Ocelot/issues/989
+    [Trait("PR", "2412")] // https://github.com/ThreeMammals/Ocelot/pull/2412
+    public void Should_have_ignore_api_attribute_to_hide_in_swagger()
     {
-        var attr = Attribute.GetCustomAttribute(
-            typeof(OutputCacheController),
-            typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+        // Arrange, Act
+        var attr = Attribute.GetCustomAttribute(typeof(OutputCacheController), typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+
+        // Assert
         Assert.NotNull(attr);
         Assert.True(attr.IgnoreApi);
     }

--- a/unit/Controllers/OutputCacheControllerTests.cs
+++ b/unit/Controllers/OutputCacheControllerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Ocelot.Administration;
 using Ocelot.Cache;
 
@@ -24,5 +25,15 @@ public class OutputCacheControllerTests : UnitTest
         // Assert
         result.ShouldBeOfType<NoContentResult>();
         _cache.Verify(x => x.ClearRegion("a"), Times.Once);
+    }
+
+    [Fact]
+    public void Should_have_ignore_api_attribute()
+    {
+        var attr = Attribute.GetCustomAttribute(
+            typeof(OutputCacheController),
+            typeof(ApiExplorerSettingsAttribute)) as ApiExplorerSettingsAttribute;
+        Assert.NotNull(attr);
+        Assert.True(attr.IgnoreApi);
     }
 }


### PR DESCRIPTION
## Fixes #989
- #989 

Add `[ApiExplorerSettings(IgnoreApi = true)]` to `FileConfigurationController` and `OutputCacheController` to prevent Swagger/OpenAPI from discovering and displaying these internal admin endpoints.

### Problem
Users who don't use the Administration feature see `/configuration` and `/outputcache/{region}` endpoints in their Swagger UI, which is confusing and clutters the documentation.

### Solution
Added the `ApiExplorerSettings` attribute with `IgnoreApi = true` to both admin controllers.

### Tests
- `FileConfigurationControllerTests.Should_have_ignore_api_attribute` - verifies attribute is present
- `OutputCacheControllerTests.Should_have_ignore_api_attribute` - same for OutputCacheController

Note: This reopens the previous PR #2410. The fork was accidentally deleted and has been re-created.
