### PR TITLE
#1687 Unit test for `OperationCanceledException` in `ExceptionHandlerMiddleware`

### DIFF
--- a/unit/Errors/ExceptionHandlerMiddlewareTests.cs
+++ b/unit/Errors/ExceptionHandlerMiddlewareTests.cs
@@ -88,6 +88,24 @@ public class ExceptionHandlerMiddlewareTests : UnitTest
     }
 
     [Fact]
+    public async Task Should_set_499_status_code_when_request_is_canceled()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _httpContext.RequestAborted = cts.Token;
+
+        var config = new InternalConfiguration();
+        _httpContext.Items.Add(nameof(IInternalConfiguration), config);
+
+        // Act
+        await _middleware.Invoke(_httpContext);
+
+        // Assert
+        _httpContext.Response.StatusCode.ShouldBe(StatusCodes.Status499ClientClosedRequest);
+    }
+
+    [Fact]
     public async Task ShouldSetAspDotNetRequestId()
     {
         // Arrange


### PR DESCRIPTION
## Fixes #1687 
- #1687

## Proposed Changes

- Added `Should_set_499_status_code_when_request_is_canceled` unit test to `ExceptionHandlerMiddlewareTests`.
- Verifies that `ExceptionHandlerMiddleware` properly sets `StatusCodes.Status499ClientClosedRequest` (499) when `OperationCanceledException` is thrown and `context.RequestAborted.IsCancellationRequested` is `true`.

## Checklist

- [x] Unit tests added and passing locally
- [x] Code adheres to the repository's coding style