### PR TITLE
#1687 Return 504 Gateway Timeout for downstream request timeouts according to RFC 9110

### DIFF
--- a/acceptance/Configuration/TimeoutTests.cs
+++ b/acceptance/Configuration/TimeoutTests.cs
@@ -65,7 +65,7 @@ public class TimeoutTests : TimeoutSteps
             WatchWhenIGetUrlOnTheApiGateway(route2.UpstreamPathTemplate));
 
     [Fact]
-    [Trait("Bug", "1687")]
+    [Trait("Bug", "1687")] // https://github.com/ThreeMammals/Ocelot/issues/1687
     [Trait("Feat", "1869")] // https://github.com/ThreeMammals/Ocelot/issues/1869
     public async Task HasRouteTimeout_ShouldTimeoutAfterRouteTimeout()
     {

--- a/acceptance/Configuration/TimeoutTests.cs
+++ b/acceptance/Configuration/TimeoutTests.cs
@@ -65,21 +65,22 @@ public class TimeoutTests : TimeoutSteps
             WatchWhenIGetUrlOnTheApiGateway(route2.UpstreamPathTemplate));
 
     [Fact]
+    [Trait("Bug", "1687")]
     [Trait("Feat", "1869")] // https://github.com/ThreeMammals/Ocelot/issues/1869
     public async Task HasRouteTimeout_ShouldTimeoutAfterRouteTimeout()
     {
         const int RouteTimeoutSeconds = 2;
-        int serviceTimeoutMs = Ms(RouteTimeoutSeconds) + 500; // total 2.5 sec
+        int serviceTimeoutMs = Ms(RouteTimeoutSeconds + 1); // total 3 sec
         var port = PortFinder.GetRandomPort();
         var configuration = GivenConfiguration(port, RouteTimeoutSeconds); // !!!
         var body = Body();
         this
-            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2.5s > 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 3s > 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
             .Then(x => ThenTimeoutIsInRange(_watcher, Ms(RouteTimeoutSeconds), serviceTimeoutMs))
-            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             .And(x => ThenTheResponseBodyShouldBe(string.Empty))
         .BDDfy();
     }

--- a/acceptance/Configuration/TimeoutTests.cs
+++ b/acceptance/Configuration/TimeoutTests.cs
@@ -18,12 +18,12 @@ public class TimeoutTests : TimeoutSteps
         var configuration = GivenConfiguration(port, RouteTimeoutSeconds, GlobalTimeoutSeconds); // !!!
         var body = Body();
         this
-            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
             .Then(x => ThenTimeoutIsInRange(_watcher, Ms(RouteTimeoutSeconds), Ms(RouteTimeoutSeconds) + 500)) // (2.0, 2.5) s
-            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             .And(x => ThenTheResponseBodyShouldBeAsync(string.Empty))
         .BDDfy();
     }
@@ -46,12 +46,12 @@ public class TimeoutTests : TimeoutSteps
         {
             ThenTimeoutIsInRange(watcher, globalTimeoutMs, Ms(DownstreamRoute.DefaultTimeoutSeconds)); // (2.0, 90) so assert roughly
             ThenTimeoutIsInRange(watcher, globalTimeoutMs, globalTimeoutMs + 500); // (2.0, 2.5) so assert precisely
-            ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable); // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
+            ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout); // after 2 secs -> TimeoutException by TimeoutDelegatingHandler
             await ThenTheResponseBodyShouldBeAsync(string.Empty);
         };
         this
-            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
-            .And(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> ServiceUnavailable
+            .Given(x => GivenThereIsAServiceRunningOn(ports[0], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
+            .And(x => GivenThereIsAServiceRunningOn(ports[1], HttpStatusCode.OK, serviceTimeoutMs, body)) // 2s -> GatewayTimeout
             .And(x => GivenThereIsAConfiguration(configuration))
             .And(x => GivenOcelotIsRunning())
             .When(x => WhenImWatchingBothRoutesWhenIGetUrlOnTheApiGateway(route1, route2))
@@ -101,12 +101,12 @@ public class TimeoutTests : TimeoutSteps
                 var configuration = GivenConfiguration(port, routeTimeout: null, globalTimeout: null); // !!! no route timeout -> DownstreamRoute.DefaultTimeoutSeconds
                 var body = Body();
                 this
-                    .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 3.5s > 3s -> ServiceUnavailable
+                    .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.OK, serviceTimeoutMs, body)) // 3.5s > 3s -> GatewayTimeout
                     .And(x => GivenThereIsAConfiguration(configuration))
                     .And(x => GivenOcelotIsRunning())
                     .When(x => WhenImWatchingWhenIGetUrlOnTheApiGateway())
                     .Then(x => ThenTimeoutIsInRange(_watcher, Ms(DownstreamRoute.LowTimeout), serviceTimeoutMs))
-                    .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 3 secs -> TimeoutException by TimeoutDelegatingHandler
+                    .And(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 3 secs -> TimeoutException by TimeoutDelegatingHandler
                     .And(x => ThenTheResponseBodyShouldBe(string.Empty))
                 .BDDfy();
             }

--- a/acceptance/QualityOfService/QualityOfServiceTests.cs
+++ b/acceptance/QualityOfService/QualityOfServiceTests.cs
@@ -235,11 +235,11 @@ public sealed class QualityOfServiceTests : QosSteps
             var route = GivenRoute(port, new(new FileQoSOptions()));
             var configuration = GivenConfiguration(route);
             this
-                .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.Created, defTimeoutMs + 500, body)) // 3.5s > 3s -> ServiceUnavailable
+                .Given(x => GivenThereIsAServiceRunningOn(port, HttpStatusCode.Created, defTimeoutMs + 500, body)) // 3.5s > 3s -> GatewayTimeout
                 .And(x => GivenThereIsAConfiguration(configuration))
                 .And(x => GivenOcelotIsRunningAsync(WithQualityOfService))
                 .When(x => WhenIGetUrlOnTheApiGateway("/"))
-                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.ServiceUnavailable)) // after 3 secs -> Timeout exception aka request cancellation
+                .Then(x => ThenTheStatusCodeShouldBe(HttpStatusCode.GatewayTimeout)) // after 3 secs -> TimeoutException by TimeoutDelegatingHandler
             .BDDfy();
         }
         finally

--- a/docs/features/errorcodes.rst
+++ b/docs/features/errorcodes.rst
@@ -71,20 +71,20 @@ Client Error Responses
 Server Error Responses
 ----------------------
 .. _502 Bad Gateway: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/502
-.. _503 Service Unavailable: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503
+.. _504 Gateway Timeout: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
 
 - `500 Internal Server Error`_: If unable to complete the HTTP request to the downstream service, and the exception is not ``OperationCanceledException`` or ``HttpRequestException``.
 - `502 Bad Gateway`_: If unable to connect to the downstream service.
-- `503 Service Unavailable`_: Returned when the downstream request times out.
+- `504 Gateway Timeout`_: Returned when the downstream request times out.
 
     | Ocelot Error: `RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot+RequestTimedOutError&type=code>`_
     | Ocelot Code: `OcelotErrorCode.RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20OcelotErrorCode.RequestTimedOutError&type=code>`_
 
-  According to Ocelot Core's design, status code ``503`` is produced in the following ``TimeoutException`` scenarios:
+  According to Ocelot Core's design, status code ``504`` is produced in the following ``TimeoutException`` scenarios:
 
   1. By ``TimeoutDelegatingHandler`` from the ``IMessageInvokerPool`` service, when an ``OperationCanceledException`` is thrown and the context's cancellation token is not in the “cancellation requested” state.
      Ocelot does not log an error with the exception body, but the ``IExceptionToErrorMapper`` service generates the internal `OcelotErrorCode.RequestTimedOutError`_.
-  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected `OcelotErrorCode.RequestTimedOutError`_ to status ``503``.
+  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected `OcelotErrorCode.RequestTimedOutError`_ to status ``504``.
      This error code is produced by the ``IExceptionToErrorMapper`` service when a ``TimeoutException`` is thrown by other middlewares—especially by ``TimeoutDelegatingHandler``.
 
 .. _eh-error-mapper:

--- a/docs/features/errorcodes.rst
+++ b/docs/features/errorcodes.rst
@@ -42,7 +42,7 @@ Client Error Responses
 .. _RequestCanceledError: https://github.com/search?q=repo%3AThreeMammals%2FOcelot+RequestCanceledError&type=code
 .. _OcelotErrorCode.RequestCanceled: https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20OcelotErrorCode.RequestCanceled&type=code
 
-- `400 Bad Request`_: If something is wrong with the incoming request, Ocelot generates an ``HttpRequestException``, for example: [#f1]_
+- `400 Bad Request`_: [#f1]_ If something is wrong with the incoming request, Ocelot generates an ``HttpRequestException``, for example:
 
   * An upstream request header contains non-ASCII characters.
     `RFC 7230`_ specifies that when a server encounters invalid or unparsable request data, it should respond with a `400 Bad Request`_ status code.
@@ -71,20 +71,20 @@ Client Error Responses
 Server Error Responses
 ----------------------
 .. _502 Bad Gateway: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/502
+.. _503 Service Unavailable: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503
 .. _504 Gateway Timeout: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
+.. _RFC 9110: https://www.rfc-editor.org/info/rfc9110
 
 - `500 Internal Server Error`_: If unable to complete the HTTP request to the downstream service, and the exception is not ``OperationCanceledException`` or ``HttpRequestException``.
 - `502 Bad Gateway`_: If unable to connect to the downstream service.
-- `504 Gateway Timeout`_: Returned when the downstream request times out.
+- `503 Service Unavailable`_: Ocelot no longer returns this status as of version `25.1`_, having replaced it with `504 Gateway Timeout`_. [#f2]_
+- `504 Gateway Timeout`_: Returned when the downstream request times out, according to `RFC 9110`_.
 
-    | Ocelot Error: `RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot+RequestTimedOutError&type=code>`_
-    | Ocelot Code: `OcelotErrorCode.RequestTimedOutError <https://github.com/search?q=repo%3AThreeMammals%2FOcelot%20OcelotErrorCode.RequestTimedOutError&type=code>`_
-
-  According to Ocelot Core's design, status code ``504`` is produced in the following ``TimeoutException`` scenarios:
+  Ocelot produces status code ``504`` in the following ``TimeoutException`` scenarios:
 
   1. By ``TimeoutDelegatingHandler`` from the ``IMessageInvokerPool`` service, when an ``OperationCanceledException`` is thrown and the context's cancellation token is not in the “cancellation requested” state.
-     Ocelot does not log an error with the exception body, but the ``IExceptionToErrorMapper`` service generates the internal `OcelotErrorCode.RequestTimedOutError`_.
-  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected `OcelotErrorCode.RequestTimedOutError`_ to status ``504``.
+     Ocelot does not log an error with the exception body, but the ``IExceptionToErrorMapper`` service generates the internal ``RequestTimedOutError``.
+  2. By ``ResponderMiddleware``, if the default ``IErrorsToHttpStatusCodeMapper`` service maps the detected ``RequestTimedOutError`` to status ``504``.
      This error code is produced by the ``IExceptionToErrorMapper`` service when a ``TimeoutException`` is thrown by other middlewares—especially by ``TimeoutDelegatingHandler``.
 
 .. _eh-error-mapper:
@@ -115,9 +115,16 @@ We expect you to share your use case with us in the `Discussions <https://github
   describe cases that may arise with request data (where a `400 Bad Request`_ status is preferred) and response data (where a `502 Bad Gateway`_ status is preferred).
   Ocelot does not perform any special validation of header data for upstream requests or downstream responses; it proxies headers as-is, with the exception of the ":doc:`../features/headerstransformation`" feature.
   This enhancement was requested in bug `2374`_, fixed in pull request `2379`_, and the patch was rolled out as part of the `25.0`_ release.
+.. [#f2] Ocelot's `RequestTimedOutError`_ is intended to align with `RFC 9110`_ (HTTP Semantics), specifically Section "`15.6.5. 504 Gateway Timeout`_".
+  The breaking change was introduced in version `25.1`_, when the incorrect `503 Service Unavailable`_ status was replaced with the correct `504 Gateway Timeout`_ status, as dictated by `RFC 9110`_.
+  This patch was provided in pull request `2420`_ and delivered as part of the `25.1`_ release.
 
 .. _"Header Fields": https://www.rfc-editor.org/rfc/rfc7230#section-3.2
 .. _"Field Parsing": https://www.rfc-editor.org/rfc/rfc7230#section-3.2.4
+.. _RequestTimedOutError: https://github.com/search?q=repo%3AThreeMammals%2FOcelot+RequestTimedOutError&type=code
+.. _15.6.5. 504 Gateway Timeout: https://www.rfc-editor.org/info/rfc9110/#section-15.6.5
 .. _2374: https://github.com/ThreeMammals/Ocelot/issues/2374
 .. _2379: https://github.com/ThreeMammals/Ocelot/pull/2379
+.. _2420: https://github.com/ThreeMammals/Ocelot/pull/2420
 .. _25.0: https://github.com/ThreeMammals/Ocelot/releases/tag/25.0.0
+.. _25.1: https://github.com/ThreeMammals/Ocelot/milestone/12

--- a/docs/features/qualityofservice.rst
+++ b/docs/features/qualityofservice.rst
@@ -586,6 +586,7 @@ Absolute timeout [#f4]_
 
 If a *QoS* section is not included, *QoS* will not be applied, and Ocelot will enforce an absolute timeout of 90 seconds (defined by the ``DownstreamRoute`` `DefTimeout`_ constant) for all downstream requests.
 This absolute timeout is configurable via the ``DownstreamRoute`` `DefaultTimeoutSeconds`_ static C# property.
+When this Ocelot Core timeout is reached, Ocelot returns ``504 Gateway Timeout``.
 For more information, refer to the :ref:`config-default-timeout` section of the :doc:`../features/configuration` chapter.
 
 .. _qos-notes-value-constraints:

--- a/docs/features/routing.rst
+++ b/docs/features/routing.rst
@@ -449,7 +449,7 @@ Errors and Gotchas
 ------------------
 .. _Show and tell: https://github.com/ThreeMammals/Ocelot/discussions/categories/show-and-tell
 .. _499 (Client Closed Request): https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.statuscodes.status499clientclosedrequest
-.. _503 (Service Unavailable): https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503
+.. _504 (Gateway Timeout): https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/504
 
 In this section, Ocelot team has gathered user scenarios where routing behavior was unclear or errors appeared in the logs.
 Please note that the failed routing cases listed below do not represent all application configurations.
@@ -466,15 +466,15 @@ If your case is not included, feel free to open a "`Show and tell`_" discussion.
   As a quick recipe, the Ocelot team recommends ensuring client stability and, if necessary, adjusting the :ref:`config-timeout` strategy:
   either increasing or decreasing the route :ref:`config-timeout` depending on your usage scenario and the behavior of the downstream service.
 
-* **Timeout errors aka 503 status**.
-  According to Ocelot Core's design, HTTP status code `503 (Service Unavailable)`_ is returned in cases involving a ``TimeoutException``.
+* **Timeout errors aka 504 status**.
+  According to Ocelot Core's design, HTTP status code `504 (Gateway Timeout)`_ is returned in cases involving a ``TimeoutException``.
   This status is typically caused by:
 
   A) Slow downstream services that may fail to respond
   B) Large requests forwarded to slow downstream services
 
   As a quick recipe, the Ocelot team recommends increasing the route :ref:`config-timeout` in your configuration.
-  This adjustment can help resolve timeout-related issues with sluggish downstream services, ultimately reducing occurrences of `503 (Service Unavailable)`_.
+  This adjustment can help resolve timeout-related issues with sluggish downstream services, ultimately reducing occurrences of `504 (Gateway Timeout)`_.
 
 .. _break: http://break.do
 

--- a/src/Errors/RequestTimedOutError.cs
+++ b/src/Errors/RequestTimedOutError.cs
@@ -6,6 +6,6 @@ public class RequestTimedOutError : Error
 {
     public RequestTimedOutError(Exception exception)
         : base($"Timeout making http request, exception: {exception}",
-            OcelotErrorCode.RequestTimedOutError, StatusCodes.Status503ServiceUnavailable)
+            OcelotErrorCode.RequestTimedOutError, StatusCodes.Status504GatewayTimeout)
     { }
 }

--- a/src/Errors/RequestTimedOutError.cs
+++ b/src/Errors/RequestTimedOutError.cs
@@ -2,10 +2,12 @@
 
 namespace Ocelot.Errors;
 
-public class RequestTimedOutError : Error
-{
-    public RequestTimedOutError(Exception exception)
-        : base($"Timeout making http request, exception: {exception}",
-            OcelotErrorCode.RequestTimedOutError, StatusCodes.Status504GatewayTimeout)
-    { }
-}
+/// <summary>
+/// This error is intended to align with <see href="https://www.rfc-editor.org/info/rfc9110">RFC 9110</see> (HTTP Semantics),
+/// specifically Section 15.6.5 "<see href="https://www.rfc-editor.org/info/rfc9110/#section-15.6.5">504 Gateway Timeout</see>".
+/// </summary>
+/// <param name="exception">Original exception object.</param>
+public class RequestTimedOutError(Exception exception)
+    : Error($"Timeout making http request, exception: {exception}",
+        OcelotErrorCode.RequestTimedOutError, StatusCodes.Status504GatewayTimeout)
+{ }

--- a/src/Requester/HttpExceptionToErrorMapper.cs
+++ b/src/Requester/HttpExceptionToErrorMapper.cs
@@ -27,8 +27,8 @@ public class HttpExceptionToErrorMapper : IExceptionToErrorMapper
             return mapper(exception);
         }
 
-        // here are mapped the exceptions thrown from Ocelot core application
-        if (type == typeof(TimeoutException))
+        // The exception thrown by Ocelot.Requester.TimeoutDelegatingHandler
+        if (type == typeof(TimeoutException) && exception.InnerException is null)
         {
             return new RequestTimedOutError(exception); // -> 504 Gateway Timeout
         }

--- a/src/Requester/HttpExceptionToErrorMapper.cs
+++ b/src/Requester/HttpExceptionToErrorMapper.cs
@@ -30,7 +30,7 @@ public class HttpExceptionToErrorMapper : IExceptionToErrorMapper
         // here are mapped the exceptions thrown from Ocelot core application
         if (type == typeof(TimeoutException))
         {
-            return new RequestTimedOutError(exception); // -> 503 Service Unavailable; TODO but it should actually be 504 Gateway Timeout
+            return new RequestTimedOutError(exception); // -> 504 Gateway Timeout
         }
 
         if (type == typeof(OperationCanceledException) || type.IsSubclassOf(typeof(OperationCanceledException)))

--- a/src/Responder/ErrorsToHttpStatusCodeMapper.cs
+++ b/src/Responder/ErrorsToHttpStatusCodeMapper.cs
@@ -29,7 +29,7 @@ public class ErrorsToHttpStatusCodeMapper : IErrorsToHttpStatusCodeMapper
 
         if (errors.Any(e => e.Code == OcelotErrorCode.RequestTimedOutError))
         {
-            return StatusCodes.Status503ServiceUnavailable;
+            return StatusCodes.Status504GatewayTimeout;
         }
 
         if (errors.Any(e => e.Code == OcelotErrorCode.RequestCanceled))

--- a/src/Responder/ErrorsToHttpStatusCodeMapper.cs
+++ b/src/Responder/ErrorsToHttpStatusCodeMapper.cs
@@ -29,6 +29,7 @@ public class ErrorsToHttpStatusCodeMapper : IErrorsToHttpStatusCodeMapper
 
         if (errors.Any(e => e.Code == OcelotErrorCode.RequestTimedOutError))
         {
+            // RFC 7231 "HTTP/1.1 Semantics and Content" section 6.6.5. 504 Gateway Timeout -> https://www.rfc-editor.org/info/rfc7231/#section-6.6.5
             return StatusCodes.Status504GatewayTimeout;
         }
 

--- a/unit/Requester/HttpExceptionToErrorMapperTests.cs
+++ b/unit/Requester/HttpExceptionToErrorMapperTests.cs
@@ -40,6 +40,7 @@ public class HttpExceptionToErrorMapperTests
 
         // Assert
         error.ShouldBeOfType<RequestCanceledError>();
+        Assert.Equal(StatusCodes.Status499ClientClosedRequest, error.HttpStatusCode);
     }
 
     [Fact]
@@ -99,7 +100,7 @@ public class HttpExceptionToErrorMapperTests
         // Assert
         Assert.IsType<RequestTimedOutError>(error);
         Assert.Equal(25, (int)error.Code);
-        Assert.Equal(503, error.HttpStatusCode);
+        Assert.Equal(504, error.HttpStatusCode);
         Assert.Equal("Timeout making http request, exception: System.TimeoutException: test", error.Message);
     }
 

--- a/unit/Responder/ErrorsToHttpStatusCodeMapperTests.cs
+++ b/unit/Responder/ErrorsToHttpStatusCodeMapperTests.cs
@@ -1,4 +1,5 @@
-﻿using Ocelot.Errors;
+﻿using Microsoft.AspNetCore.Http;
+using Ocelot.Errors;
 using Ocelot.Responder;
 namespace Ocelot.UnitTests.Responder;
 
@@ -27,9 +28,9 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
 
     [Theory]
     [InlineData(OcelotErrorCode.RequestTimedOutError)]
-    public void Should_return_service_unavailable(OcelotErrorCode errorCode)
+    public void Should_return_gateway_timeout(OcelotErrorCode errorCode)
     {
-        ShouldMapErrorToStatusCode(errorCode, HttpStatusCode.ServiceUnavailable);
+        ShouldMapErrorToStatusCode(errorCode, HttpStatusCode.GatewayTimeout);
     }
 
     [Theory]
@@ -46,6 +47,12 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
     public void Should_return_bad_gateway_error(OcelotErrorCode errorCode)
     {
         ShouldMapErrorToStatusCode(errorCode, HttpStatusCode.BadGateway);
+    }
+
+    [Fact]
+    public void Should_return_client_closed_request()
+    {
+        ShouldMapErrorsToStatusCode(new() { OcelotErrorCode.RequestCanceled }, StatusCodes.Status499ClientClosedRequest);
     }
 
     [Theory]
@@ -121,7 +128,7 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
     }
 
     [Fact]
-    public void ServiceUnavailableErrorsHaveThirdHighestPriority()
+    public void GatewayTimeoutErrorsHaveThirdHighestPriority()
     {
         var errors = new List<OcelotErrorCode>
         {
@@ -129,7 +136,7 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
             OcelotErrorCode.RequestTimedOutError,
         };
 
-        ShouldMapErrorsToStatusCode(errors, HttpStatusCode.ServiceUnavailable);
+        ShouldMapErrorsToStatusCode(errors, HttpStatusCode.GatewayTimeout);
     }
 
     [Fact]
@@ -144,10 +151,15 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
 
     private void ShouldMapErrorToStatusCode(OcelotErrorCode errorCode, HttpStatusCode expectedHttpStatusCode)
     {
-        ShouldMapErrorsToStatusCode(new List<OcelotErrorCode> { errorCode }, expectedHttpStatusCode);
+        ShouldMapErrorsToStatusCode(new List<OcelotErrorCode> { errorCode }, (int)expectedHttpStatusCode);
     }
 
     private void ShouldMapErrorsToStatusCode(List<OcelotErrorCode> errorCodes, HttpStatusCode expectedHttpStatusCode)
+    {
+        ShouldMapErrorsToStatusCode(errorCodes, (int)expectedHttpStatusCode);
+    }
+
+    private void ShouldMapErrorsToStatusCode(List<OcelotErrorCode> errorCodes, int expectedHttpStatusCode)
     {
         // Arrange
         var errors = new List<Error>();
@@ -160,6 +172,6 @@ public class ErrorsToHttpStatusCodeMapperTests : UnitTest
         var result = _codeMapper.Map(errors);
 
         // Assert
-        result.ShouldBe((int)expectedHttpStatusCode);
+        result.ShouldBe(expectedHttpStatusCode);
     }
 }


### PR DESCRIPTION
## Fixes #1687

- #1687

## Proposed Changes

- return 504 Gateway Timeout when Ocelot times out waiting for a downstream response
- keep client cancellation behavior unchanged
- preserve existing QoS/Circuit Breaker behavior
- update related tests and documentation

## Validation

- `dotnet test unit/Ocelot.UnitTests.csproj --no-build --filter FullyQualifiedName~HttpExceptionToErrorMapperTests`
- `dotnet test unit/Ocelot.UnitTests.csproj --no-build --filter FullyQualifiedName~ErrorsToHttpStatusCodeMapperTests`
- `dotnet test unit/Ocelot.UnitTests.csproj --no-build --filter FullyQualifiedName~CircuitBreakerDelegatingHandlerTests`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net8.0 --filter FullyQualifiedName~TimeoutTests -p:UseSharedCompilation=false`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net9.0 --filter FullyQualifiedName~TimeoutTests -p:UseSharedCompilation=false`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net10.0 --filter FullyQualifiedName~TimeoutTests -p:UseSharedCompilation=false`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net8.0 --filter FullyQualifiedName~Should_timeout_per_default_after_90_seconds -p:UseSharedCompilation=false`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net9.0 --filter FullyQualifiedName~Should_timeout_per_default_after_90_seconds -p:UseSharedCompilation=false`
- `dotnet test acceptance/Ocelot.Acceptance.csproj --framework net10.0 --filter FullyQualifiedName~Should_timeout_per_default_after_90_seconds -p:UseSharedCompilation=false`
- `dotnet test unit/Ocelot.UnitTests.csproj --no-build --culture en-US --parallel none`
- `git diff --check`

## Notes

- `dotnet test` from the repository root does not execute because multiple solution files exist.
- `dotnet test Ocelot.slnx` is blocked before test execution because `benchmark/Ocelot.Benchmarks.csproj` uses VSTest while `global.json` requires Microsoft.Testing.Platform.
- Full acceptance on net8 reproduced one unrelated local failure in `ClientWebSocketTests.Http20ClientWhenDirectConnectionThenShouldConnect`.