### PR TITLE
Update docs for Ocelot v25.0 based on `25.0.0-beta.4` tag

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,3 +17,83 @@ This is the final beta pre-release for the current release cycle (milestone [.NE
 Stay updated — [subscribe](https://github.com/ThreeMammals/Ocelot/subscription) to Ocelot releases! :point_down: 
 
 [![Watch Ocelot releases](https://img.shields.io/badge/Subscribe-Releases-brightgreen?style=for-the-badge&logo=github)](https://github.com/ThreeMammals/Ocelot/subscription "Ocelot repository notifications status") [![Ocelot Releases RSS feed](https://img.shields.io/badge/Subscribe-Releases-2ea44f?style=for-the-badge&logo=rss)](https://github.com/ThreeMammals/Ocelot/releases.atom "Ocelot Releases RSS feed")
+
+---
+
+| Release Tag: [25.0.0](https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4)
+| Release Codename: [.NET 10](https://github.com/ThreeMammals/Ocelot/milestone/13)
+
+In this major release, the Ocelot team focused on preparing the codebase and its ecosystem for [.NET 10](https://github.com/ThreeMammals/Ocelot/milestone/13), while also extracting several integrated extension packages from the mono-repo into their own dedicated repositories to speed up delivery and reduce release coupling.
+This release also introduces a built-in *Quality of Service* (QoS) circuit breaker that works out of the box, without requiring the [Polly](https://www.nuget.org/packages/Polly/) library.
+
+The updated documentation highlights [the deprecation](https://ocelot.readthedocs.io/en/latest/search.html?q=deprecated) of certain packages through multiple notes and warnings.
+With the [Obsolete attributes](https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20%5BObsolete&type=code) in place, C# developers will notice several warnings in the build logs during compilation.
+
+On top of that, this release brings a great enhancement to the [Kubernetes](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/kubernetes.rst) provider, also known as the [Ocelot.Discovery.KubeClient](https://www.nuget.org/packages/Ocelot.Discovery.KubeClient/) package.
+
+### :new: What's New?
+
+- **[Quality of Service](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/qualityofservice.rst)**: A "[Built-in Circuit Breaker](https://github.com/ThreeMammals/Ocelot/issues/2384)" implementation was added by @ocelot-ot in pull request #2385, no [Polly](https://www.nuget.org/packages/Polly/) required.
+
+  Ocelot's QoS schema no longer strictly depends on the external [Ocelot.QualityOfService.Polly](https://www.nuget.org/packages/Ocelot.QualityOfService.Polly/) package to provide circuit breaking and timeout enforcement.
+  A lightweight, thread-safe circuit breaker (`Closed` → `Open` → `HalfOpen` → `Closed`) ships in the Ocelot core package, supporting both count-based and `FailureRatio`-based modes.
+  The two implementations are mutually exclusive: the last of `AddQualityOfService()` or `AddPolly()` registered on the `OcelotBuilder` wins.
+  See the built-in QoS documentation for full details, including the `AddQualityOfService<THandler>()` extensibility point for overriding server error codes.
+
+- **[Websockets](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/websockets.rst)**: [Overridable WebSocket buffer size](https://github.com/ThreeMammals/Ocelot/issues/2386) and custom middleware injection was added by @erannevo in pull request #2387.
+
+  The previously hard-coded `DefaultWebSocketBufferSize` is now a `protected virtual` property that can be overridden by subclassing.
+  The [Middleware Injection](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/middlewareinjection.rst) feature was extended with a `WebSocketsProxyMiddleware` override on `OcelotPipelineConfiguration`, allowing a fully custom WebSocket middleware to be injected into the pipeline.
+
+- **[Websockets](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/websockets.rst)**: [SecurityOptions support for the WebSocket pipeline](https://github.com/ThreeMammals/Ocelot/issues/2403) was added by @CurtisRobertOliver in pull request #2406.
+
+  Previously, IP allow/block-list [Routing](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/routing.rst) `SecurityOptions` were not enforced for WebSocket upgrade requests, allowing them to bypass IP security.
+  WebSocket upgrade requests are now intercepted by the same `IPSecurityPolicy` used for regular HTTP requests, and denied upgrades now correctly return `403 Forbidden`.
+
+- **[Configuration](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/configuration.rst)**: "[Merge custom JSON properties across multiple configuration files](https://github.com/ThreeMammals/Ocelot/issues/651)" was implemented by @jlukawska in pull request #1183.
+
+  Ocelot's configuration builder now merges custom (non-schema) JSON properties defined across multiple `ocelot.*.json` files using Newtonsoft's `JToken` merge functionality, instead of the last-loaded file silently overwriting properties from previous files.
+  This also applies to the `DynamicRoutes` collection. See the updated [Configuration](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/configuration.rst) documentation and the `Configuration` sample app for details.
+
+- **[Aggregation](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/aggregation.rst)**: "[Correct mapping of RouteKeysConfig arrays in aggregates](https://github.com/ThreeMammals/Ocelot/issues/2248)" fix, contributed in pull request #2328.
+
+  Aggregate routes configured with the `RouteKeysConfig` array now correctly map route keys to the corresponding aggregator context, fixing a bug where keys could be mismatched or dropped during multiplexing.
+
+### :up: What's Updated?
+
+- Package extraction #2334: The Ocelot team, led by @raman-m, continued extracting integrated extension packages out of the mono-repo into their own dedicated repositories, each with an independent release cycle:
+
+  * [Ocelot.Cache.CacheManager](https://www.nuget.org/packages/Ocelot.Cache.CacheManager/) — pull request #2360
+  * [Ocelot.Tracing.Butterfly](https://www.nuget.org/packages/Ocelot.Tracing.Butterfly/) — pull request #2361
+  * [Ocelot.Tracing.OpenTracing](https://www.nuget.org/packages/Ocelot.Tracing.OpenTracing/) — pull request #2362
+  * [Ocelot.Discovery.Eureka](https://www.nuget.org/packages/Ocelot.Discovery.Eureka/) (renamed from `Ocelot.Provider.Eureka`, see issue #2371) — pull request #2372
+  * [Ocelot.QualityOfService.Polly](https://www.nuget.org/packages/Ocelot.QualityOfService.Polly/) (renamed from `Ocelot.Provider.Polly`, see issue #2378) — pull request #2380
+  * [Ocelot.Discovery.Consul](https://www.nuget.org/packages/Ocelot.Discovery.Consul/) (renamed from `Ocelot.Provider.Consul`, see issue #2378) — pull request #2388
+  * [Ocelot.Discovery.KubeClient](https://www.nuget.org/packages/Ocelot.Discovery.KubeClient/) (renamed from `Ocelot.Provider.Kubernetes`, see issue #2378) — pull request #2404
+
+  This keeps the Ocelot core repo lean, avoids delays caused by integrated packages' own release schedules, and lets each provider evolve independently.
+  Consult the [Caching](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/caching.rst), [Tracing](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/tracing.rst), [Service Discovery](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/servicediscovery.rst) and [Kubernetes](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/kubernetes.rst) chapters for package-specific upgrade notes.
+
+- **[Error Codes](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/errorcodes.rst)**: [Non-ASCII header exceptions mapped to 400 Bad Request](https://github.com/ThreeMammals/Ocelot/issues/2374) per RFC 7230, in pull request #2379.
+
+  Requests containing non-ASCII characters in HTTP header values previously surfaced as an unhandled `HttpRequestException` and an HTTP 500 response.
+  Ocelot now catches this `HttpRequestException` and maps it to a `400 Bad Request` response, in line with RFC 7230 "Field Parsing" rules.
+
+- **[Administration](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/administration.rst)**: "[Hide Administration controllers from Swagger and OpenAPI](https://github.com/ThreeMammals/Ocelot/issues/989)" fix, contributed in pull request #2412.
+
+  The `{adminPath}/configuration` and `{adminPath}/outputcache/{region}` endpoints are now decorated with `[ApiExplorerSettings(IgnoreApi = true)]` so that they no longer appear in Swagger/OpenAPI documentation generated for the downstream API surface.
+
+- **[DevOps](https://github.com/ThreeMammals/Ocelot/labels/DevOps)**: Extensive testing and tooling modernization was carried out by @raman-m and contributors ahead of [.NET 10](https://github.com/ThreeMammals/Ocelot/milestone/13):
+
+  * Solutions upgraded to the Visual Studio 2026 format.
+  * Testing projects migrated from xUnit v2 to xUnit v3, and acceptance tests migrated to the Microsoft.Testing.Platform framework.
+  * [Ocelot.Testing](https://github.com/ThreeMammals/Ocelot.Testing) was re-embedded into the mono-repo and later excluded from Cobertura coverage via `coverlet.runsettings`.
+  * [Codecov](https://about.codecov.io/) coverage reporting was installed for the repository.
+  * All NuGet packages were bumped to their latest versions to support .NET SDK `10.0.302` (.NET Runtime `10.0.10`).
+
+### :package: Patches Included
+
+- **[Routing](https://github.com/ThreeMammals/Ocelot/blob/main/docs/features/routing.rst)**: Issue #2346 patch, contributed in pull request #2351.
+
+  This fixes a bug where downstream URL query parameter names could be corrupted if they contained a placeholder with a non-empty value.
+  The `DownstreamUrlCreatorMiddleware` query string merging algorithm was refactored to take full advantage of ASP.NET Core's `QueryHelpers`.

--- a/docs/building/building.rst
+++ b/docs/building/building.rst
@@ -19,7 +19,7 @@ or by a CI/CD server (currently `GitHub Actions`_), with minimal logic defined i
 
 The final goal of the build process is to create ``Ocelot.*`` `NuGet`_ packages (.nupkg files) for redistribution via the `NuGet`_ repository or manually.
 The build process consists of several steps: (1) compilation, (2) testing, (3) creating and publishing `NuGet`_ packages, and (4) making an official GitHub release.
-The build process requires pre-installed .NET SDKs on the build machine (host) for all target framework monikers: TFMs are ``net8.0`` and ``net9.0`` currently.
+The build process requires pre-installed .NET SDKs on the build machine (host) for all target framework monikers: TFMs are ``net8.0``, ``net9.0`` and ``net10.0`` currently.
 In general, the build process is the same across all environments and tools, with a few differences described below.
 
 .. _b-in-ide:
@@ -28,7 +28,7 @@ In IDE
 ------
 .. _Release configuration: https://learn.microsoft.com/en-us/visualstudio/debugger/how-to-set-debug-and-release-configurations?view=vs-2022
 
-In an IDE, a DevOps engineer can build the project in Visual Studio IDE or another IDE in `Release configuration`_ mode, but the latest .NET 8/9 SDKs must be pre-installed on the local machine.
+In an IDE, a DevOps engineer can build the project in Visual Studio IDE or another IDE in `Release configuration`_ mode, but the latest .NET 8/9/10 SDKs must be pre-installed on the local machine.
 However, this approach is not practical because the generated '.nupkg' files must be uploaded to `NuGet`_ manually, and the GitHub release must also be created manually.
 A better approach is to utilize the '`build.cake`_' script :ref:`b-in-terminal`, which covers all building scenarios.
 

--- a/docs/features/administration.rst
+++ b/docs/features/administration.rst
@@ -122,6 +122,10 @@ If all the other Ocelot instances in the cluster have the same certificate then 
 Administration API
 ------------------
 
+.. note::
+  As of version `25.0`_, the ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{{region}}`` endpoints are decorated with ``[ApiExplorerSettings(IgnoreApi = true)]`` and are therefore hidden from Swagger/OpenAPI documentation generators (e.g. `MMLib.SwaggerForOcelot <https://github.com/Burgyn/MMLib.SwaggerForOcelot>`_).
+  This prevents these internal administration endpoints from cluttering the API documentation surfaced to your API consumers, while the endpoints themselves remain fully functional.
+
 * **POST** ``{adminPath}/connect/token``
 
     This gets a token for use with the admin area using the client credentials we talk about setting above.
@@ -160,3 +164,5 @@ Administration API
 
 .. [#f1] The ":ref:`Your Own IdentityServer <ad-your-own-identityserver>`" feature was implemented for issue `228 <https://github.com/ThreeMammals/Ocelot/issues/228>`_.
 .. [#f2] The :ref:`di-services-addocelot-method` adds default ASP.NET services to the DI container. You can call another extended :ref:`di-addocelotusingbuilder-method` while configuring services to develop your own :ref:`di-custom-builder`. See more instructions in the ":ref:`di-addocelotusingbuilder-method`" section of the :doc:`../features/dependencyinjection` feature.
+
+.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13

--- a/docs/features/administration.rst
+++ b/docs/features/administration.rst
@@ -2,27 +2,26 @@
 .. _IdentityServer4: https://www.nuget.org/packages/IdentityServer4
 .. _Program: https://github.com/ThreeMammals/Ocelot.Administration.IdentityServer4/blob/main/sample/Program.cs
 .. _Ocelot.Administration.IdentityServer4: https://www.nuget.org/packages/Ocelot.Administration.IdentityServer4
-.. _24.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0
 .. _Ocelot.postman_collection.json: https://github.com/ThreeMammals/Ocelot.Administration.IdentityServer4/blob/main/sample/Ocelot.postman_collection.json
 
 Administration
 ==============
 
-  **Ocelot extension package**: `Ocelot.Administration.IdentityServer4`_ with integrated `IdentityServer4`_ package by `IdentityServer org <https://github.com/IdentityServer>`_ (archived on March 6, 2025)
+  **Package**: `Ocelot.Administration.IdentityServer4`_ with integrated `IdentityServer4`_ package by `IdentityServer org <https://github.com/IdentityServer>`_ (archived on March 6, 2025)
 
 Ocelot supports changing configuration during runtime via an authenticated HTTP API.
 This can be authenticated in two ways either using Ocelot's internal `IdentityServer`_ (for authenticating requests to the :ref:`administration-api` only) or hooking the :ref:`administration-api` authentication into your own `IdentityServer`_.
 
 The first thing you need to do if you want to use the :ref:`administration-api` is bring in the relevant `Ocelot.Administration.IdentityServer4`_ package:
 
-.. code-block:: powershell
+.. code-block:: shell
 
-  NuGet\Install-Package Ocelot.Administration.IdentityServer4
   dotnet add package Ocelot.Administration.IdentityServer4
 
 This will bring down everything needed by the :ref:`administration-api`.
 
-  **Warning!** Currently, the *Administration* feature relies solely on the `IdentityServer4`_ package, whose `repository <https://github.com/DuendeArchive/IdentityServer4>`_ was archived by its owner on July 31, 2024 (for the first time) and again on March 6, 2025.
+.. warning::
+  Currently, the *Administration* feature relies solely on the `IdentityServer4`_ package, whose `repository <https://github.com/DuendeArchive/IdentityServer4>`_ was archived by its owner on July 31, 2024 (for the first time) and again on March 6, 2025.
   In release `24.0`_, the Ocelot team deprecated the `Ocelot.Administration.IdentityServer4`_ extension package.
   However, `the repository <https://github.com/ThreeMammals/Ocelot.Administration.IdentityServer4>`_ remains available, allowing for potential patches.
 
@@ -121,10 +120,8 @@ If all the other Ocelot instances in the cluster have the same certificate then 
 
 Administration API
 ------------------
-
-.. note::
-  As of version `25.0`_, the ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{region}`` endpoints are decorated with ``[ApiExplorerSettings(IgnoreApi = true)]`` and are therefore hidden from Swagger/OpenAPI documentation generators (e.g. `MMLib.SwaggerForOcelot <https://github.com/Burgyn/MMLib.SwaggerForOcelot>`_).
-  This prevents these internal administration endpoints from cluttering the API documentation surfaced to your API consumers, while the endpoints themselves remain fully functional.
+.. _MMLib.SwaggerForOcelot: https://github.com/Burgyn/MMLib.SwaggerForOcelot
+.. _ApiExplorerSettings: https://github.com/search?q=repo%3AThreeMammals%2FOcelot+ApiExplorerSettings%28&type=code
 
 * **POST** ``{adminPath}/connect/token``
 
@@ -160,9 +157,18 @@ Administration API
 
     The region is whatever you set against the ``Region`` field in the `FileCacheOptions <https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20FileCacheOptions&type=code>`_ section of the Ocelot configuration.
 
+.. note::
+  [#f3]_ As of version `25.0`_, the ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{region}`` endpoints are decorated with `ApiExplorerSettings`_ attribute and are therefore hidden from Swagger/OpenAPI documentation generators (e.g. `MMLib.SwaggerForOcelot`_).
+  This prevents these internal administration endpoints from cluttering the API documentation surfaced to your API consumers, while the endpoints themselves remain fully functional.
+
 """"
 
 .. [#f1] The ":ref:`Your Own IdentityServer <ad-your-own-identityserver>`" feature was implemented for issue `228 <https://github.com/ThreeMammals/Ocelot/issues/228>`_.
 .. [#f2] The :ref:`di-services-addocelot-method` adds default ASP.NET services to the DI container. You can call another extended :ref:`di-addocelotusingbuilder-method` while configuring services to develop your own :ref:`di-custom-builder`. See more instructions in the ":ref:`di-addocelotusingbuilder-method`" section of the :doc:`../features/dependencyinjection` feature.
+.. [#f3] The ":ref:`administration-api`" controller endpoints were hidden due to bug `989`_, and patch `2412`_ was applied and rolled out as part of version `25.0`_.
 
+.. _989: https://github.com/ThreeMammals/Ocelot/issues/989
+.. _2412: https://github.com/ThreeMammals/Ocelot/pull/2412
+
+.. _24.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0
 .. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/administration.rst
+++ b/docs/features/administration.rst
@@ -165,4 +165,4 @@ Administration API
 .. [#f1] The ":ref:`Your Own IdentityServer <ad-your-own-identityserver>`" feature was implemented for issue `228 <https://github.com/ThreeMammals/Ocelot/issues/228>`_.
 .. [#f2] The :ref:`di-services-addocelot-method` adds default ASP.NET services to the DI container. You can call another extended :ref:`di-addocelotusingbuilder-method` while configuring services to develop your own :ref:`di-custom-builder`. See more instructions in the ":ref:`di-addocelotusingbuilder-method`" section of the :doc:`../features/dependencyinjection` feature.
 
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/administration.rst
+++ b/docs/features/administration.rst
@@ -123,7 +123,7 @@ Administration API
 ------------------
 
 .. note::
-  As of version `25.0`_, the ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{{region}}`` endpoints are decorated with ``[ApiExplorerSettings(IgnoreApi = true)]`` and are therefore hidden from Swagger/OpenAPI documentation generators (e.g. `MMLib.SwaggerForOcelot <https://github.com/Burgyn/MMLib.SwaggerForOcelot>`_).
+  As of version `25.0`_, the ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{region}`` endpoints are decorated with ``[ApiExplorerSettings(IgnoreApi = true)]`` and are therefore hidden from Swagger/OpenAPI documentation generators (e.g. `MMLib.SwaggerForOcelot <https://github.com/Burgyn/MMLib.SwaggerForOcelot>`_).
   This prevents these internal administration endpoints from cluttering the API documentation surfaced to your API consumers, while the endpoints themselves remain fully functional.
 
 * **POST** ``{adminPath}/connect/token``

--- a/docs/features/aggregation.rst
+++ b/docs/features/aggregation.rst
@@ -423,4 +423,4 @@ Gotchas
 
 .. _13.4: https://github.com/ThreeMammals/Ocelot/releases/tag/13.4.1
 .. _23.1: https://github.com/ThreeMammals/Ocelot/releases/tag/23.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/authentication.rst
+++ b/docs/features/authentication.rst
@@ -409,4 +409,4 @@ Please open a "`Show and tell <https://github.com/ThreeMammals/Ocelot/discussion
 .. _2336: https://github.com/ThreeMammals/Ocelot/pull/2336
 .. _23.0: https://github.com/ThreeMammals/Ocelot/releases/tag/23.0.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/caching.rst
+++ b/docs/features/caching.rst
@@ -13,12 +13,21 @@ The following example shows how to add *CacheManager* to Ocelot so that you can 
 
 Install
 -------
+.. _Ocelot.Cache.CacheManager: https://www.nuget.org/packages/Ocelot.Cache.CacheManager
 
-First of all, add the following `Ocelot.Cache.CacheManager <https://www.nuget.org/packages/Ocelot.Cache.CacheManager>`_ package:
+  | Package: `Ocelot.Cache.CacheManager`_
+  | Namespace: ``Ocelot.Cache.CacheManager``
+  | Repository: `ThreeMammals/Ocelot.Cache.CacheManager <https://github.com/ThreeMammals/Ocelot.Cache.CacheManager>`_
+
+First of all, add the following `Ocelot.Cache.CacheManager`_ package:
 
 .. code-block:: powershell
 
-    Install-Package Ocelot.Cache.CacheManager
+    dotnet add package Ocelot.Cache.CacheManager
+
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Cache.CacheManager`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Cache.CacheManager <https://github.com/ThreeMammals/Ocelot.Cache.CacheManager>`_.
 
 This will give you access to the Ocelot cache manager extension methods.
 The second step is to add the following to your `Program`_:

--- a/docs/features/caching.rst
+++ b/docs/features/caching.rst
@@ -115,7 +115,7 @@ Finally, in order to use caching on a route in your route configuration add thes
 * Finally, ``EnableContentHashing`` is disabled due to the current route using the ``GET`` verb, which does not include a request body.
 
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
 .. warning::
   According to the static :ref:`config-route-schema`, the ``FileCacheOptions`` section has been deprecated!
 

--- a/docs/features/caching.rst
+++ b/docs/features/caching.rst
@@ -14,20 +14,17 @@ The following example shows how to add *CacheManager* to Ocelot so that you can 
 Install
 -------
 .. _Ocelot.Cache.CacheManager: https://www.nuget.org/packages/Ocelot.Cache.CacheManager
+.. _ThreeMammals/Ocelot.Cache.CacheManager: https://github.com/ThreeMammals/Ocelot.Cache.CacheManager
 
   | Package: `Ocelot.Cache.CacheManager`_
   | Namespace: ``Ocelot.Cache.CacheManager``
-  | Repository: `ThreeMammals/Ocelot.Cache.CacheManager <https://github.com/ThreeMammals/Ocelot.Cache.CacheManager>`_
+  | Repository: `ThreeMammals/Ocelot.Cache.CacheManager`_
 
 First of all, add the following `Ocelot.Cache.CacheManager`_ package:
 
-.. code-block:: powershell
+.. code-block:: shell
 
     dotnet add package Ocelot.Cache.CacheManager
-
-.. warning::
-  Starting with version `25.0`_, the `Ocelot.Cache.CacheManager`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
-  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Cache.CacheManager <https://github.com/ThreeMammals/Ocelot.Cache.CacheManager>`_.
 
 This will give you access to the Ocelot cache manager extension methods.
 The second step is to add the following to your `Program`_:
@@ -39,6 +36,10 @@ The second step is to add the following to your `Program`_:
     builder.Services
         .AddOcelot(builder.Configuration)
         .AddCacheManager(x => x.WithDictionaryHandle());
+
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Cache.CacheManager`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Cache.CacheManager`_.
 
 ``CacheOptions`` Schema
 -----------------------

--- a/docs/features/configuration.rst
+++ b/docs/features/configuration.rst
@@ -1224,4 +1224,4 @@ Refer to the :ref:`config-merging-recipes` and :ref:`Extend with Custom Properti
 .. _23.2: https://github.com/ThreeMammals/Ocelot/releases/tag/23.2.0
 .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/errorcodes.rst
+++ b/docs/features/errorcodes.rst
@@ -117,4 +117,4 @@ We expect you to share your use case with us in the `Discussions <https://github
 .. _"Field Parsing": https://www.rfc-editor.org/rfc/rfc7230#section-3.2.4
 .. _2374: https://github.com/ThreeMammals/Ocelot/issues/2374
 .. _2379: https://github.com/ThreeMammals/Ocelot/pull/2379
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/kubernetes.rst
+++ b/docs/features/kubernetes.rst
@@ -395,4 +395,4 @@ you must define ``DownstreamScheme`` to enable the provider to recognize the des
 .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _24.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/middlewareinjection.rst
+++ b/docs/features/middlewareinjection.rst
@@ -170,4 +170,4 @@ In any case, if the current overridden middleware does not provide enough pipeli
   :height: 25
   :class: img-valign-middle
 
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/qualityofservice.rst
+++ b/docs/features/qualityofservice.rst
@@ -702,4 +702,4 @@ Finally, to define your own set of exceptions for mapping, you can apply the fol
 .. _23.2: https://github.com/ThreeMammals/Ocelot/releases/tag/23.2.0
 .. _24.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/ratelimiting.rst
+++ b/docs/features/ratelimiting.rst
@@ -323,7 +323,7 @@ Filter the current discussions by the `Rate Limiting <https://github.com/ThreeMa
 .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _24.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.0.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
 
 .. |octocat| image:: https://github.githubassets.com/images/icons/emoji/octocat.png
   :alt: octocat

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -522,4 +522,4 @@ If your case is not included, feel free to open a "`Show and tell`_" discussion.
 .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _23.4: https://github.com/ThreeMammals/Ocelot/releases/tag/23.4.0
 .. _23.4.1: https://github.com/ThreeMammals/Ocelot/releases/tag/23.4.1
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/servicediscovery.rst
+++ b/docs/features/servicediscovery.rst
@@ -767,4 +767,4 @@ However, you can retain this ``Type`` option to maintain compatibility between b
 .. _13.5.2: https://github.com/ThreeMammals/Ocelot/releases/tag/13.5.2
 .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/tracing.rst
+++ b/docs/features/tracing.rst
@@ -16,12 +16,17 @@ This chapter explains how to perform distributed tracing using Ocelot.
 -------------------------------------
 
 .. _OpenTracing: https://opentracing.io
+.. _Ocelot.Tracing.OpenTracing: https://www.nuget.org/packages/Ocelot.Tracing.OpenTracing
 
-  | Package: `Ocelot.Tracing.OpenTracing <https://www.nuget.org/packages/Ocelot.Tracing.OpenTracing>`_
+  | Package: `Ocelot.Tracing.OpenTracing`_
   | Namespace: ``Ocelot.Tracing.OpenTracing``
+  | Repository: `ThreeMammals/Ocelot.Tracing.OpenTracing <https://github.com/ThreeMammals/Ocelot.Tracing.OpenTracing>`_
 
 Ocelot provides tracing functionality through the excellent project from `opentracing-csharp <https://github.com/opentracing/opentracing-csharp>`_ repository.
-The code for Ocelot integration can be found in this `Ocelot project <https://github.com/ThreeMammals/Ocelot/tree/main/src/Ocelot.Tracing.OpenTracing>`_.
+
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Tracing.OpenTracing`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.OpenTracing <https://github.com/ThreeMammals/Ocelot.Tracing.OpenTracing>`_.
 
 The example below uses the `C# Client for Jaeger <https://github.com/jaegertracing/jaeger-client-csharp>`_ to provide the tracer used in Ocelot.
 To add `OpenTracing`_ services, you must call the ``AddOpenTracing()`` extension method on the ``OcelotBuilder`` returned by ``AddOcelot()`` [#f1]_, as shown below:
@@ -62,13 +67,18 @@ Butterfly
 ---------
 
 .. _Butterfly: https://github.com/liuhaoyang/butterfly
+.. _Ocelot.Tracing.Butterfly: https://www.nuget.org/packages/Ocelot.Tracing.Butterfly
 
-  | Package: `Ocelot.Tracing.Butterfly <https://www.nuget.org/packages/Ocelot.Tracing.Butterfly>`_
+  | Package: `Ocelot.Tracing.Butterfly`_
   | Namespace: ``Ocelot.Tracing.Butterfly``
+  | Repository: `ThreeMammals/Ocelot.Tracing.Butterfly <https://github.com/ThreeMammals/Ocelot.Tracing.Butterfly>`_
 
 Ocelot provides tracing functionality through the excellent `Butterfly`_ project.
-The code for the Ocelot integration can be found in this `Ocelot project <https://github.com/ThreeMammals/Ocelot/tree/main/src/Ocelot.Tracing.Butterfly>`__.
 To use the tracing functionality, please refer to the `Butterfly`_ documentation.
+
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Tracing.Butterfly`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.Butterfly <https://github.com/ThreeMammals/Ocelot.Tracing.Butterfly>`_.
 
 In Ocelot, you need to add the NuGet package if you wish to trace a route:
 
@@ -104,7 +114,7 @@ Ocelot will now send tracing information to `Butterfly`_ whenever this route is 
 
   **Note**: The `Butterfly`_ project has not been supported for more than seven years, as of 2025.
   The latest release of the `Butterfly.Client <https://www.nuget.org/packages/Butterfly.Client>`_ package (version `0.0.8 <https://www.nuget.org/packages/Butterfly.Client/0.0.8>`_) was made on February 22, 2018.
-  The Ocelot team is planning to discontinue the `Ocelot.Tracing.Butterfly`_ package, which is scheduled to happen after the release of Ocelot version `24.1`_.
+  As planned, the Ocelot team discontinued distribution of the `Ocelot.Tracing.Butterfly`_ package from the main Ocelot mono-repo in version `25.0`_, moving it to its own dedicated repository instead.
 
 """"
 
@@ -113,3 +123,4 @@ Ocelot will now send tracing information to `Butterfly`_ whenever this route is 
 .. _Program: https://github.com/ThreeMammals/Ocelot/blob/main/samples/Basic/Program.cs
 .. _ocelot.json: https://github.com/ThreeMammals/Ocelot/blob/main/samples/Basic/ocelot.json
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
+.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13

--- a/docs/features/tracing.rst
+++ b/docs/features/tracing.rst
@@ -17,16 +17,17 @@ This chapter explains how to perform distributed tracing using Ocelot.
 
 .. _OpenTracing: https://opentracing.io
 .. _Ocelot.Tracing.OpenTracing: https://www.nuget.org/packages/Ocelot.Tracing.OpenTracing
+.. _ThreeMammals/Ocelot.Tracing.OpenTracing: https://github.com/ThreeMammals/Ocelot.Tracing.OpenTracing
 
   | Package: `Ocelot.Tracing.OpenTracing`_
   | Namespace: ``Ocelot.Tracing.OpenTracing``
-  | Repository: `ThreeMammals/Ocelot.Tracing.OpenTracing <https://github.com/ThreeMammals/Ocelot.Tracing.OpenTracing>`_
+  | Repository: `ThreeMammals/Ocelot.Tracing.OpenTracing`_
 
-Ocelot provides tracing functionality through the excellent project from `opentracing-csharp <https://github.com/opentracing/opentracing-csharp>`_ repository.
+Ocelot provides tracing functionality through the project from `opentracing-csharp <https://github.com/opentracing/opentracing-csharp>`_ repository.
 
-.. warning::
-  Starting with version `25.0`_, the `Ocelot.Tracing.OpenTracing`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
-  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.OpenTracing <https://github.com/ThreeMammals/Ocelot.Tracing.OpenTracing>`_.
+.. code-block:: shell
+
+  dotnet add package Ocelot.Tracing.OpenTracing
 
 The example below uses the `C# Client for Jaeger <https://github.com/jaegertracing/jaeger-client-csharp>`_ to provide the tracer used in Ocelot.
 To add `OpenTracing`_ services, you must call the ``AddOpenTracing()`` extension method on the ``OcelotBuilder`` returned by ``AddOcelot()`` [#f1]_, as shown below:
@@ -56,10 +57,14 @@ Then, in your `ocelot.json <https://github.com/ThreeMammals/Ocelot/blob/main/sam
 
 Ocelot will now send tracing information to `Jaeger <https://www.jaegertracing.io/>`_ whenever this route is called.
 
-  **Note 1**: A clean yet functional sample can be found here: `Ocelot.Samples.OpenTracing <https://github.com/ThreeMammals/Ocelot/tree/main/samples/OpenTracing>`_.
+.. note::
+  1. A clean yet functional sample can be found here: `Ocelot.Samples.OpenTracing <https://github.com/ThreeMammals/Ocelot/tree/main/samples/OpenTracing>`_.
+  2. The `OpenTracing`_ project was archived on January 31, 2022 (see `the article <https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/>`_).
+     The Ocelot team is planning to decide on a migration to `OpenTelemetry <https://opentelemetry.io>`_, which is highly desirable.
 
-  **Note 2**: The `OpenTracing`_ project was archived on January 31, 2022 (see `the article <https://www.cncf.io/blog/2022/01/31/cncf-archives-the-opentracing-project/>`_).
-  The Ocelot team is planning to decide on a migration to `OpenTelemetry <https://opentelemetry.io>`_, which is highly desirable.
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Tracing.OpenTracing`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.OpenTracing`_.
 
 .. _tr-butterfly:
 
@@ -68,23 +73,20 @@ Butterfly
 
 .. _Butterfly: https://github.com/liuhaoyang/butterfly
 .. _Ocelot.Tracing.Butterfly: https://www.nuget.org/packages/Ocelot.Tracing.Butterfly
+.. _ThreeMammals/Ocelot.Tracing.Butterfly: https://github.com/ThreeMammals/Ocelot.Tracing.Butterfly
 
   | Package: `Ocelot.Tracing.Butterfly`_
   | Namespace: ``Ocelot.Tracing.Butterfly``
-  | Repository: `ThreeMammals/Ocelot.Tracing.Butterfly <https://github.com/ThreeMammals/Ocelot.Tracing.Butterfly>`_
+  | Repository: `ThreeMammals/Ocelot.Tracing.Butterfly`_
 
 Ocelot provides tracing functionality through the excellent `Butterfly`_ project.
 To use the tracing functionality, please refer to the `Butterfly`_ documentation.
 
-.. warning::
-  Starting with version `25.0`_, the `Ocelot.Tracing.Butterfly`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
-  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.Butterfly <https://github.com/ThreeMammals/Ocelot.Tracing.Butterfly>`_.
-
 In Ocelot, you need to add the NuGet package if you wish to trace a route:
 
-.. code-block:: powershell
+.. code-block:: shell
 
-    Install-Package Ocelot.Tracing.Butterfly
+  dotnet add package Ocelot.Tracing.Butterfly
 
 In your `Program`_, to add `Butterfly`_ services, you must call the ``AddButterfly()`` extension method on the ``OcelotBuilder`` returned by ``AddOcelot()``, as shown below:
 
@@ -112,9 +114,14 @@ Then, in your `ocelot.json`_, add the following to the route you want to trace:
 
 Ocelot will now send tracing information to `Butterfly`_ whenever this route is called.
 
-  **Note**: The `Butterfly`_ project has not been supported for more than seven years, as of 2025.
+.. note::
+  The `Butterfly`_ project has not been supported for more than seven years, as of 2026.
   The latest release of the `Butterfly.Client <https://www.nuget.org/packages/Butterfly.Client>`_ package (version `0.0.8 <https://www.nuget.org/packages/Butterfly.Client/0.0.8>`_) was made on February 22, 2018.
   As planned, the Ocelot team discontinued distribution of the `Ocelot.Tracing.Butterfly`_ package from the main Ocelot mono-repo in version `25.0`_, moving it to its own dedicated repository instead.
+
+.. warning::
+  Starting with version `25.0`_, the `Ocelot.Tracing.Butterfly`_ package has been extracted from the Ocelot mono-repo into its own dedicated repository.
+  The package ID and namespace remain unchanged, but the source code, issues, and releases are now hosted at `ThreeMammals/Ocelot.Tracing.Butterfly`_.
 
 """"
 

--- a/docs/features/tracing.rst
+++ b/docs/features/tracing.rst
@@ -123,4 +123,4 @@ Ocelot will now send tracing information to `Butterfly`_ whenever this route is 
 .. _Program: https://github.com/ThreeMammals/Ocelot/blob/main/samples/Basic/Program.cs
 .. _ocelot.json: https://github.com/ThreeMammals/Ocelot/blob/main/samples/Basic/ocelot.json
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/milestone/13
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4

--- a/docs/features/websockets.rst
+++ b/docs/features/websockets.rst
@@ -271,7 +271,7 @@ Additionally, we welcome any bug reports, enhancement suggestions, or proposals 
 .. _5.3.0: https://github.com/ThreeMammals/Ocelot/releases/tag/5.3.0
 .. _8.0.7: https://github.com/ThreeMammals/Ocelot/releases/tag/8.0.7
 .. _20.0: https://github.com/ThreeMammals/Ocelot/releases/tag/20.0.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
 
 .. |octocat| image:: https://github.githubassets.com/images/icons/emoji/octocat.png
   :alt: octocat

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
 .. role::  htm(raw)
     :format: html
 .. role:: pdf(raw)

--- a/docs/introduction/gettingstarted.rst
+++ b/docs/introduction/gettingstarted.rst
@@ -12,9 +12,9 @@ Install Ocelot and it's dependencies using `NuGet <https://www.nuget.org/>`_.
 You will need to create a `ASP.NET Core minimal API project <https://learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api>`_ with "ASP.NET Core Empty" template but without ``app.Map*`` methods, and bring the package into it.
 Then follow the startup below and :doc:`../features/configuration` sections to get up and running.
 
-.. code-block:: powershell
+.. code-block:: shell
 
-   Install-Package Ocelot
+  dotnet add package Ocelot
 
 All versions can be found in the `NuGet Gallery | Ocelot <https://www.nuget.org/packages/Ocelot/>`_.
 

--- a/docs/introduction/gettingstarted.rst
+++ b/docs/introduction/gettingstarted.rst
@@ -1,8 +1,9 @@
 Getting Started
 ===============
 
-Ocelot is designed to work with `ASP.NET Core <https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-9.0>`_ and is currently on `.NET 8 <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle>`_ `LTS <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types>`_
-and `.NET 9 <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle>`_ `STS <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types>`_ frameworks.
+Ocelot is designed to work with `ASP.NET Core <https://learn.microsoft.com/en-us/aspnet/core/?view=aspnetcore-10.0>`_ and currently targets `.NET 8 <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle>`_ `LTS <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types>`_,
+`.NET 9 <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle>`_ `STS <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types>`_
+and `.NET 10 <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle>`_ `LTS <https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#release-types>`_ frameworks.
 
 Install
 -------

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,7 +1,7 @@
 .. _24.1: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
 .. _24.1.0: https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0
-.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
-.. _25.0.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.3
+.. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
+.. _25.0.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0-beta.4
 .. _.NET 9: https://dotnet.microsoft.com/en-us/download/dotnet/9.0
 .. _.NET 10: https://github.com/ThreeMammals/Ocelot/milestone/13
 .. _Globality: https://github.com/ThreeMammals/Ocelot/milestone/9

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -37,12 +37,12 @@ Release Notes
   | Release Codename: `.NET 10`_
 
 In this major release, the Ocelot team focused on preparing the codebase and its ecosystem for `.NET 10`_, while also extracting several integrated extension packages from the mono-repo into their own dedicated repositories to speed up delivery and reduce release coupling.
-This release also introduces a built-in *Quality of Service* (QoS) circuit breaker that works out of the box, without requiring the `Polly`_ library.
+This release also introduces a built-in :doc:`../features/qualityofservice` (QoS) circuit breaker that works out of the box, without requiring the `Polly`_ library.
 
 The updated documentation highlights `the deprecation <https://ocelot.readthedocs.io/en/latest/search.html?q=deprecated>`_ of certain packages through multiple notes and warnings.
 With the `Obsolete attributes`_ in place, C# developers will notice several warnings in the build logs during compilation.
 
-On top of that, this release brings a great enhancement to the :doc:`../features/kubernetes` provider, also known as the `Ocelot.Discovery.KubeClient`_ package.
+Additionally, this release brings a significant enhancement to the :doc:`../features/kubernetes` ``PollKube`` provider from the `Ocelot.Discovery.KubeClient`_ package.
 
 What's New?
 -----------
@@ -77,13 +77,14 @@ What's New?
 
 - :doc:`../features/websockets`: `SecurityOptions support for the WebSocket pipeline <2403_>`_ was added by `@CurtisRobertOliver`_ in pull request `2406`_.
 
-  Previously, IP allow/block-list :doc:`../features/routing` ``SecurityOptions`` were not enforced for WebSocket upgrade requests, allowing them to bypass IP security.
+  Previously, IP allow/block-list :doc:`../features/routing` :ref:`Security Options <routing-security-options>` were not enforced for WebSocket upgrade requests, allowing them to bypass IP security.
   WebSocket upgrade requests are now intercepted by the same ``IPSecurityPolicy`` used for regular HTTP requests, and denied upgrades now correctly return ``403 Forbidden``.
 
 - :doc:`../features/configuration`: "`Merge custom JSON properties across multiple configuration files <651_>`_" was implemented by `@jlukawska`_ in pull request `1183`_.
 
   Ocelot's configuration builder now merges custom (non-schema) JSON properties defined across multiple ``ocelot.*.json`` files using Newtonsoft's ``JToken`` merge functionality, instead of the last-loaded file silently overwriting properties from previous files.
-  This also applies to the ``DynamicRoutes`` collection. See the updated :doc:`../features/configuration` documentation and the ``Configuration`` sample app for details.
+  This also applies to the ``DynamicRoutes`` collection.
+  See the updated :doc:`../features/configuration` documentation, the ":ref:`Extend with Custom Properties <config-custom-properties>`" section and the :ref:`Configuration Sample <config-sample>` app for details.
 
 - :doc:`../features/aggregation`: "`Correct mapping of RouteKeysConfig arrays in aggregates <2248_>`_" fix, contributed in pull request `2328`_.
 

--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -36,196 +36,124 @@ Release Notes
   | Release Tag: `25.0.0`_
   | Release Codename: `.NET 10`_
 
-.. In this minor release, the Ocelot team put the spotlight on the :doc:`../features/configuration` feature as part of their semi-annual 2025 effort, with a particular focus on the :ref:`config-global-configuration-schema`.
-.. This release enhances support for global configurations across both routing modes: the classic static :doc:`../features/routing` and the :doc:`service discovery <../features/servicediscovery>`-based :ref:`Dynamic Routing <sd-dynamic-routing>`.
+In this major release, the Ocelot team focused on preparing the codebase and its ecosystem for `.NET 10`_, while also extracting several integrated extension packages from the mono-repo into their own dedicated repositories to speed up delivery and reduce release coupling.
+This release also introduces a built-in *Quality of Service* (QoS) circuit breaker that works out of the box, without requiring the `Polly`_ library.
 
-.. The updated documentation highlights `the deprecation <https://ocelot.readthedocs.io/en/latest/search.html?q=deprecated>`_ of certain options through multiple notes and warnings.
-.. This deprecation process will be completed in the upcoming `.NET 10`_ release.
-.. With the `Obsolete attributes`_ in place, C# developers will notice several warnings in the build logs during compilation.
+The updated documentation highlights `the deprecation <https://ocelot.readthedocs.io/en/latest/search.html?q=deprecated>`_ of certain packages through multiple notes and warnings.
+With the `Obsolete attributes`_ in place, C# developers will notice several warnings in the build logs during compilation.
 
-.. On top of that, this release brings a great enhancement to the :doc:`../features/kubernetes` provider, also known as the `Ocelot.Discovery.KubeClient`_ package.
+On top of that, this release brings a great enhancement to the :doc:`../features/kubernetes` provider, also known as the `Ocelot.Discovery.KubeClient`_ package.
 
-.. What's New?
-.. -----------
-.. .. _@raman-m: https://github.com/raman-m
-.. .. _@kick2nick: https://github.com/kick2nick
-.. .. _@hogwartsdeveloper: https://github.com/hogwartsdeveloper
-.. .. _@RaynaldM: https://github.com/RaynaldM
-.. .. _585: https://github.com/ThreeMammals/Ocelot/issues/585
-.. .. _2073: https://github.com/ThreeMammals/Ocelot/pull/2073
-.. .. _2081: https://github.com/ThreeMammals/Ocelot/pull/2081
-.. .. _2174: https://github.com/ThreeMammals/Ocelot/pull/2174
-.. .. _Dynamic routing global configuration: https://github.com/ThreeMammals/Ocelot/issues/585
-.. .. _KubeClient: https://www.nuget.org/packages/KubeClient/
-.. .. _Polly: https://www.nuget.org/packages/Polly/
-.. .. _Ocelot.Provider.Polly: https://www.nuget.org/packages/Ocelot.Provider.Polly
-.. .. _FailureRatio and SamplingDuration parameters of Polly V8 circuit-breaker: https://github.com/ThreeMammals/Ocelot/issues/2080
+What's New?
+-----------
+.. _@raman-m: https://github.com/raman-m
+.. _@ocelot-ot: https://github.com/ocelot-ot
+.. _@erannevo: https://github.com/erannevo
+.. _@CurtisRobertOliver: https://github.com/CurtisRobertOliver
+.. _@jlukawska: https://github.com/jlukawska
+.. _2384: https://github.com/ThreeMammals/Ocelot/issues/2384
+.. _2385: https://github.com/ThreeMammals/Ocelot/pull/2385
+.. _2386: https://github.com/ThreeMammals/Ocelot/issues/2386
+.. _2387: https://github.com/ThreeMammals/Ocelot/pull/2387
+.. _2403: https://github.com/ThreeMammals/Ocelot/issues/2403
+.. _2406: https://github.com/ThreeMammals/Ocelot/pull/2406
+.. _651: https://github.com/ThreeMammals/Ocelot/issues/651
+.. _1183: https://github.com/ThreeMammals/Ocelot/pull/1183
+.. _2248: https://github.com/ThreeMammals/Ocelot/issues/2248
+.. _2328: https://github.com/ThreeMammals/Ocelot/pull/2328
+.. _Polly: https://www.nuget.org/packages/Polly/
 
-.. - :doc:`../features/configuration`: The "`Dynamic routing global configuration`_" feature has been redesigned by `@raman-m`_ and contributors.
+- :doc:`../features/qualityofservice`: A "`Built-in Circuit Breaker <2384_>`_" implementation was added by `@ocelot-ot`_ in pull request `2385`_, no `Polly`_ required.
 
-..   This update brings changes to the :ref:`config-dynamic-route-schema` and :ref:`config-global-configuration-schema`, while the :ref:`config-route-schema` stays the same apart from deprecation updates.
-..   All work was coordinated under issue `585`_, which addressed the challenges of configuring Ocelot's most popular features globally before version `24.1`_, when :ref:`dynamic routing <sd-dynamic-routing>` gained global configuration partial support, but static routing mostly lacked it.
-..   A key outcome of `585`_ is the ability to override global configuration options within the ``DynamicRoutes`` collection.
-..   This ongoing issue will continue to require attention, as adapting static route global configurations for :ref:`dynamic routing <sd-dynamic-routing>` is complex and, in some cases, impossible.
-..   This will be a challenge for future `Ocelot`_ releases and the community.
+  Ocelot's :ref:`qos-schema` no longer strictly depends on the external `Ocelot.QualityOfService.Polly`_ package to provide circuit breaking and timeout enforcement.
+  A lightweight, thread-safe circuit breaker (``Closed`` → ``Open`` → ``HalfOpen`` → ``Closed``) ships in the Ocelot core package, supporting both count-based and ``FailureRatio``-based modes.
+  The two implementations are mutually exclusive: the last of ``AddQualityOfService()`` or ``AddPolly()`` registered on the ``OcelotBuilder`` wins.
+  See the ":ref:`qos-builtin`" documentation for full details, including the ``AddQualityOfService<THandler>()`` extensibility point for overriding server error codes.
 
-.. - :doc:`../features/kubernetes`: The ":ref:`Kubernetes provider based on watch requests <k8s-watchkube-provider>`" feature by `@kick2nick`_ in pull request `2174`_.
+- :doc:`../features/websockets`: `Overridable WebSocket buffer size <2386_>`_ and custom middleware injection was added by `@erannevo`_ in pull request `2387`_.
 
-..   The `Ocelot.Discovery.KubeClient`_ package now features a new :ref:`WatchKube provider <k8s-watchkube-provider>` for :doc:`Kubernetes <../features/kubernetes>` service discovery.
-..   This provider is a great fit for high-load environments where the older :ref:`Kube <k8s-kube-provider>` and :ref:`PollKube <k8s-pollkube-provider>` providers struggle to handle heavy traffic, often leading to increased log errors, HTTP 500 issues, and potential Ocelot instance failures.
-..   ``WatchKube`` is the next step in the evolution of these providers, leveraging the reactive capabilities of the `KubeClient`_ API.
-..   For guidance on choosing the right provider for your Kubernetes setup, check out the ":ref:`k8s-comparing-providers`" section.
+  The previously hard-coded ``DefaultWebSocketBufferSize`` is now a ``protected virtual`` property that can be overridden by subclassing.
+  The :doc:`../features/middlewareinjection` feature was extended with a ``WebSocketsProxyMiddleware`` override on ``OcelotPipelineConfiguration``, allowing a fully custom WebSocket middleware to be injected into the pipeline.
 
-.. - :doc:`../features/configuration`: The ":ref:`Routing default timeout <config-timeout>`" feature by `@hogwartsdeveloper`_ in pull request `2073`_.
+- :doc:`../features/websockets`: `SecurityOptions support for the WebSocket pipeline <2403_>`_ was added by `@CurtisRobertOliver`_ in pull request `2406`_.
 
-..   In the past, the ``Timeout`` setting in the :ref:`config-route-schema` did not actually stop requests, defaulting instead to a fixed `90 seconds <https://github.com/search?q=repo%3AThreeMammals%2FOcelot+%2290+seconds%22&type=code>`_.
-..   Custom timeouts were handled using the :doc:`../features/qualityofservice` :ref:`qos-timeout-strategy`, and this only applied if `Polly`_ and the `Ocelot.Provider.Polly`_ package were used.
-..   Now, the ``Timeout`` option (in seconds) can be set at the route, global, and QoS levels.
-..   The :ref:`config-global-configuration-schema` and :ref:`config-dynamic-route-schema` also include the new ``Timeout`` setting, making it possible to configure default timeouts for :ref:`dynamic routing <sd-dynamic-routing>` as well.
+  Previously, IP allow/block-list :doc:`../features/routing` ``SecurityOptions`` were not enforced for WebSocket upgrade requests, allowing them to bypass IP security.
+  WebSocket upgrade requests are now intercepted by the same ``IPSecurityPolicy`` used for regular HTTP requests, and denied upgrades now correctly return ``403 Forbidden``.
 
-.. - :doc:`../features/qualityofservice`: The "`FailureRatio and SamplingDuration parameters of Polly V8 circuit-breaker`_" feature by `@RaynaldM`_ in pull request `2081`_.
+- :doc:`../features/configuration`: "`Merge custom JSON properties across multiple configuration files <651_>`_" was implemented by `@jlukawska`_ in pull request `1183`_.
 
-..   Starting with version `24.1`_, two new options in :ref:`qos-schema`, ``FailureRatio`` and ``SamplingDuration``, let you fine-tune the behavior of the :ref:`qos-circuit-breaker-strategy`.
-..   Both can be :ref:`configured globally <qos-global-configuration>`, even with :ref:`dynamic routing <sd-dynamic-routing>`.
+  Ocelot's configuration builder now merges custom (non-schema) JSON properties defined across multiple ``ocelot.*.json`` files using Newtonsoft's ``JToken`` merge functionality, instead of the last-loaded file silently overwriting properties from previous files.
+  This also applies to the ``DynamicRoutes`` collection. See the updated :doc:`../features/configuration` documentation and the ``Configuration`` sample app for details.
 
-..   .. note:: The ``DurationOfBreak``, ``ExceptionsAllowedBeforeBreaking``, and ``TimeoutValue`` options are now deprecated in `24.1`_, so check the ":ref:`qos-schema`" documentation for details.
+- :doc:`../features/aggregation`: "`Correct mapping of RouteKeysConfig arrays in aggregates <2248_>`_" fix, contributed in pull request `2328`_.
 
-.. What's Updated?
-.. ---------------
-.. .. _@marklonquist: https://github.com/marklonquist
-.. .. _@jlukawska: https://github.com/jlukawska
-.. .. _@MiladRv: https://github.com/MiladRv
-.. .. _1592: https://github.com/ThreeMammals/Ocelot/pull/1592
-.. .. _1659: https://github.com/ThreeMammals/Ocelot/pull/1659
-.. .. _2114: https://github.com/ThreeMammals/Ocelot/pull/2114
-.. .. _2294: https://github.com/ThreeMammals/Ocelot/pull/2294
-.. .. _2295: https://github.com/ThreeMammals/Ocelot/pull/2295
-.. .. _2324: https://github.com/ThreeMammals/Ocelot/pull/2324
-.. .. _2331: https://github.com/ThreeMammals/Ocelot/pull/2331
-.. .. _2332: https://github.com/ThreeMammals/Ocelot/pull/2332
-.. .. _2336: https://github.com/ThreeMammals/Ocelot/pull/2336
-.. .. _2339: https://github.com/ThreeMammals/Ocelot/pull/2339
-.. .. _2342: https://github.com/ThreeMammals/Ocelot/pull/2342
-.. .. _2345: https://github.com/ThreeMammals/Ocelot/pull/2345
-.. .. _2347: https://github.com/ThreeMammals/Ocelot/pull/2347
-.. .. _File-model: https://github.com/ThreeMammals/Ocelot/tree/main/src/Ocelot/Configuration/File
-.. .. _deprecated options: https://github.com/search?q=repo%3AThreeMammals%2FOcelot+deprecated+language%3AreStructuredText&type=code&l=reStructuredText
-.. .. _Ocelot.Testing: https://github.com/ThreeMammals/Ocelot/tree/24.0.0/test/Ocelot.Testing
-.. .. _extension packages: https://www.nuget.org/profiles/ThreeMammals
-.. .. _23.3: https://github.com/ThreeMammals/Ocelot/releases/tag/23.3.0
-.. .. _DevOps: https://github.com/ThreeMammals/Ocelot/labels/DevOps
-.. .. _GH-Actions: https://github.com/ThreeMammals/Ocelot/actions
+  Aggregate routes configured with the ``RouteKeysConfig`` array now correctly map route keys to the corresponding aggregator context, fixing a bug where keys could be mismatched or dropped during multiplexing.
 
-.. - :doc:`../features/configuration`: Several `File-model`_ options have been deprecated by `@raman-m`_.
+What's Updated?
+---------------
+.. _Ocelot.Cache.CacheManager: https://www.nuget.org/packages/Ocelot.Cache.CacheManager/
+.. _Ocelot.Tracing.Butterfly: https://www.nuget.org/packages/Ocelot.Tracing.Butterfly/
+.. _Ocelot.Tracing.OpenTracing: https://www.nuget.org/packages/Ocelot.Tracing.OpenTracing/
+.. _Ocelot.Discovery.Eureka: https://www.nuget.org/packages/Ocelot.Discovery.Eureka/
+.. _Ocelot.QualityOfService.Polly: https://www.nuget.org/packages/Ocelot.QualityOfService.Polly/
+.. _Ocelot.Discovery.Consul: https://www.nuget.org/packages/Ocelot.Discovery.Consul/
+.. _2334: https://github.com/ThreeMammals/Ocelot/issues/2334
+.. _2360: https://github.com/ThreeMammals/Ocelot/pull/2360
+.. _2361: https://github.com/ThreeMammals/Ocelot/pull/2361
+.. _2362: https://github.com/ThreeMammals/Ocelot/pull/2362
+.. _2371: https://github.com/ThreeMammals/Ocelot/issues/2371
+.. _2372: https://github.com/ThreeMammals/Ocelot/pull/2372
+.. _2378: https://github.com/ThreeMammals/Ocelot/issues/2378
+.. _2380: https://github.com/ThreeMammals/Ocelot/pull/2380
+.. _2388: https://github.com/ThreeMammals/Ocelot/pull/2388
+.. _2404: https://github.com/ThreeMammals/Ocelot/pull/2404
+.. _2374: https://github.com/ThreeMammals/Ocelot/issues/2374
+.. _2379: https://github.com/ThreeMammals/Ocelot/pull/2379
+.. _989: https://github.com/ThreeMammals/Ocelot/issues/989
+.. _2412: https://github.com/ThreeMammals/Ocelot/pull/2412
+.. _DevOps: https://github.com/ThreeMammals/Ocelot/labels/DevOps
+.. _Ocelot.Testing: https://github.com/ThreeMammals/Ocelot.Testing
 
-..   The updated docs now highlight these `deprecated options`_ with multiple notes and warnings.
-..   The `24.1`_ deprecation process will wrap up in the upcoming `.NET 10`_ release.
-..   Due to the `Obsolete attributes`_, C# developers will notice several build warnings during compilation.
+- Package extraction `2334`_: The Ocelot team, led by `@raman-m`_, continued extracting integrated extension packages out of the mono-repo into their own dedicated repositories, each with an independent release cycle:
 
-.. - :ref:`b-testing`: The `Ocelot.Testing`_ project was deprecated by `@raman-m`_ in pull request `2295`_.
+  * `Ocelot.Cache.CacheManager`_ — pull request `2360`_
+  * `Ocelot.Tracing.Butterfly`_ — pull request `2361`_
+  * `Ocelot.Tracing.OpenTracing`_ — pull request `2362`_
+  * `Ocelot.Discovery.Eureka`_ (renamed from ``Ocelot.Provider.Eureka``, see issue `2371`_) — pull request `2372`_
+  * `Ocelot.QualityOfService.Polly`_ (renamed from ``Ocelot.Provider.Polly``, see issue `2378`_) — pull request `2380`_
+  * `Ocelot.Discovery.Consul`_ (renamed from ``Ocelot.Provider.Consul``, see issue `2378`_) — pull request `2388`_
+  * `Ocelot.Discovery.KubeClient`_ (renamed from ``Ocelot.Provider.Kubernetes``, see issue `2378`_) — pull request `2404`_
 
-..   The project was removed from the main repo and moved to its own `Ocelot.Testing <https://github.com/ThreeMammals/Ocelot.Testing>`__ repository.
-..   This change allows the `Ocelot.Testing <https://www.nuget.org/packages/Ocelot.Testing/>`__ package to be shared independently for delivery of `extension packages`_.
-..   The Ocelot team also plans to deprecate more projects and move them to separate repos because:
-..   **a)** despite the fact that a monorepo enables faster builds and quicker delivery;
-..   **b)** but the release process can be delayed by missing versions of integrated libraries in `extension packages`_.
-..   The goal is for the Ocelot repo to only contain essential projects, avoiding delays caused by integrated package release schedules.
-..   Legacy or abandoned integrated packages should be deprecated and maintained in their own repos with independent release cycles.
+  This keeps the Ocelot core repo lean, avoids delays caused by integrated packages' own release schedules, and lets each provider evolve independently.
+  Consult the ":doc:`../features/caching`", ":doc:`../features/tracing`", ":doc:`../features/servicediscovery`" and ":doc:`../features/kubernetes`" chapters for package-specific upgrade notes.
 
-.. - :doc:`../features/headerstransformation`: Added :ref:`global configuration <ht-configuration>` by `@marklonquist`_ in pull request `1659`_.
+- :doc:`../features/errorcodes`: `Non-ASCII header exceptions mapped to 400 Bad Request <2374_>`_ per RFC 7230, in pull request `2379`_.
 
-..   The :ref:`config-global-configuration-schema` now includes new ``DownstreamHeaderTransform`` and ``UpstreamHeaderTransform`` options.
-..   These work only with static routes, meaning the ``Routes`` collection (see :ref:`config-route-schema`).
-..   They are not supported for dynamic routes because they are not part of the :ref:`config-dynamic-route-schema`, and Ocelot Core does not read global configuration of this feature in :ref:`dynamic routing <sd-dynamic-routing>` mode.
-..   This is noted in the :ref:`ht-roadmap` documentation.
+  Requests containing non-ASCII characters in HTTP header values previously surfaced as an unhandled ``HttpRequestException`` and an HTTP 500 response.
+  Ocelot now catches this ``HttpRequestException`` and maps it to a ``400 Bad Request`` response, in line with RFC 7230 "Field Parsing" rules.
 
-.. - :doc:`../features/authentication`: Added :ref:`global configuration <authentication-configuration>` by `@jlukawska`_ in pull request `2114`_.
+- :doc:`../features/administration`: "`Hide Administration controllers from Swagger and OpenAPI <989_>`_" fix, contributed in pull request `2412`_.
 
-..   The :ref:`config-global-configuration-schema` now includes a new ``AuthenticationOptions`` property for setting up static routes globally.
-..   This also introduces the :ref:`AllowAnonymous boolean option <authentication-configuration>` within ``AuthenticationOptions`` to control static route authentication.
-..   Later, pull request `2336`_ extended global authentication support to dynamic routes.
+  The ``{adminPath}/configuration`` and ``{adminPath}/outputcache/{region}`` endpoints are now decorated with ``[ApiExplorerSettings(IgnoreApi = true)]`` so that they no longer appear in Swagger/OpenAPI documentation generated for the downstream API surface.
 
-..   .. note:: The ``AuthenticationProviderKey`` option is deprecated in version `24.1`_—see the ":ref:`authentication-options-schema`" documentation for details.
+- `DevOps`_: Extensive testing and tooling modernization was carried out by `@raman-m`_ and contributors ahead of `.NET 10`_:
 
-.. - :doc:`../features/ratelimiting`: Re-designed :ref:`global configuration <rl-configuration>` by `@MiladRv`_ and `@raman-m`_ in pull request `2294`_.
+  * Solutions upgraded to the Visual Studio 2026 format.
+  * Testing projects migrated from xUnit v2 to xUnit v3, and acceptance tests migrated to the Microsoft.Testing.Platform framework.
+  * `Ocelot.Testing`_ was re-embedded into the mono-repo and later excluded from Cobertura coverage via ``coverlet.runsettings``.
+  * `Codecov <https://about.codecov.io/>`_ coverage reporting was installed for the repository.
+  * All NuGet packages were bumped to their latest versions to support .NET SDK ``10.0.302`` (.NET Runtime ``10.0.10``).
 
-..   The :ref:`config-global-configuration-schema` now includes a new ``RateLimitOptions`` property for both static and dynamic routes.
-..   Previously, global configuration was available through ``RateLimitOptions`` in :ref:`dynamic routing <sd-dynamic-routing>` mode, while route overriding used the now-deprecated ``RateLimitRule`` from the :ref:`config-dynamic-route-schema`.
+Patches Included
+----------------
+.. _2346: https://github.com/ThreeMammals/Ocelot/issues/2346
+.. _2351: https://github.com/ThreeMammals/Ocelot/pull/2351
 
-..   This marks the second major overhaul of the *Rate Limiting* feature since the first update in pull request `1592`_.
-..   A new ``Wait`` option has been added, replacing the deprecated ``PeriodTimespan``, to enhance the :ref:`Fixed Window <rl-algorithms>` algorithm.
-..   The full list of deprecated options can be found in the ":ref:`Deprecated options <rl-deprecated-options>`" documentation.
+- :doc:`../features/routing`: Issue `2346`_ patch, contributed in pull request `2351`_.
 
-.. - :doc:`../features/loadbalancer`: Added :ref:`global configuration <lb-global-configuration>` by `@raman-m`_ in pull request `2324`_.
+  This fixes a bug where downstream URL query parameter names could be corrupted if they contained a placeholder with a non-empty value.
+  The ``DownstreamUrlCreatorMiddleware`` query string merging algorithm was refactored to take full advantage of ASP.NET Core's ``QueryHelpers``.
 
-..   The :ref:`config-global-configuration-schema` now includes a new ``LoadBalancerOptions`` property for both static and dynamic routes.
-..   Previously, global configuration was available through ``LoadBalancerOptions`` in :ref:`dynamic routing <sd-dynamic-routing>` mode without dynamic route overrides.
-..   Starting with version `24.1`_, the :ref:`config-dynamic-route-schema` also supports ``LoadBalancerOptions`` for overriding, and global configuration for static routes is now supported as well.
-
-.. - :doc:`../features/caching`: Added :ref:`global configuration <caching-global-configuration>` by `@raman-m`_ in pull request `2331`_.
-
-..   The :ref:`config-global-configuration-schema` now includes a new ``CacheOptions`` property for both static and dynamic routes.
-..   Global configuration has been available for static routes since version `23.3`_, but starting with version `24.1`_, the :ref:`config-dynamic-route-schema` also supports ``CacheOptions`` for overriding.
-
-..   .. note::
-..     The ``FileCacheOptions`` property in the :ref:`config-route-schema` (static routes) is deprecated in version `24.1`_.
-..     For more details, see the caching :ref:`caching-configuration` documentation.
-
-.. - :ref:`Http Handler <config-http-handler-options>`: Added :ref:`global configuration <config-http-handler-options>` by `@raman-m`_ in pull request `2332`_.
-
-..   The :ref:`config-global-configuration-schema` now includes a new ``HttpHandlerOptions`` property for both static and dynamic routes.
-..   Previously, global configuration was available through ``HttpHandlerOptions`` in :ref:`dynamic routing <sd-dynamic-routing>` mode without dynamic route overriding.
-..   Starting with version `24.1`_, the :ref:`config-dynamic-route-schema` also supports ``HttpHandlerOptions`` for overriding, and global configuration is now available for static routes as well.
-
-.. - :doc:`../features/authentication`: Added :ref:`global configuration <authentication-global-configuration>` by `@raman-m`_ in pull request `2336`_.
-
-..   The :ref:`config-global-configuration-schema` now includes a new ``AuthenticationOptions`` property for both static and dynamic routes.
-..   Starting with version `24.1`_, the :ref:`config-dynamic-route-schema` also supports ``AuthenticationOptions`` to override global settings.
-
-..   .. note::
-..     The ``AuthenticationProviderKey`` option is deprecated in version `24.1`_, so check the ":ref:`authentication-options-schema`" documentation for details.
-
-.. - :doc:`../features/qualityofservice`: Added :ref:`global configuration <qos-global-configuration>` by `@raman-m`_ in pull request `2339`_.
-
-..   The :ref:`config-global-configuration-schema` now includes a new ``QoSOptions`` property for both static and dynamic routes.
-..   Previously, global configuration was available through ``QoSOptions`` in :ref:`dynamic routing <sd-dynamic-routing>` mode without the option for dynamic route overrides.
-..   Starting with version `24.1`_, the :ref:`config-dynamic-route-schema` supports ``QoSOptions`` for overriding, and global configuration support is now available for static routes as well.
-
-..   .. note::
-..     The ``DurationOfBreak``, ``ExceptionsAllowedBeforeBreaking``, and ``TimeoutValue`` options are deprecated in version `24.1`_.
-..     For details, see the ":ref:`qos-schema`" documentation.
-
-.. - `DevOps`_: Stabilized tests and reviewed `GH-Actions`_ workflows by `@raman-m`_ in pull requests `2342`_ and `2345`_.
-
-..   These efforts kept the CI/CD builds in `GitHub Actions <https://github.com/ThreeMammals/Ocelot/actions>`_ stable, targeting the `alpha release <https://github.com/ThreeMammals/Ocelot/releases/tag/24.1.0-pre-release-24-1.1>`_ of version `24.1`_.
-..   The CI/CD environment was set up and tested `GH-Actions`_ workflows in advance for the beta release, which is the goal of pull request `2347`_.
-
-.. Patches Included
-.. ----------------
-.. .. _@mehyaa: https://github.com/mehyaa
-.. .. _913: https://github.com/ThreeMammals/Ocelot/issues/913
-.. .. _930: https://github.com/ThreeMammals/Ocelot/issues/930
-.. .. _1478: https://github.com/ThreeMammals/Ocelot/pull/1478
-.. .. _2091: https://github.com/ThreeMammals/Ocelot/pull/2091
-.. .. _2304: https://github.com/ThreeMammals/Ocelot/issues/2304
-.. .. _2335: https://github.com/ThreeMammals/Ocelot/pull/2335
-.. .. _RFC 8693: https://datatracker.ietf.org/doc/html/rfc8693
-
-.. - :doc:`../features/websockets`: Issue `930`_ patch by `@hogwartsdeveloper`_ in pull request `2091`_.
-
-..   This update removes the troublesome ``System.Net.WebSockets.WebSocketException`` from logs, preventing Ocelot from running into 500 status disasters.
-..   The issue stemmed from client-side or network events that Ocelot's ``WebSocketsProxyMiddleware`` could not anticipate on the server side.
-..   The patch now checks for incorrect connection statuses, attempting to close the connection and end server-side tasks gracefully without errors.
-
-.. - :doc:`../features/kubernetes`: Issue `2304`_ patch by `@raman-m`_ in pull request `2335`_.
-
-..   This update fixes the :ref:`PollKube provider <k8s-pollkube-provider>` to address a bug with the first cold request, where the winning thread got an empty collection before the initial callback was triggered.
-..   The solution is to call the integrated discovery provider for the first cold request when the queue is empty.
-
-.. - :doc:`../features/authorization`: Issue `913`_ patch by `@mehyaa`_ in pull request `1478`_.
-
-..   Starting with version `24.1`_, Ocelot now supports `RFC 8693`_ (OAuth 2.0 Token Exchange) for the '``scope``' claim in the ``ScopesAuthorizer`` service, also referred to as the ``IScopesAuthorizer`` service in the DI container.
-..   This is noted in the ":ref:`authentication-allowed-scopes`" documentation (see the first note).
 
 Contributing
 ------------


### PR DESCRIPTION
## Proposed Changes
Refreshes `docs/*.rst` sources ahead of the v25.0.0 release, closing gaps between the code changes in the [24.1.0...25.0.0-beta.4](https://github.com/ThreeMammals/Ocelot/compare/24.1.0...25.0.0-beta.4) diff and their documentation.

### Undocumented package extractions
- `tracing.rst`: note that `Ocelot.Tracing.Butterfly` and `Ocelot.Tracing.OpenTracing` were extracted from the mono-repo into dedicated repos (package IDs unchanged)
- `caching.rst`: same treatment for `Ocelot.Cache.CacheManager`

(Eureka, Polly, Consul, and Kubernetes provider extractions were already documented in their originating PRs — verified, no changes needed.)

### Undocumented feature/fix
- `administration.rst`: document that `{adminPath}/configuration` and `{adminPath}/outputcache/{region}` are now hidden from Swagger/OpenAPI via `[ApiExplorerSettings(IgnoreApi = true)]`

(Verified built-in QoS circuit breaker, WebSocket buffer size/`SecurityOptions`, JSON config merge, and `RouteKeysConfig` aggregation fix already had adequate docs from their PRs.)

### Release notes
- `releasenotes.rst`: replaced the leftover 24.1-era commented-out placeholder with real v25.0.0 "What's New / What's Updated / Patches Included" content, citing the relevant PRs/issues (built-in circuit breaker, WebSocket enhancements, JSON merge, package extractions, Swagger fix, query-param patch)

### .NET 10 alignment
- `building.rst`: TFM list and SDK requirement updated from net8.0/net9.0 to include net10.0
- `gettingstarted.rst`: added .NET 10 (LTS) to supported frameworks
- Bumped all `25.0` release-tag doc references from `beta.3` to `beta.4`

### Verified, no action needed
- [Milestone 13](https://github.com/ThreeMammals/Ocelot/milestone/13) (closed issues/PRs) reviewed end-to-end — remaining items are internal test/SDK fixes with no doc surface
- README.md, `build.cake`, and CI workflows already reflect net8.0/net9.0/net10.0 and .NET 10 SDK